### PR TITLE
Fix: windows debug test job looking for release artifact

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -705,8 +705,8 @@ jobs:
             python: python.exe
             container: null
             os: windows-2022
-            package: shoopdaloop.*.release-windows-msvc-x64.portable.tar.gz
-            second_package: shoopdaloop.*.release-windows-msvc-x64.test_binaries.tar.gz
+            package: shoopdaloop.*.debug-windows-msvc-x64.portable.tar.gz
+            second_package: shoopdaloop.*.debug-windows-msvc-x64.test_binaries.tar.gz
             pathconvert: "| cygpath -u -f -"
             sentry_build_type: debug
         exclude:


### PR DESCRIPTION
Fixes a copy-paste bug where the `debug_windows` test matrix entry was searching for `release-windows-msvc-x64` artifacts instead of `debug-windows-msvc-x64` artifacts.

This caused failures on draft PRs (where release builds are skipped) because the release artifact never existed. On normal PRs it went unnoticed because both release and debug artifacts were present.