### PR TITLE
Fix flaky QML tests by adding missing wait_updated calls

### DIFF
--- a/src/qml/test/tst_LuaEngine_SessionControlHandler.qml
+++ b/src/qml/test/tst_LuaEngine_SessionControlHandler.qml
@@ -381,12 +381,15 @@ ShoopTestFile {
                     loop_at(-1, 0).queue_set_length(100);
                     loop_at(0, 1).queue_set_length(300);
                     loop_at(-1, 0).transition(ShoopRustConstants.LoopMode.Playing, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
 
                     session.backend.dummy_request_controlled_frames(50)
                     session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
 
                     loop_at(0, 1).transition(ShoopRustConstants.LoopMode.Playing, 0, ShoopRustConstants.DontAlignToSyncImmediately)
                     session.target_loop(loop_at(0, 1))
+                    testcase.wait_updated(session.backend)
 
                     session.backend.dummy_request_controlled_frames(100)
                     session.backend.dummy_run_requested_frames()

--- a/src/qml/test/tst_TrackControlAndLoop_drywet.qml
+++ b/src/qml/test/tst_TrackControlAndLoop_drywet.qml
@@ -575,6 +575,7 @@ ShoopTestFile {
 
                     session.backend.dummy_request_controlled_frames(200)
                     session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
 
                     tut_control().monitor = false
                     tut_control().mute = false


### PR DESCRIPTION
Fixes two frequently-flaky QML test cases on CI:

- `TrackControlAndLoop_drywet::test_drywet_midi_playdry_no_monitor`
- `SessionControlHandler::test_loop_record_with_targeted`

Both were missing `wait_updated` calls at critical state-transition boundaries, causing race conditions between pending GUI-thread updates and subsequent backend/state mutations. On fast local machines the signal backlog clears instantly, masking the issue. On slower CI runners the interleaving becomes visible.

Changes:
- Add `wait_updated` after the initial 200-frame run in `test_drywet_midi_playdry_no_monitor`.
- Add `wait_updated` after sync-loop transition, after the first frame run, and after `target_loop()` in `test_loop_record_with_targeted`.