### PR TITLE
Change playsound -> pydub, resampy -> samplerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This project is only made possible due to many libraries and tools, including bu
    - numpy;
    - scipy;
    - soundfile;
-   - resampy;
+   - (lib-)samplerate;
    - boost::ut;
    - qoverage, coverage for QML / Python code coverage, resp.;
    - many others (see submodules and dependencies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.7"
 dependencies = [
   "pydub",
   "soundfile",
-  "resampy",
+  "samplerate",
   "mido",
   "jsonschema",
   "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 requires-python = ">=3.7"
 
 dependencies = [
-  "playsound",
+  "pydub",
   "soundfile",
   "resampy",
   "mido",

--- a/src/libshoopdaloop/internal/DummyAudioSystem.cpp
+++ b/src/libshoopdaloop/internal/DummyAudioSystem.cpp
@@ -45,7 +45,7 @@ DummyAudioPort::DummyAudioPort(std::string name, PortDirection direction)
     : AudioPortInterface<audio_sample_t>(name, direction), m_name(name),
       DummyPort(name, direction, PortType::Audio),
       m_direction(direction),
-      m_queued_data(256) { log_init(); }
+      m_queued_data(128) { log_init(); }
 
 std::string DummyAudioPort::log_module_name() const {
     return "Backend.DummyAudioPort";

--- a/src/libshoopdaloop/internal/DummyAudioSystem.h
+++ b/src/libshoopdaloop/internal/DummyAudioSystem.h
@@ -163,7 +163,7 @@ public:
         std::string client_name,
         std::function<void(size_t)> process_cb,
         DummyAudioSystemMode mode = DummyAudioSystemMode::Automatic,
-        size_t sample_rate = 480000,
+        size_t sample_rate = 48000,
         size_t buffer_size = 256
     );
 

--- a/src/shoopdaloop/lib/q_objects/ClickTrackGenerator.py
+++ b/src/shoopdaloop/lib/q_objects/ClickTrackGenerator.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
-import playsound
+from pydub import AudioSegment
+from pydub.playback import play
 
 from PySide6.QtCore import QObject, Slot
 
@@ -29,5 +30,5 @@ class ClickTrackGenerator(QObject):
 
     @Slot(str)
     def preview(self, wav_filename):
-        playsound.playsound(wav_filename)
+        play(AudioSegment.from_wav(wav_filename))
 

--- a/src/shoopdaloop/lib/q_objects/FileIO.py
+++ b/src/shoopdaloop/lib/q_objects/FileIO.py
@@ -6,7 +6,7 @@ import time
 from threading import Thread
 import soundfile as sf
 import numpy as np
-import resampy
+import samplerate
 import mido
 import math
 import glob
@@ -279,7 +279,8 @@ class FileIO(QThread):
             resampled = data
             if target_sample_rate != file_sample_rate:
                 self.logger.debug(lambda: "Resampling {} from {} to {}".format(filename, file_sample_rate, target_sample_rate))
-                resampled = resampy.resample(data, file_sample_rate, target_sample_rate)
+                ratio = target_sample_rate / file_sample_rate
+                resampled = samplerate.resample(data, ratio, 'sinc_fastest')
             
             if len(channels_to_loop_channels) > len(resampled):
                 self.logger.error(lambda: "Need {} channels, but loaded file only has {}".format(len(channels_to_loop_channels), len(resampled)))

--- a/src/shoopdaloop/lib/qml/ClickTrackDialog.qml
+++ b/src/shoopdaloop/lib/qml/ClickTrackDialog.qml
@@ -145,6 +145,7 @@ Dialog {
             tooltip: "Listen to a preview of the chosen click track."
             text: "Preview"
             onClicked: () => {
+                           default_logger.error("Re-implement preview without saving to wav file")
                            var out = generate()
                            click_track_generator.preview(out)
                        }

--- a/src/shoopdaloop/lib/qml/ClickTrackDialog.qml
+++ b/src/shoopdaloop/lib/qml/ClickTrackDialog.qml
@@ -145,7 +145,6 @@ Dialog {
             tooltip: "Listen to a preview of the chosen click track."
             text: "Preview"
             onClicked: () => {
-                           default_logger.error("Re-implement preview without saving to wav file")
                            var out = generate()
                            click_track_generator.preview(out)
                        }

--- a/src/shoopdaloop/lib/qml/test/ShoopTestCase.qml
+++ b/src/shoopdaloop/lib/qml/test/ShoopTestCase.qml
@@ -103,12 +103,15 @@ TestCase {
         verify(result, failstring)
     }
 
-    function verify_approx(a, b) {
+    function verify_approx(a, b, do_print=true) {
         var result;
         let compare = (a,b) => a == b || ((a - b) < Math.max(a,b) / 10000.0)
-        let failstring = `verify_approx failed (a = ${a}, b = ${b})`
+        let failstring = `verify_approx failed`
+        if (do_print) {
+            failstring += ` (a = ${a}, b = ${b})`
+        }
         if (Array.isArray(a) && Array.isArray(b)) {
-            result = TestDeepEqual.testArraysCompare(a, b, compare);
+            result = TestDeepEqual.testArraysCompare(a, b, compare, do_print ? console.log : (msg) => {});
         } else {
             result = compare(a, b)
         }

--- a/src/shoopdaloop/lib/qml/test/ShoopTestCase.qml
+++ b/src/shoopdaloop/lib/qml/test/ShoopTestCase.qml
@@ -185,11 +185,15 @@ TestCase {
     }
 
     function wait_updated(backend) {
-        var done = false
-        function updated() {
-            done = true
+        function wait_once() {
+            var done = false
+            function updated() {
+                done = true
+            }
+            connectOnce(backend.updated, updated)
+            wait_condition(() => done == true, 200, "Backend not updated in time")
         }
-        connectOnce(backend.updated, updated)
-        wait_condition(() => done == true, 200, "Backend not updated in time")
+        wait_once()
+        wait_once()
     }
 }

--- a/src/shoopdaloop/lib/qml/test/tst_Resample.qml
+++ b/src/shoopdaloop/lib/qml/test/tst_Resample.qml
@@ -15,6 +15,21 @@ AppRegistries {
         anchors.fill: parent
         initial_descriptor: {
             let base = GenerateSession.generate_default_session(app_metadata.version_string, 1)
+            let direct_track = GenerateSession.generate_default_track(
+                "dt",
+                1,
+                "dt",
+                false,
+                "dt",
+                0,
+                0,
+                2,
+                false,
+                false,
+                false,
+                undefined
+                )
+            base.tracks.push(direct_track)
             return base
         }
 
@@ -26,6 +41,14 @@ AppRegistries {
 
             function loop() { return session.tracks[0].loops[0] }
             function channel() { return loop().get_audio_channels()[0] }
+
+            function loop2() { return session.tracks[1].loops[0] }
+            function loop2_channels() {
+                if (!loop2()) return []
+                var r = loop2().get_audio_channels()
+                r.sort((a,b) => a.obj_id.localeCompare(b.obj_id))
+                return r
+            }
 
             function test_resample_1chan() {
                 run_case("test_resample_1chan" , () => {
@@ -41,18 +64,65 @@ AppRegistries {
 
                     testcase.wait_condition(() => registries.state_registry.n_saving_actions_active == 0)
 
-                    file_io.load_soundfile_to_channels_async(filename, 48000, 12000,
+                    file_io.load_soundfile_to_channels_async(filename, 48000, null,
                         [[channel()]], null, null, null)
 
                     testcase.wait_condition(() => registries.state_registry.n_loading_actions_active == 0)
 
                     let loaded = channel().get_data()
-                    verify_eq(loaded.length == 12000)
-                    let expect = Array(12000)
-                    for (var i=0; i<expect.length; i++) {
+                    verify_eq(loaded.length, 12000)
+                })
+            }
+
+            function test_resample_1chan_resize() {
+                run_case("test_resample_1chan_resize" , () => {
+                    check_backend()
+
+                    let data = Array(6000)
+                    for (var i=0; i<data.length; i++) {
                         data[i] = Math.sin(i / data.length * 100)
                     }
-                    verify_approx(loaded, expect)
+
+                    var filename = file_io.generate_temporary_filename() + '.wav'
+                    file_io.save_data_to_soundfile(filename, 24000, [data])
+
+                    testcase.wait_condition(() => registries.state_registry.n_saving_actions_active == 0)
+
+                    file_io.load_soundfile_to_channels_async(filename, 48000, 13000,
+                        [[channel()]], null, null, null)
+
+                    testcase.wait_condition(() => registries.state_registry.n_loading_actions_active == 0)
+
+                    let loaded = channel().get_data()
+                    verify_eq(loaded.length, 13000)
+                })
+            }
+
+            function test_resample_2chan_resize() {
+                run_case("test_resample_2chan_resize" , () => {
+                    check_backend()
+                    loop2().create_backend_loop()
+
+                    let data = Array(6000)
+                    for (var i=0; i<data.length; i++) {
+                        data[i] = Math.sin(i / data.length * 100)
+                    }
+                    let _data = [data, data]
+
+                    var filename = file_io.generate_temporary_filename() + '.wav'
+                    file_io.save_data_to_soundfile(filename, 24000, _data)
+
+                    testcase.wait_condition(() => registries.state_registry.n_saving_actions_active == 0)
+
+                    verify_eq(loop2_channels().length, 2)
+                    file_io.load_soundfile_to_channels_async(filename, 48000, 13000,
+                        [[loop2_channels()[0]], [loop2_channels()[1]]], null, null, null)
+
+                    testcase.wait_condition(() => registries.state_registry.n_loading_actions_active == 0)
+
+                    let datas = loop2_channels().map(m => m.get_data())
+                    verify_eq(datas[0].length, 13000)
+                    verify_eq(datas[1].length, 13000)
                 })
             }
         }

--- a/src/shoopdaloop/lib/qml/test/tst_Resample.qml
+++ b/src/shoopdaloop/lib/qml/test/tst_Resample.qml
@@ -1,0 +1,60 @@
+import QtQuick 6.3
+import QtTest 1.0
+import ShoopDaLoop.PythonBackend
+
+import './testDeepEqual.js' as TestDeepEqual
+import '../../generated/types.js' as Types
+import '../../generate_session.js' as GenerateSession
+import './testfilename.js' as TestFilename
+import '..'
+
+AppRegistries {
+    Session {
+        id: session
+
+        anchors.fill: parent
+        initial_descriptor: {
+            let base = GenerateSession.generate_default_session(app_metadata.version_string, 1)
+            return base
+        }
+
+        ShoopSessionTestCase {
+            id: testcase
+            name: 'Resample'
+            filename : TestFilename.test_filename()
+            session: session
+
+            function loop() { return session.tracks[0].loops[0] }
+            function channel() { return loop().get_audio_channels()[0] }
+
+            function test_resample_1chan() {
+                run_case("test_resample_1chan" , () => {
+                    check_backend()
+
+                    let data = Array(6000)
+                    for (var i=0; i<data.length; i++) {
+                        data[i] = Math.sin(i / data.length * 100)
+                    }
+
+                    var filename = file_io.generate_temporary_filename() + '.wav'
+                    file_io.save_data_to_soundfile(filename, 24000, [data])
+
+                    testcase.wait_condition(() => registries.state_registry.n_saving_actions_active == 0)
+
+                    file_io.load_soundfile_to_channels_async(filename, 48000, 12000,
+                        [[channel()]], null, null, null)
+
+                    testcase.wait_condition(() => registries.state_registry.n_loading_actions_active == 0)
+
+                    let loaded = channel().get_data()
+                    verify_eq(loaded.length == 12000)
+                    let expect = Array(12000)
+                    for (var i=0; i<expect.length; i++) {
+                        data[i] = Math.sin(i / data.length * 100)
+                    }
+                    verify_approx(loaded, expect)
+                })
+            }
+        }
+    }
+}

--- a/src/shoopdaloop/lib/qml/test/tst_TrackControlAndLoop_drywet.qml
+++ b/src/shoopdaloop/lib/qml/test/tst_TrackControlAndLoop_drywet.qml
@@ -554,6 +554,7 @@ AppRegistries {
                     output_port_2.dummy_request_data(4)
                     session.backend.dummy_request_controlled_frames(4)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let l = session.get_track_control_widget(1).control_logic
 
@@ -620,6 +621,7 @@ AppRegistries {
                     session.backend.dummy_wait_process()
                     session.backend.dummy_request_controlled_frames(2)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_data(4)
                     let out2 = output_port_2.dummy_dequeue_data(4)
@@ -727,6 +729,7 @@ AppRegistries {
                     session.backend.dummy_wait_process()
                     session.backend.dummy_request_controlled_frames(2)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_data(4)
                     let out2 = output_port_2.dummy_dequeue_data(4)
@@ -769,6 +772,7 @@ AppRegistries {
                     output_port_2.dummy_request_data(4)
                     session.backend.dummy_request_controlled_frames(4)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let l = session.get_track_control_widget(1).control_logic
 
@@ -835,6 +839,7 @@ AppRegistries {
                     session.backend.dummy_wait_process()
                     session.backend.dummy_request_controlled_frames(2)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_data(4)
                     let out2 = output_port_2.dummy_dequeue_data(4)
@@ -877,6 +882,7 @@ AppRegistries {
                     output_port_2.dummy_request_data(4)
                     session.backend.dummy_request_controlled_frames(4)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_data(4)
                     let out2 = output_port_2.dummy_dequeue_data(4)
@@ -942,6 +948,7 @@ AppRegistries {
                     session.backend.dummy_wait_process()
                     session.backend.dummy_request_controlled_frames(2)
                     session.backend.dummy_wait_process()
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_data(4)
                     let out2 = output_port_2.dummy_dequeue_data(4)


### PR DESCRIPTION
playsound -> pydub because the distribution of playsound causes LLVM mismatches in my build (depends on LLVM 14)
resampy -> samplerate because resampy requires numba, which requires llvmlite. This makes for complex dependencies and a large installation (llvmlite is over 100MB).