### PR TITLE
Embed Carla windows into UI on Linux by implementing a Wayland compositor

### DIFF
--- a/scripts/wayland-example/README
+++ b/scripts/wayland-example/README
@@ -1,0 +1,9 @@
+if running inside X, run the compositor with:
+
+QT_XCB_GL_INTEGRATION=xcb_egl QT_WAYLAND_CLIENT_BUFFER_INTEGRATION=wayland-egl
+
+and always run Carla with:
+
+QT_QPA_PLATFORM=wayland
+
+and play with WAYLAND_DISPLAY to have a temporary location for the socket.

--- a/scripts/wayland-example/main.py
+++ b/scripts/wayland-example/main.py
@@ -2,13 +2,39 @@
 import sys
 import os
 
+from PySide6 import QtCore, QtGui, QtQml
+
 script_dir = os.path.dirname(__file__)
 
 from PySide6.QtCore import QUrl, QCoreApplication, Qt
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
 
+import subprocess
+
+subproc = None
+
+if os.environ['XDG_SESSION_TYPE'] == 'x11':
+    print("Detected X11 session, using xcb_egl integration")
+    os.environ['QT_XCB_GL_INTEGRATION'] = 'xcb_egl'
+
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)
+
+class Helper(QtCore.QObject):
+    def __init__(self, parent=None):
+        super(Helper, self).__init__(parent)
+    
+    @QtCore.Slot(str, str)
+    def set_env(self, key, value):
+        os.environ[key] = value
+    
+    @QtCore.Slot()
+    def initialized_callback(self):
+        global subproc
+        print("Initialized callback called, running client")
+        subproc = subprocess.Popen(['carla'])
+        
+QtQml.qmlRegisterType(Helper, "Helper", 1, 0, "Helper")
 
 app = QGuiApplication(sys.argv)
 

--- a/scripts/wayland-example/main.py
+++ b/scripts/wayland-example/main.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+import sys
+import os
+
+script_dir = os.path.dirname(__file__)
+
+from PySide6.QtCore import QUrl, QCoreApplication, Qt
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlApplicationEngine
+
+QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)
+
+app = QGuiApplication(sys.argv)
+
+appEngine = QQmlApplicationEngine(os.path.join(script_dir, 'main.qml'))
+
+exit(app.exec())

--- a/scripts/wayland-example/main.qml
+++ b/scripts/wayland-example/main.qml
@@ -1,0 +1,62 @@
+// Copyright (C) 2017 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+import QtQuick
+import QtQuick.Window
+import QtWayland.Compositor
+import QtWayland.Compositor.XdgShell
+import QtWayland.Compositor.WlShell
+import QtWayland.Compositor.IviApplication
+
+//! [compositor]
+WaylandCompositor {
+//! [compositor]
+    // The output defines the screen.
+
+    //! [output]
+    WaylandOutput {
+        sizeFollowsWindow: true
+        window: Window {
+            width: 1024
+            height: 768
+            visible: true
+    //! [output]
+
+            //! [shell surface item]
+            Repeater {
+                model: shellSurfaces
+                // ShellSurfaceItem handles displaying a shell surface.
+                // It has implementations for things like interactive
+                // resize/move, and forwarding of mouse and keyboard
+                // events to the client process.
+                ShellSurfaceItem {
+                    shellSurface: modelData
+                    onSurfaceDestroyed: shellSurfaces.remove(index)
+                }
+            }
+            //! [shell surface item]
+        }
+    }
+
+    // Extensions are additions to the core Wayland
+    // protocol. We choose to support three different
+    // shells (window management protocols). When the
+    // client creates a new shell surface (i.e. a window)
+    // we append it to our list of shellSurfaces.
+
+    //! [shells]
+    WlShell {
+        onWlShellSurfaceCreated: (shellSurface) => shellSurfaces.append({shellSurface: shellSurface});
+    }
+    XdgShell {
+        onToplevelCreated: (toplevel, xdgSurface) => shellSurfaces.append({shellSurface: xdgSurface});
+    }
+    IviApplication {
+        onIviSurfaceCreated: (iviSurface) => shellSurfaces.append({shellSurface: iviSurface});
+    }
+    //! [shells]
+
+    //! [model]
+    ListModel { id: shellSurfaces }
+    //! [model]
+}

--- a/scripts/wayland-example/main.qml
+++ b/scripts/wayland-example/main.qml
@@ -8,21 +8,72 @@ import QtWayland.Compositor.XdgShell
 import QtWayland.Compositor.WlShell
 import QtWayland.Compositor.IviApplication
 
-//! [compositor]
-WaylandCompositor {
-//! [compositor]
-    // The output defines the screen.
+import Helper
 
-    //! [output]
-    WaylandOutput {
-        sizeFollowsWindow: true
-        window: Window {
-            width: 1024
-            height: 768
-            visible: true
-    //! [output]
+//! [compositor]
+Window {
+    id: mainwindow
+    width: 1024
+    height: 768
+    visible: true
 
-            //! [shell surface item]
+    WaylandCompositor {
+    //! [compositor]
+        // The output defines the screen.
+
+        socketName: 'testsocket'
+
+        //! [output]
+        WaylandOutput {
+            sizeFollowsWindow: true
+            window: mainwindow.Window.window
+        }
+
+        // Extensions are additions to the core Wayland
+        // protocol. We choose to support three different
+        // shells (window management protocols). When the
+        // client creates a new shell surface (i.e. a window)
+        // we append it to our list of shellSurfaces.
+
+        function add_surface(surface) {
+            shellSurfaces.append({shellSurface: surface})
+        }
+
+        //! [shells]
+        WlShell {
+            onWlShellSurfaceCreated: (shellSurface) => add_surface(shellSurface)
+        }
+        XdgShell {
+            onToplevelCreated: (toplevel, xdgSurface) => add_surface(xdgSurface)
+        }
+        IviApplication {
+            onIviSurfaceCreated: (iviSurface) => add_surface(shellSurface)
+        }
+        //! [shells]
+
+        //! [model]
+        ListModel { id: shellSurfaces }
+        //! [model]
+
+        Helper { id: helper }
+
+        Component.onCompleted: {
+            console.log('socket:', socketName)
+            helper.set_env("WAYLAND_DISPLAY", socketName)
+            helper.set_env("QT_QPA_PLATFORM", "wayland")
+            helper.initialized_callback()
+        }
+    }
+
+    //! [shell surface item]
+    Rectangle {
+        anchors.fill: parent
+        color: 'black'
+        anchors.margins: 10
+    
+        Item {
+            anchors.fill: parent
+            anchors.margins: 10
             Repeater {
                 model: shellSurfaces
                 // ShellSurfaceItem handles displaying a shell surface.
@@ -37,26 +88,4 @@ WaylandCompositor {
             //! [shell surface item]
         }
     }
-
-    // Extensions are additions to the core Wayland
-    // protocol. We choose to support three different
-    // shells (window management protocols). When the
-    // client creates a new shell surface (i.e. a window)
-    // we append it to our list of shellSurfaces.
-
-    //! [shells]
-    WlShell {
-        onWlShellSurfaceCreated: (shellSurface) => shellSurfaces.append({shellSurface: shellSurface});
-    }
-    XdgShell {
-        onToplevelCreated: (toplevel, xdgSurface) => shellSurfaces.append({shellSurface: xdgSurface});
-    }
-    IviApplication {
-        onIviSurfaceCreated: (iviSurface) => shellSurfaces.append({shellSurface: iviSurface});
-    }
-    //! [shells]
-
-    //! [model]
-    ListModel { id: shellSurfaces }
-    //! [model]
 }

--- a/src/libshoopdaloop/internal/lv2/CarlaLV2ProcessingChain.cpp
+++ b/src/libshoopdaloop/internal/lv2/CarlaLV2ProcessingChain.cpp
@@ -457,6 +457,7 @@ void CarlaLV2ProcessingChain<TimeType, SizeType>::show() {
             m_ui_thread.join();
         }
         m_ui_thread = std::thread([this]() {
+            static bool shown = false;
             while (true) {
                 auto t = std::chrono::high_resolution_clock::now();
                 {
@@ -464,6 +465,18 @@ void CarlaLV2ProcessingChain<TimeType, SizeType>::show() {
                     if (!m_ui_widget) {
                         break;
                     }
+                    bool should_show = m_visible.load();
+                    if (should_show != shown) {
+                        if (should_show) {
+                            log<log_level_debug>("Showing Carla UI");
+                            m_ui_widget->show(m_ui_widget);
+                        } else {
+                            log<log_level_debug>("Hiding Carla UI");
+                            m_ui_widget->hide(m_ui_widget);
+                        }
+                        shown = should_show;
+                    }
+                    log<log_level_debug>("Running Carla UI");
                     m_ui_widget->run(m_ui_widget);
                 }
                 while (t < std::chrono::high_resolution_clock::now()) {
@@ -473,16 +486,13 @@ void CarlaLV2ProcessingChain<TimeType, SizeType>::show() {
             }
         });
     }
-    m_ui_widget->show(m_ui_widget);
+    log<log_level_debug>("Queue show Carla UI");
     m_visible = true;
 }
 
 template <typename TimeType, typename SizeType>
 void CarlaLV2ProcessingChain<TimeType, SizeType>::hide() {
-    std::cout << "Hide!\n";
-    if (m_ui_widget) {
-        m_ui_widget->hide(m_ui_widget);
-    }
+    log<log_level_debug>("Queue hide Carla UI");
     m_visible = false;
 }
 

--- a/src/libshoopdaloop/internal/lv2/CarlaLV2ProcessingChain.h
+++ b/src/libshoopdaloop/internal/lv2/CarlaLV2ProcessingChain.h
@@ -73,7 +73,7 @@ public:
 
 template<typename TimeType, typename SizeType>
 class CarlaLV2ProcessingChain : public ProcessingChainInterface<TimeType, SizeType>,
-                                public ModuleLoggingEnabled<"Backend.CarlaLV2">,
+                                public ModuleLoggingEnabled<"Backend.CarlaLV2ProcessingChain">,
                                 public ExternalUIInterface,
                                 public SerializeableStateInterface {
 public:
@@ -90,7 +90,7 @@ private:
     LV2_External_UI_Widget * m_ui_widget = nullptr;
     std::recursive_mutex m_ui_mutex;
     std::thread m_ui_thread;
-    bool m_visible = false;
+    std::atomic<bool> m_visible = false;
     std::vector<const LilvPort*> m_audio_in_lilv_ports, m_audio_out_lilv_ports, m_midi_in_lilv_ports, m_midi_out_lilv_ports;
     std::vector<uint32_t> m_audio_in_port_indices, m_audio_out_port_indices, m_midi_in_port_indices, m_midi_out_port_indices;
     uint32_t m_internal_buffers_size;

--- a/src/shoopdaloop/lib/backend_wrappers.py
+++ b/src/shoopdaloop/lib/backend_wrappers.py
@@ -891,6 +891,7 @@ class BackendFXChain:
     def set_visible(self, visible):
         with bindings_lock:
             if self.available():
+                print(f"WAYLAND_DISPLAY {os.environ['WAYLAND_DISPLAY']}")
                 bindings.fx_chain_set_ui_visible(self._c_handle, int(visible))
     
     def set_active(self, active):

--- a/src/shoopdaloop/lib/q_objects/Application.py
+++ b/src/shoopdaloop/lib/q_objects/Application.py
@@ -147,9 +147,10 @@ class Application(ShoopQApplication):
     
     # Ensure that we forward any terminating signals to our child
     # processes
-    def exit_signal_handler(self, sig, frame):
-        self.logger.debug(lambda: 'Got signal {}.'.format(sig))    
-        self.logger.info(lambda: 'Exiting due to signal.')
+    def exit_signal_handler(self, sig, frame): 
+        self.logger.info(lambda: f'Exiting due to signal {sig}.')
+        if sig == signal.SIGTERM or ('SIGQUIT' in dir(signal) and sig == signal.SIGQUIT):
+            signal.signal(sig, signal.SIG_DFL)
         self.exit_handler()
     
     def exit_handler(self):

--- a/src/shoopdaloop/lib/q_objects/EnvHelper.py
+++ b/src/shoopdaloop/lib/q_objects/EnvHelper.py
@@ -1,0 +1,17 @@
+from PySide6.QtCore import Slot
+
+import os
+
+from .ShoopPyObject import ShoopQObject
+
+class EnvHelper(ShoopQObject):
+    def __init__(self, parent=None):
+        super(EnvHelper, self).__init__(parent)
+    
+    @Slot(str, 'QVariant')
+    def set_env(self, key, value):
+        os.environ[key] = value
+    
+    @Slot(str, result='QVariant')
+    def get_env(self, key):
+        return os.environ[key]

--- a/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
+++ b/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
@@ -1,0 +1,65 @@
+import QtQuick 6.3
+import QtQuick.Window 6.3
+import QtWayland.Compositor
+import QtWayland.Compositor.XdgShell
+import QtWayland.Compositor.WlShell
+import QtWayland.Compositor.IviApplication
+
+Item {
+    id: root
+    
+    property var shellSurfaces: compositor_loader.item ? compositor_loader.item.shellSurfaces : []
+    
+    property string socketName: 'shoop-wayland-display-' + Math.random().toString(36).slice(2, 7)
+
+    Component.onCompleted: {
+        if (true) { //(qpa_platform == 'xcb') {
+            console.log('FIX QPA PLATFORM CHECK')
+            // On X11, we need to set some env vars before starting our compositor.
+            env_helper.set_env('QT_XCB_GL_INTEGRATION', 'xcb_egl')
+            env_helper.set_env('QT_WAYLAND_CLIENT_BUFFER_INTEGRATION', 'wayland-egl')
+        }
+
+        // We are already displaying, but our child processes will need to
+        // find the socket and know it should run on Wayland.
+        env_helper.set_env('QT_QPA_PLATFORM', 'wayland')
+        env_helper.set_env('WAYLAND_DISPLAY', socketName)
+
+        // Start the compositor.
+        compositor_loader.active = true
+    }
+
+    function removeShellSurface(surface) {
+        if (compositor_loader.item) {
+            compositor_loader.item.shellSurfaces.remove(surface)
+        }
+    }
+
+    Loader {
+        id: compositor_loader
+        active: false
+
+        sourceComponent: Component {
+            WaylandCompositor {
+                id: compositor
+                socketName: root.socketName
+                WlShell {
+                    onWlShellSurfaceCreated: (shellSurface) => shellSurfaces.append({shellSurface: shellSurface});
+                }
+                XdgShell {
+                    onToplevelCreated: (toplevel, xdgSurface) => shellSurfaces.append({shellSurface: xdgSurface});
+                }
+                IviApplication {
+                    onIviSurfaceCreated: (iviSurface) => shellSurfaces.append({shellSurface: iviSurface});
+                }
+
+                ListModel { id: shellSurfaces }
+
+                WaylandOutput {
+                    sizeFollowsWindow: true
+                    window: Window.window
+                }
+            }
+        }
+    }
+}

--- a/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
+++ b/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
@@ -20,12 +20,16 @@ Item {
         // We are already displaying, but our child processes will need to
         // find the socket and know it should run on Wayland.
         root.logger.debug(`Wayland server for embedding subprocesses @ ${socketName}, setting QT_QPA_PLATFORM and WAYLAND_DISPLAY`)
-        env_helper.set_env('QT_QPA_PLATFORM', 'wayland-egl')
+        env_helper.set_env('QT_QPA_PLATFORM', 'wayland')
+        env_helper.set_env('XDG_SESSION_TYPE', 'wayland')
+        env_helper.set_env('GDK_BACKEND', 'wayland')
         env_helper.set_env('WAYLAND_DISPLAY', socketName)
     }
 
     function removeShellSurface(surface) {
-        compositor.shellSurfaces.remove(surface)
+        compositor.shellSurfaces = compositor.shellSurfaces.filter(s => s != surface)
+        root.logger.debug(`Surface destroyed for client ${surface.surface.client.processId}`)
+        shellSurfacesChanged()
     }
 
     WaylandCompositor {
@@ -51,7 +55,7 @@ Item {
         property var shellSurfaces: []
 
         WaylandOutput {
-            sizeFollowsWindow: true
+            sizeFollowsWindow: false
             window: root.Window.window
         }
     }

--- a/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
+++ b/src/shoopdaloop/lib/qml/CarlaWaylandWrapper.qml
@@ -53,11 +53,11 @@ Item {
                     onIviSurfaceCreated: (iviSurface) => shellSurfaces.append({shellSurface: iviSurface});
                 }
 
-                ListModel { id: shellSurfaces }
+                property var shellSurfaces: []
 
                 WaylandOutput {
                     sizeFollowsWindow: true
-                    window: Window.window
+                    window: { console.log(compositor_loader.Window.window); return compositor_loader.Window.window }
                 }
             }
         }

--- a/src/shoopdaloop/lib/qml/DetailsPane.qml
+++ b/src/shoopdaloop/lib/qml/DetailsPane.qml
@@ -2,6 +2,7 @@ import QtQuick 6.3
 import QtQuick.Controls 6.3
 import QtQuick.Controls.Material 6.3
 import QtWayland.Compositor
+import ShoopDaLoop.PythonLogger
 
 Item {
     id: root
@@ -9,6 +10,8 @@ Item {
     property real max_height: 1000
     property real min_height: 50
     property alias pane_y_offset : details_tabbar.height
+
+    readonly property PythonLogger logger : PythonLogger { name: "Frontend.Qml.DetailsPane" }
 
     // The details for items are structured as:
     // [ { 'title': str, 'item': item, 'autoselect': bool  } ]
@@ -117,6 +120,10 @@ Item {
                         property var maybe_loop_with_backend :
                             (maybe_loop && details_item.mapped_item.item.maybe_backend_loop) ?
                             details_item.mapped_item.item : null
+
+                        onMapped_itemChanged: {
+                            root.logger.debug(`Mapped item changed to ${mapped_item.item}`)
+                        }
                         
                         Loader {
                             anchors {
@@ -187,6 +194,10 @@ Item {
                                     height: contentrect.height
                                     shellSurface: details_item.mapped_item.item
                                     onSurfaceDestroyed: root.carla_wayland_wrapper.removeShellSurface(shellSurface)
+
+                                    Component.onCompleted: {
+                                        root.logger.debug(`Accepted Wayland surface. Size: ${width}x${height}.`)
+                                    }
                                 }
                             }
                         }

--- a/src/shoopdaloop/lib/qml/DetailsPane.qml
+++ b/src/shoopdaloop/lib/qml/DetailsPane.qml
@@ -176,6 +176,8 @@ Item {
                         }
 
                         Loader {
+                            id: surface_loader
+
                             anchors {
                                 left: parent.left
                                 right: parent.right
@@ -193,9 +195,25 @@ Item {
                                     width: contentrect.width
                                     height: contentrect.height
                                     shellSurface: details_item.mapped_item.item
-                                    onSurfaceDestroyed: root.carla_wayland_wrapper.removeShellSurface(shellSurface)
+                                    onSurfaceDestroyed: {
+                                        surface_loader.active = false
+                                        root.carla_wayland_wrapper.removeShellSurface(shellSurface)
+                                    }
+                                    autoCreatePopupItems: true
+
+                                    function update_size() {
+                                        if (shellSurface instanceof WlShellSurface) {
+                                            shellSurface.sendConfigure(Qt.size(width, height), 0)
+                                        } else if (shellSurface instanceof XdgSurface) {
+                                            shellSurface.toplevel.sendConfigure(Qt.size(width, height), [])
+                                        }
+                                    }
+
+                                    onWidthChanged: update_size()
+                                    onHeightChanged: update_size()
 
                                     Component.onCompleted: {
+                                        update_size()
                                         root.logger.debug(`Accepted Wayland surface. Size: ${width}x${height}.`)
                                     }
                                 }

--- a/src/shoopdaloop/lib/qml/DetailsPane.qml
+++ b/src/shoopdaloop/lib/qml/DetailsPane.qml
@@ -26,11 +26,11 @@ Item {
     }
     property alias carla_wayland_wrapper : lookup_carla_wayland_wrapper.object
 
-    property var carla_window_items: carla_wayland_wrapper.shellSurfaces.map(s => ({
+    property var carla_window_items: carla_wayland_wrapper && carla_wayland_wrapper.shellSurfaces ? carla_wayland_wrapper.shellSurfaces.map(s => ({
         'title': s.title ? s.title : 'Untitled Wayland Window',
         'item': s,
         'autoselect': false
-    }))
+    })) : []
 
     property var items : {
         var rval = []

--- a/src/shoopdaloop/lib/qml/Session.qml
+++ b/src/shoopdaloop/lib/qml/Session.qml
@@ -575,8 +575,6 @@ Rectangle {
             }
         }
 
-        Component.onCompleted: root.logger.error("TODO: uninstall signal handlers on first occurrence of 'exiting due to signal'")
-
         Rectangle {
             id: sync_loop_area
             color: "#555555"

--- a/src/shoopdaloop/lib/qml/SettingsDialog.qml
+++ b/src/shoopdaloop/lib/qml/SettingsDialog.qml
@@ -34,6 +34,9 @@ Dialog {
             anchors.top: parent.top
 
             TabButton {
+                text: 'General'
+            }
+            TabButton {
                 text: 'MIDI Control'
             }
             TabButton {
@@ -48,6 +51,9 @@ Dialog {
             anchors.bottom: parent.bottom
             currentIndex: bar.currentIndex
 
+            GeneralSettingsUi {
+                id: general_settings_being_edited
+            }
             MIDISettingsUi {
                 id: midi_settings_being_edited
             }
@@ -86,6 +92,10 @@ Dialog {
         Component.onCompleted: load()
 
         contents: ({
+            'general_settings': {
+                'schema': 'general_settings.1',
+                'configuration': general_settings.default_contents()
+            },
             'midi_settings': {
                 'schema': 'midi_settings.1',
                 'configuration': midi_settings.default_contents()
@@ -95,6 +105,20 @@ Dialog {
                 'configuration': script_settings.default_contents()
             }
         })
+    }
+
+    Settings {
+        id: general_settings
+        name: 'GeneralSettings'
+        schema_name: 'general_settings'
+        current_version: 1
+
+        contents: all_settings.contents.general_settings ?
+            all_settings.contents.general_settings.configuration : default_contents()
+
+        function default_contents() { return ({
+            'embed_carla': false
+        }) }
     }
 
     Settings {
@@ -113,6 +137,39 @@ Dialog {
                 'configuration': []
             }
         }) }
+    }
+
+    component GeneralSettingsUi : Item {
+        id: general_settings_ui
+
+        property bool embed_carla: general_settings.contents && general_settings.contents.embed_carla != null ? general_settings.contents.embed_carla : false
+        onEmbed_carlaChanged: general_settings.contents.embed_carla = embed_carla
+
+        RegisterInRegistry {
+            registry: registries.state_registry
+            key: 'general_settings'
+            object: general_settings_ui
+        }
+
+        Column {
+
+            anchors {
+                topMargin: 10
+                horizontalCenter: parent.horizontalCenter
+            }
+
+            Row {
+                CheckBox {
+                    id: embed_carla_checkbox
+                    checked: general_settings_ui.embed_carla
+                    onCheckedChanged: general_settings_ui.embed_carla = checked
+                }
+                Label {
+                    anchors.verticalCenter: embed_carla_checkbox.verticalCenter
+                    text: "Embed Carla FX windows in the details pane (experimental)"
+                }
+            }
+        }
     }
 
     component MIDISettingsUi : Item {

--- a/src/shoopdaloop/lib/qml/applications/shoopdaloop_main.qml
+++ b/src/shoopdaloop/lib/qml/applications/shoopdaloop_main.qml
@@ -16,11 +16,23 @@ ApplicationWindow {
 
     Material.theme: Material.Dark
 
-    CarlaWaylandWrapper {
-        RegisterInRegistry {
+    Loader {
+        RegistryLookup {
+            id: lookup_general_settings
             registry: registries.state_registry
-            key: 'carla_wayland_wrapper'
-            object: parent
+            key: 'general_settings'
+        }
+        property alias general_settings: lookup_general_settings.object
+        active: general_settings && general_settings.embed_carla
+
+        sourceComponent: Component{
+            CarlaWaylandWrapper {
+                RegisterInRegistry {
+                    registry: registries.state_registry
+                    key: 'carla_wayland_wrapper'
+                    object: parent
+                }
+            }
         }
     }
 

--- a/src/shoopdaloop/lib/qml/applications/shoopdaloop_main.qml
+++ b/src/shoopdaloop/lib/qml/applications/shoopdaloop_main.qml
@@ -16,6 +16,14 @@ ApplicationWindow {
 
     Material.theme: Material.Dark
 
+    CarlaWaylandWrapper {
+        RegisterInRegistry {
+            registry: registries.state_registry
+            key: 'carla_wayland_wrapper'
+            object: parent
+        }
+    }
+
     Session {
         anchors.fill: parent
         initial_descriptor: GenerateSession.generate_default_session(app_metadata.version_string, null, true)

--- a/src/shoopdaloop/lib/qml_helpers.py
+++ b/src/shoopdaloop/lib/qml_helpers.py
@@ -42,6 +42,7 @@ from .q_objects.TestCase import TestCase
 from .q_objects.OSUtils import OSUtils
 from .q_objects.DummyProcessHelper import DummyProcessHelper
 from .q_objects.CompositeLoop import CompositeLoop
+from .q_objects.EnvHelper import EnvHelper
 
 from .logging import Logger as BareLogger
 from .js_constants import create_js_constants
@@ -69,12 +70,12 @@ import time
     
 #     #fn("%s: %s (%s:%d, %s)" % (mode, message, context.file, context.line, context.file))
             
-def install_qt_message_handler():
-    global qt_message_handler_installed
-    global qt_logger
-    if not qt_message_handler_installed:
-        QtCore.qInstallMessageHandler(qt_msg_handler)
-        qt_message_handler_installed = True
+# def install_qt_message_handler():
+#     global qt_message_handler_installed
+#     global qt_logger
+#     if not qt_message_handler_installed:
+#         QtCore.qInstallMessageHandler(qt_msg_handler)
+#         qt_message_handler_installed = True
 
 # Read version from the version.txt file (will be present when packaged)
 pkg_version = None
@@ -153,7 +154,8 @@ def create_and_populate_root_context(engine, global_args, additional_items={}):
         'settings_io': SettingsIO(parent=engine),
         'registries': registries,
         'screen_grabber': TestScreenGrabber(weak_engine=weakref.ref(engine), parent=engine),
-        'os_utils': OSUtils(parent=engine)
+        'os_utils': OSUtils(parent=engine),
+        'env_helper': EnvHelper(parent=engine)
     }
 
     for key, item in additional_items.items():

--- a/src/shoopdaloop/lib/session_schemas/schemas/general_settings.1.json
+++ b/src/shoopdaloop/lib/session_schemas/schemas/general_settings.1.json
@@ -1,0 +1,16 @@
+{
+    "type": "object",
+    "properties": {
+        "schema": { "const": "general_settings.1" },
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "embed_carla": {
+                    "type": "boolean"
+                }
+            },
+            "required": []
+        }
+    },
+    "required": ["schema", "configuration"]
+}

--- a/src/shoopdaloop/lib/session_schemas/schemas/midi_settings.1.json
+++ b/src/shoopdaloop/lib/session_schemas/schemas/midi_settings.1.json
@@ -21,11 +21,7 @@
                     "required": [ "schema" ]
                 }
             },
-            "required": [
-                "autoconnect_input_regexes",
-                "autoconnect_output_regexes",
-                "midi_control_configuration"
-            ]
+            "required": []
         }
     },
     "required": ["schema", "configuration"]

--- a/src/shoopdaloop/lib/session_schemas/schemas/script_settings.1.json
+++ b/src/shoopdaloop/lib/session_schemas/schemas/script_settings.1.json
@@ -19,9 +19,7 @@
                     }
                 }
             },
-            "required": [
-                "known_scripts"
-            ]
+            "required": []
         }
     },
     "required": ["schema", "configuration"]

--- a/src/shoopdaloop/lib/session_schemas/schemas/settings.1.json
+++ b/src/shoopdaloop/lib/session_schemas/schemas/settings.1.json
@@ -5,6 +5,13 @@
         "configuration": {
             "type": "object",
             "properties": {
+                "general_settings": {
+                    "type": "object",
+                    "properties": {
+                        "schema": { "const": "general_settings.1", "$comment": "see general_settings.1 schema" }
+                    },
+                    "required": ["schema"]
+                },
                 "midi_settings": {
                     "type": "object",
                     "properties": {
@@ -20,9 +27,7 @@
                     "required": ["schema"]
                 }
             },
-            "required": [
-                "midi_settings", "script_settings"
-            ]
+            "required": []
         }
     },
     "required": ["schema", "configuration"]


### PR DESCRIPTION
Plugins each having their own window is already a bit messy sometimes.

But the clutter gets more frustrating because each FX chain has its own Carla instance, which has its own window as well (and they al look alike).

By implementing a Wayland compositor, we can embed the carla windows in our UI to reduce the clutter. For now, the plugins themselves won't all work on Wayland so we leave them in their own windows.