### PR TITLE
Draft PRs only trigger debug builds; add ready_for_review trigger

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,6 +6,7 @@ on:
       tags: "v*.*.*"
     pull_request:
       branches: [ "master" ]
+      types: [opened, synchronize, reopened, ready_for_review]
     workflow_dispatch:
       inputs:
         windows:
@@ -143,6 +144,12 @@ jobs:
           resolve checkpoints "${{ env.CHECKPOINTS_DEFAULT }}" "${{ github.event.inputs.checkpoints }}"
           resolve pi_checkpoints "${{ env.PI_CHECKPOINTS_DEFAULT }}" "${{ github.event.inputs.pi_checkpoints }}"
           resolve create_draft_release "${{ env.CREATE_DRAFT_RELEASE_DEFAULT }}" "${{ github.event.inputs.create_draft_release }}"
+
+          # For draft PRs, only run debug builds and tests (no release/coverage)
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "coverage=false" >> "$GITHUB_OUTPUT"
+          fi
 
   ##############################################################
   ## Release creation for tag pushes

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -215,6 +215,7 @@ jobs:
       matrix:
         kind:
           - name: linux_release
+            if: needs.setup.outputs.release == 'true'
             release_build: true
             package_kind: portable_folder
             second_package_kind: appimage
@@ -222,6 +223,7 @@ jobs:
             upload_release_assets: true
             platform: linux-x64
           - name: linux_debug
+            if: needs.setup.outputs.debug == 'true'
             release_build: false
             package_kind: portable_folder
             second_package_kind: test_binaries
@@ -236,6 +238,7 @@ jobs:
           #   cmake_opts: '"ENABLE_ASAN" = "On"'
           #   platform: linux-x64
           - name: linux_coverage
+            if: needs.setup.outputs.coverage == 'true'
             release_build: false
             package_kind: portable_folder
             second_package_kind: test_binaries
@@ -264,7 +267,7 @@ jobs:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       checkpoints_enabled: ${{ needs.setup.outputs.checkpoints }}
     needs: [maybe_create_release, setup]
-    if: ${{ needs.setup.outputs.linux == 'true' && needs.setup.outputs.release == 'true' }}
+    if: ${{ needs.setup.outputs.linux == 'true' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -308,23 +311,27 @@ jobs:
       matrix:
         kind:
           - name: release_debian_stable
+            if: needs.setup.outputs.release == 'true'
             python: python3
             container: docker.io/sandervocke/shoopdaloop_run_base_debian_latest_x86_64:latest
             package: shoopdaloop.*.release-linux-x64.portable.tar.gz
             second_package: shoopdaloop.*.release-linux-x64.test_binaries.tar.gz
             sentry_build_type: release
           - name: debug_debian_stable
+            if: needs.setup.outputs.debug == 'true'
             python: python3
             container: docker.io/sandervocke/shoopdaloop_run_base_debian_latest_x86_64:latest
             package: shoopdaloop.*.debug-linux-x64.portable.tar.gz
             second_package: shoopdaloop.*.debug-linux-x64.test_binaries.tar.gz
             sentry_build_type: debug
           - name: release_debian_appimage
+            if: needs.setup.outputs.release == 'true'
             python: python3
             container: docker.io/sandervocke/shoopdaloop_run_base_debian_latest_x86_64:latest
             package: shoopdaloop.*.release-linux-x64.AppImage
             sentry_build_type: release
           - name: coverage_debian_bookworm
+            if: needs.setup.outputs.coverage == 'true'
             python: python3
             container: docker.io/sandervocke/shoopdaloop_build_base_debian_bookworm_x86_64:latest
             coverage: true
@@ -341,7 +348,7 @@ jobs:
               scripts/run_and_generate_coverage.sh
     runs-on: ubuntu-latest
     needs: [build_linux, setup]
-    if: ${{ needs.setup.outputs.test_enabled == 'true' && needs.setup.outputs.linux == 'true' && (needs.setup.outputs.release == 'true' || needs.setup.outputs.debug == 'true' || needs.setup.outputs.coverage == 'true') }}
+    if: ${{ needs.setup.outputs.test_enabled == 'true' && needs.setup.outputs.linux == 'true' }}
     container:
       image: ${{ matrix.kind.container }}
       options: --user root --workdir / # Note: this gets disregarded if container is null
@@ -400,6 +407,7 @@ jobs:
       matrix:
         kind:
           - name: macos_release
+            if: needs.setup.outputs.release == 'true'
             release_build: true
             package_kind: portable_folder
             second_package_kind: test_binaries
@@ -416,6 +424,7 @@ jobs:
           #   upload_release_assets: true
           #   platform: macos-x64
           - name: macos_release_arm
+            if: needs.setup.outputs.release == 'true'
             release_build: true
             package_kind: portable_folder
             # second_package_kind: dmg
@@ -432,7 +441,7 @@ jobs:
           #   platform: macos-arm
     runs-on: ${{ matrix.kind.os }}
     needs: [maybe_create_release, setup]
-    if: ${{ needs.setup.outputs.macos == 'true' && needs.setup.outputs.release == 'true' }}
+    if: ${{ needs.setup.outputs.macos == 'true' }}
     env:
        PATH_SEPARATOR: ":"
        COMPRESS_FOLDER_FN: bash -c "OUT=\$(pwd)/\$(basename \$1.tar.gz); PARENT=\$1/..; FOLDER=\$(basename \$1); cd \$PARENT; tar -czf \$OUT \$FOLDER > /dev/null; echo \$OUT" _
@@ -481,6 +490,7 @@ jobs:
       matrix:
         kind:
           - name: release_macos_arm
+            if: needs.setup.outputs.release == 'true'
             python: python3
             container: null
             os: macos-15
@@ -494,6 +504,7 @@ jobs:
           #   package: shoopdaloop.*.debug-macos-arm.portable.tar.gz
           #   second_package: shoopdaloop.*.debug-macos-arm.test_binaries.tar.gz
           - name: release_macos
+            if: needs.setup.outputs.release == 'true'
             python: python3
             container: null
             os: macos-15-intel
@@ -567,6 +578,7 @@ jobs:
       matrix:
         kind:
           - name: windows_release
+            if: needs.setup.outputs.release == 'true'
             os: windows-2022
             python: python.exe
             pip: python.exe -m pip
@@ -579,6 +591,7 @@ jobs:
             upload_release_assets: true
             platform: windows-msvc-x64
           - name: windows_debug
+            if: needs.setup.outputs.debug == 'true'
             os: windows-2022
             python: python.exe
             pip: python.exe -m pip
@@ -611,7 +624,7 @@ jobs:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       checkpoints_enabled: ${{ needs.setup.outputs.checkpoints }}
-    if: ${{ needs.setup.outputs.windows == 'true' && (needs.setup.outputs.release == 'true' || needs.setup.outputs.debug == 'true') }}
+    if: ${{ needs.setup.outputs.windows == 'true' }}
     container:
       image: ${{ matrix.kind.container_image }}
       options: --user root --workdir /
@@ -651,6 +664,7 @@ jobs:
       matrix:
         kind:
           - name: release_windows
+            if: needs.setup.outputs.release == 'true'
             python: python.exe
             container: null
             os: windows-2022
@@ -659,6 +673,7 @@ jobs:
             pathconvert: "| cygpath -u -f -"
             sentry_build_type: release
           - name: release_windows_innosetup
+            if: needs.setup.outputs.release == 'true'
             python: python.exe
             container: null
             os: windows-2022
@@ -666,6 +681,7 @@ jobs:
             pathconvert: "| cygpath -u -f -"
             sentry_build_type: release
           - name: debug_windows
+            if: needs.setup.outputs.debug == 'true'
             python: python.exe
             container: null
             os: windows-2022
@@ -682,7 +698,7 @@ jobs:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       checkpoints_enabled: ${{ needs.setup.outputs.checkpoints }}
-    if: ${{ needs.setup.outputs.test_enabled == 'true' && needs.setup.outputs.windows == 'true' && (needs.setup.outputs.release == 'true' || needs.setup.outputs.debug == 'true') }}
+    if: ${{ needs.setup.outputs.test_enabled == 'true' && needs.setup.outputs.windows == 'true' }}
     container:
       image: ${{ matrix.kind.container }}
       options: --user root --workdir / # Note: this gets disregarded if container is null


### PR DESCRIPTION
- Added types: [opened, synchronize, reopened, ready_for_review] to pull_request trigger so that converting a draft PR to ready-for-review re-runs the workflow with full (release) builds.
- In setup job: after resolving all defaults, override release and coverage to false when the event is a pull_request in draft state. This ensures draft PRs only build and test debug variants.