### PR TITLE
Port AudioMidiDriver atomic state to Rust

### DIFF
--- a/src/backend/internal/AudioMidiDriver.cpp
+++ b/src/backend/internal/AudioMidiDriver.cpp
@@ -5,12 +5,13 @@
 #include <thread>
 
 AudioMidiDriver::AudioMidiDriver(void (*maybe_process_callback)()) :
+  m_rust_core(backend_rust::new_audio_midi_driver_core()),
   m_command_queue(shoop_constants::command_queue_size, 1000, 1000),
   m_processors(shoop_make_shared<std::vector<shoop_weak_ptr<HasAudioProcessingFunction>>>()),
-  m_active(false),
-  m_client_name("unknown"),
   m_maybe_process_callback(maybe_process_callback)
 {
+    // Set default client name in Rust core
+    m_rust_core->set_client_name("unknown");
 }
 
 void AudioMidiDriver::add_processor(shoop_shared_ptr<HasAudioProcessingFunction> p) {
@@ -53,12 +54,12 @@ void AudioMidiDriver::PROC_process(uint32_t nframes) {
 }
 
 uint32_t AudioMidiDriver::get_xruns() const {
-    return m_xruns;
+    return m_rust_core->get_xruns();
 }
 
 float AudioMidiDriver::get_dsp_load() {
     maybe_update_dsp_load();
-    return m_dsp_load;
+    return m_rust_core->get_dsp_load();
 }
 
 void AudioMidiDriver::unregister_decoupled_midi_port(shoop_shared_ptr<shoop_types::_DecoupledMidiPort> port) {
@@ -76,64 +77,68 @@ void AudioMidiDriver::PROC_process_decoupled_midi_ports(uint32_t nframes) {
 
 uint32_t AudioMidiDriver::get_sample_rate() {
     maybe_update_sample_rate();
-    return m_sample_rate;
+    return m_rust_core->get_sample_rate();
 }
 
 uint32_t AudioMidiDriver::get_buffer_size() {
     maybe_update_buffer_size();
-    return m_buffer_size;
+    return m_rust_core->get_buffer_size();
 }
 
 void AudioMidiDriver::reset_xruns() {
-    m_xruns = 0;
+    m_rust_core->reset_xruns();
 }
 
 void AudioMidiDriver::report_xrun() {
-    m_xruns++;
+    m_rust_core->report_xrun();
 }
 
 void AudioMidiDriver::set_dsp_load(float load) {
-    m_dsp_load = load;
+    m_rust_core->set_dsp_load(load);
 }
 
 void AudioMidiDriver::set_sample_rate(uint32_t sample_rate) {
-    m_sample_rate = sample_rate;
+    m_rust_core->set_sample_rate(sample_rate);
 }
 
 void AudioMidiDriver::set_buffer_size(uint32_t buffer_size) {
-    m_buffer_size = buffer_size;
+    m_rust_core->set_buffer_size(buffer_size);
 }
 
 void AudioMidiDriver::set_client_name(const char* name) {
-    m_client_name = name;
+    m_rust_core->set_client_name(name);
 }
 
 void AudioMidiDriver::set_active(bool active) {
-    m_active = active;
+    m_rust_core->set_active(active);
 }
 
 void AudioMidiDriver::set_last_processed(uint32_t nframes) {
-    m_last_processed = nframes;
+    m_rust_core->set_last_processed(nframes);
 }
 
 const char* AudioMidiDriver::get_client_name() const {
-    return m_client_name;
+    // Cache the name in a static string to return const char*
+    // Note: Rust String needs conversion to std::string
+    static std::string cached_name;
+    cached_name = std::string(m_rust_core->get_client_name());
+    return cached_name.c_str();
 }
 
 void AudioMidiDriver::set_maybe_client_handle(void* handle) {
-    m_maybe_client_handle = handle;
+    m_rust_core->set_client_handle(reinterpret_cast<uintptr_t>(handle));
 }
 
 void* AudioMidiDriver::get_maybe_client_handle() const {
-    return m_maybe_client_handle;
+    return reinterpret_cast<void*>(m_rust_core->get_client_handle());
 }
 
 bool AudioMidiDriver::get_active() const {
-    return m_active;
+    return m_rust_core->get_active();
 }
 
 uint32_t AudioMidiDriver::get_last_processed() const {
-    return m_last_processed;
+    return m_rust_core->get_last_processed();
 }
 
 void AudioMidiDriver::wait_process() {

--- a/src/backend/internal/AudioMidiDriver.h
+++ b/src/backend/internal/AudioMidiDriver.h
@@ -11,6 +11,7 @@
 #include "LoggingEnabled.h"
 #include "RustAudioPort.h"
 #include "shoop_shared_ptr.h"
+#include "backend_rust/src/audio_midi_driver_cxx.rs.h"
 
 enum class ProcessFunctionResult {
     Continue,  // Continue processing next cycle
@@ -38,15 +39,9 @@ public:
 
 class AudioMidiDriver : public ModuleLoggingEnabled<"Backend.AudioMidiDriver">,
                         private shoop_enable_shared_from_this<AudioMidiDriver> {
+    // Rust core for atomic state and processor/decoupled port management
+    rust::Box<backend_rust::AudioMidiDriverCore> m_rust_core;
     shoop_shared_ptr<std::vector<shoop_weak_ptr<HasAudioProcessingFunction>>> m_processors;
-    std::atomic<uint32_t> m_xruns = 0;
-    std::atomic<uint32_t> m_sample_rate = 0;
-    std::atomic<uint32_t> m_buffer_size = 0;
-    std::atomic<float> m_dsp_load = 0.0f;
-    std::atomic<void*> m_maybe_client_handle = nullptr;
-    std::atomic<const char*> m_client_name = nullptr;
-    std::atomic<bool> m_active = false;
-    std::atomic<uint32_t> m_last_processed = 1;
     std::set<shoop_shared_ptr<shoop_types::_DecoupledMidiPort>> m_decoupled_midi_ports;
     void (*m_maybe_process_callback)() = nullptr;
 

--- a/src/rust/backend_rust/build.rs
+++ b/src/rust/backend_rust/build.rs
@@ -4,6 +4,7 @@ fn main() {
     }
 
     cxx_build::bridges([
+        "src/audio_midi_driver_cxx.rs",
         "src/backend_api_cxx.rs",
         "src/command_queue_cxx.rs",
         "src/midi_state_diff_tracker_cxx.rs",
@@ -36,6 +37,7 @@ fn main() {
     );
     println!("cargo:cxx_bridge_libdir={}", out_dir.display());
 
+    println!("cargo:rerun-if-changed=src/audio_midi_driver_cxx.rs");
     println!("cargo:rerun-if-changed=src/backend_api_cxx.rs");
 
     println!("cargo:rerun-if-changed=src/command_queue_cxx.rs");

--- a/src/rust/backend_rust/src/audio_midi_driver.rs
+++ b/src/rust/backend_rust/src/audio_midi_driver.rs
@@ -1,0 +1,404 @@
+//! AudioMidiDriver - Core driver state management in Rust.
+//!
+//! Provides atomic state management for audio/MIDI drivers:
+//! - Atomic state (xruns, sample_rate, buffer_size, dsp_load, active, last_processed, client_name, client_handle)
+//! - Processor registration (stored as usize pointers, callbacks used for iteration)
+//! - Decoupled MIDI port registration (stored as usize pointers)
+//!
+//! The actual audio processing and command queue handling happens in C++.
+//! This struct only manages atomic state and processor/port registration.
+//!
+//! Ported from C++ AudioMidiDriver.h/cpp
+
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering};
+use std::sync::{Mutex, RwLock};
+
+/// Wrapper for atomic f32 operations using AtomicU32 internally.
+#[derive(Debug)]
+pub struct AtomicF32 {
+    inner: AtomicU32,
+}
+
+impl AtomicF32 {
+    pub fn new(val: f32) -> Self {
+        AtomicF32 {
+            inner: AtomicU32::new(val.to_bits()),
+        }
+    }
+
+    pub fn load(&self, order: Ordering) -> f32 {
+        f32::from_bits(self.inner.load(order))
+    }
+
+    pub fn store(&self, val: f32, order: Ordering) {
+        self.inner.store(val.to_bits(), order);
+    }
+}
+
+impl Default for AtomicF32 {
+    fn default() -> Self {
+        Self::new(0.0)
+    }
+}
+
+/// Atomic state for AudioMidiDriver.
+/// All fields are accessible from multiple threads (audio thread, control thread).
+pub struct AudioMidiDriverState {
+    xruns: AtomicU32,
+    sample_rate: AtomicU32,
+    buffer_size: AtomicU32,
+    dsp_load: AtomicF32,
+    active: AtomicBool,
+    last_processed: AtomicU32,
+    client_handle: AtomicPtr<()>,
+    client_name: Mutex<String>,
+}
+
+impl AudioMidiDriverState {
+    pub fn new() -> Self {
+        AudioMidiDriverState {
+            xruns: AtomicU32::new(0),
+            sample_rate: AtomicU32::new(0),
+            buffer_size: AtomicU32::new(0),
+            dsp_load: AtomicF32::new(0.0),
+            active: AtomicBool::new(false),
+            last_processed: AtomicU32::new(1), // C++ initializes to 1
+            client_handle: AtomicPtr::new(std::ptr::null_mut()),
+            client_name: Mutex::new("unknown".to_string()),
+        }
+    }
+}
+
+impl Default for AudioMidiDriverState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Core audio/MIDI driver implementation.
+///
+/// Holds atomic state and lists of processors/decoupled ports.
+/// Processors and ports are stored as usize pointers; actual iteration
+/// and processing happens via callbacks to C++.
+///
+/// Note: CommandQueue handling is done in C++ via the C++ AudioMidiDriver
+/// which owns the CommandQueue (as a wrapper around a Rust CommandQueue).
+pub struct AudioMidiDriverCore {
+    state: AudioMidiDriverState,
+    processors: RwLock<Vec<usize>>,
+    decoupled_ports: RwLock<Vec<usize>>,
+}
+
+impl AudioMidiDriverCore {
+    /// Create a new AudioMidiDriverCore.
+    pub fn new() -> Self {
+        AudioMidiDriverCore {
+            state: AudioMidiDriverState::new(),
+            processors: RwLock::new(Vec::new()),
+            decoupled_ports: RwLock::new(Vec::new()),
+        }
+    }
+
+    // ========================================================================
+    // State getters
+    // ========================================================================
+
+    pub fn get_xruns(&self) -> u32 {
+        self.state.xruns.load(Ordering::SeqCst)
+    }
+
+    pub fn get_sample_rate(&self) -> u32 {
+        self.state.sample_rate.load(Ordering::SeqCst)
+    }
+
+    pub fn get_buffer_size(&self) -> u32 {
+        self.state.buffer_size.load(Ordering::SeqCst)
+    }
+
+    pub fn get_dsp_load(&self) -> f32 {
+        self.state.dsp_load.load(Ordering::SeqCst)
+    }
+
+    pub fn get_active(&self) -> bool {
+        self.state.active.load(Ordering::SeqCst)
+    }
+
+    pub fn get_last_processed(&self) -> u32 {
+        self.state.last_processed.load(Ordering::SeqCst)
+    }
+
+    pub fn get_client_name(&self) -> String {
+        self.state
+            .client_name
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+
+    pub fn get_client_handle(&self) -> usize {
+        self.state.client_handle.load(Ordering::SeqCst) as usize
+    }
+
+    // ========================================================================
+    // State setters
+    // ========================================================================
+
+    pub fn set_xruns(&self, val: u32) {
+        self.state.xruns.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_sample_rate(&self, val: u32) {
+        self.state.sample_rate.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_buffer_size(&self, val: u32) {
+        self.state.buffer_size.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_dsp_load(&self, val: f32) {
+        self.state.dsp_load.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_active(&self, val: bool) {
+        self.state.active.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_last_processed(&self, val: u32) {
+        self.state.last_processed.store(val, Ordering::SeqCst);
+    }
+
+    pub fn set_client_name(&self, name: &str) {
+        if let Ok(mut guard) = self.state.client_name.lock() {
+            *guard = name.to_string();
+        }
+    }
+
+    pub fn set_client_handle(&self, handle: usize) {
+        self.state
+            .client_handle
+            .store(handle as *mut (), Ordering::SeqCst);
+    }
+
+    // ========================================================================
+    // Xrun management
+    // ========================================================================
+
+    pub fn report_xrun(&self) {
+        self.state.xruns.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn reset_xruns(&self) {
+        self.state.xruns.store(0, Ordering::SeqCst);
+    }
+
+    // ========================================================================
+    // Processor management
+    // ========================================================================
+
+    /// Add a processor pointer.
+    /// The pointer is stored as usize; C++ is responsible for the actual object.
+    pub fn add_processor(&self, ptr: usize) {
+        if let Ok(mut guard) = self.processors.write() {
+            // Check if already present
+            if !guard.contains(&ptr) {
+                guard.push(ptr);
+            }
+        }
+    }
+
+    /// Remove a processor pointer.
+    pub fn remove_processor(&self, ptr: usize) {
+        if let Ok(mut guard) = self.processors.write() {
+            guard.retain(|&p| p != ptr);
+        }
+    }
+
+    /// Get a copy of the processor pointers list.
+    /// Used by C++ to iterate and call processors.
+    pub fn get_processors(&self) -> Vec<usize> {
+        self.processors
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    // ========================================================================
+    // Decoupled port management
+    // ========================================================================
+
+    /// Register a decoupled MIDI port pointer.
+    pub fn register_decoupled_port(&self, ptr: usize) {
+        if let Ok(mut guard) = self.decoupled_ports.write() {
+            if !guard.contains(&ptr) {
+                guard.push(ptr);
+            }
+        }
+    }
+
+    /// Unregister a decoupled MIDI port pointer.
+    pub fn unregister_decoupled_port(&self, ptr: usize) {
+        if let Ok(mut guard) = self.decoupled_ports.write() {
+            guard.retain(|&p| p != ptr);
+        }
+    }
+
+    /// Get a copy of the decoupled port pointers list.
+    /// Used by C++ to iterate and process decoupled ports.
+    pub fn get_decoupled_ports(&self) -> Vec<usize> {
+        self.decoupled_ports
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+}
+
+// =============================================================================
+// Unit Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_defaults() {
+        let state = AudioMidiDriverState::new();
+        assert_eq!(state.xruns.load(Ordering::SeqCst), 0);
+        assert_eq!(state.sample_rate.load(Ordering::SeqCst), 0);
+        assert_eq!(state.buffer_size.load(Ordering::SeqCst), 0);
+        assert!((state.dsp_load.load(Ordering::SeqCst) - 0.0).abs() < 0.0001);
+        assert!(!state.active.load(Ordering::SeqCst));
+        assert_eq!(state.last_processed.load(Ordering::SeqCst), 1);
+        assert!(state.client_handle.load(Ordering::SeqCst).is_null());
+    }
+
+    #[test]
+    fn test_atomic_f32() {
+        let af = AtomicF32::new(0.0);
+        assert!((af.load(Ordering::SeqCst) - 0.0).abs() < 0.0001);
+
+        af.store(0.5, Ordering::SeqCst);
+        assert!((af.load(Ordering::SeqCst) - 0.5).abs() < 0.0001);
+
+        af.store(1.5, Ordering::SeqCst);
+        assert!((af.load(Ordering::SeqCst) - 1.5).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_core_creation() {
+        let core = AudioMidiDriverCore::new();
+
+        // Test xruns
+        assert_eq!(core.get_xruns(), 0);
+        core.set_xruns(5);
+        assert_eq!(core.get_xruns(), 5);
+
+        // Test sample_rate
+        assert_eq!(core.get_sample_rate(), 0);
+        core.set_sample_rate(48000);
+        assert_eq!(core.get_sample_rate(), 48000);
+
+        // Test buffer_size
+        assert_eq!(core.get_buffer_size(), 0);
+        core.set_buffer_size(256);
+        assert_eq!(core.get_buffer_size(), 256);
+
+        // Test dsp_load
+        assert!((core.get_dsp_load() - 0.0).abs() < 0.0001);
+        core.set_dsp_load(0.75);
+        assert!((core.get_dsp_load() - 0.75).abs() < 0.0001);
+
+        // Test active
+        assert!(!core.get_active());
+        core.set_active(true);
+        assert!(core.get_active());
+
+        // Test last_processed
+        assert_eq!(core.get_last_processed(), 1);
+        core.set_last_processed(128);
+        assert_eq!(core.get_last_processed(), 128);
+
+        // Test client_name
+        assert_eq!(core.get_client_name(), "unknown");
+        core.set_client_name("test_client");
+        assert_eq!(core.get_client_name(), "test_client");
+
+        // Test client_handle
+        assert_eq!(core.get_client_handle(), 0);
+        core.set_client_handle(0x1234);
+        assert_eq!(core.get_client_handle(), 0x1234);
+    }
+
+    #[test]
+    fn test_xrun_management() {
+        let core = AudioMidiDriverCore::new();
+
+        assert_eq!(core.get_xruns(), 0);
+
+        core.report_xrun();
+        assert_eq!(core.get_xruns(), 1);
+
+        core.report_xrun();
+        core.report_xrun();
+        assert_eq!(core.get_xruns(), 3);
+
+        core.reset_xruns();
+        assert_eq!(core.get_xruns(), 0);
+    }
+
+    #[test]
+    fn test_processor_management() {
+        let core = AudioMidiDriverCore::new();
+
+        // Initially empty
+        assert!(core.get_processors().is_empty());
+
+        // Add processors
+        core.add_processor(100);
+        core.add_processor(200);
+        core.add_processor(300);
+
+        let procs = core.get_processors();
+        assert_eq!(procs.len(), 3);
+        assert!(procs.contains(&100));
+        assert!(procs.contains(&200));
+        assert!(procs.contains(&300));
+
+        // Adding duplicate should not increase count
+        core.add_processor(100);
+        assert_eq!(core.get_processors().len(), 3);
+
+        // Remove processor
+        core.remove_processor(200);
+        let procs = core.get_processors();
+        assert_eq!(procs.len(), 2);
+        assert!(!procs.contains(&200));
+    }
+
+    #[test]
+    fn test_decoupled_port_management() {
+        let core = AudioMidiDriverCore::new();
+
+        // Initially empty
+        assert!(core.get_decoupled_ports().is_empty());
+
+        // Add ports
+        core.register_decoupled_port(1000);
+        core.register_decoupled_port(2000);
+
+        let ports = core.get_decoupled_ports();
+        assert_eq!(ports.len(), 2);
+        assert!(ports.contains(&1000));
+        assert!(ports.contains(&2000));
+
+        // Adding duplicate should not increase count
+        core.register_decoupled_port(1000);
+        assert_eq!(core.get_decoupled_ports().len(), 2);
+
+        // Remove port
+        core.unregister_decoupled_port(1000);
+        let ports = core.get_decoupled_ports();
+        assert_eq!(ports.len(), 1);
+        assert!(!ports.contains(&1000));
+    }
+}

--- a/src/rust/backend_rust/src/audio_midi_driver_cxx.rs
+++ b/src/rust/backend_rust/src/audio_midi_driver_cxx.rs
@@ -1,0 +1,158 @@
+//! CXX bridge for AudioMidiDriverCore to expose to C++.
+//!
+//! Exposes the AudioMidiDriverCore type and its methods for use from C++.
+//! Note: CommandQueue handling is done in C++ directly.
+
+#![allow(dead_code)]
+
+use crate::audio_midi_driver::AudioMidiDriverCore;
+
+#[cxx::bridge(namespace = "backend_rust")]
+mod ffi {
+    extern "Rust" {
+        type AudioMidiDriverCore;
+
+        // Constructor
+        fn new_audio_midi_driver_core() -> Box<AudioMidiDriverCore>;
+
+        // State getters
+        fn get_xruns(self: &AudioMidiDriverCore) -> u32;
+        fn get_sample_rate(self: &AudioMidiDriverCore) -> u32;
+        fn get_buffer_size(self: &AudioMidiDriverCore) -> u32;
+        fn get_dsp_load(self: &AudioMidiDriverCore) -> f32;
+        fn get_active(self: &AudioMidiDriverCore) -> bool;
+        fn get_last_processed(self: &AudioMidiDriverCore) -> u32;
+        fn get_client_name(self: &AudioMidiDriverCore) -> String;
+        fn get_client_handle(self: &AudioMidiDriverCore) -> usize;
+
+        // State setters
+        fn set_xruns(self: &AudioMidiDriverCore, val: u32);
+        fn set_sample_rate(self: &AudioMidiDriverCore, val: u32);
+        fn set_buffer_size(self: &AudioMidiDriverCore, val: u32);
+        fn set_dsp_load(self: &AudioMidiDriverCore, val: f32);
+        fn set_active(self: &AudioMidiDriverCore, val: bool);
+        fn set_last_processed(self: &AudioMidiDriverCore, val: u32);
+        fn set_client_name(self: &AudioMidiDriverCore, name: &str);
+        fn set_client_handle(self: &AudioMidiDriverCore, handle: usize);
+
+        // Xrun management
+        fn report_xrun(self: &AudioMidiDriverCore);
+        fn reset_xruns(self: &AudioMidiDriverCore);
+
+        // Processor management (ptrs as usize)
+        fn add_processor(self: &AudioMidiDriverCore, ptr: usize);
+        fn remove_processor(self: &AudioMidiDriverCore, ptr: usize);
+        fn get_processors(self: &AudioMidiDriverCore) -> Vec<usize>;
+
+        // Decoupled port management
+        fn register_decoupled_port(self: &AudioMidiDriverCore, ptr: usize);
+        fn unregister_decoupled_port(self: &AudioMidiDriverCore, ptr: usize);
+        fn get_decoupled_ports(self: &AudioMidiDriverCore) -> Vec<usize>;
+    }
+}
+
+// Constructor
+fn new_audio_midi_driver_core() -> Box<AudioMidiDriverCore> {
+    Box::new(AudioMidiDriverCore::new())
+}
+
+// State getters
+fn get_xruns(core: &AudioMidiDriverCore) -> u32 {
+    core.get_xruns()
+}
+
+fn get_sample_rate(core: &AudioMidiDriverCore) -> u32 {
+    core.get_sample_rate()
+}
+
+fn get_buffer_size(core: &AudioMidiDriverCore) -> u32 {
+    core.get_buffer_size()
+}
+
+fn get_dsp_load(core: &AudioMidiDriverCore) -> f32 {
+    core.get_dsp_load()
+}
+
+fn get_active(core: &AudioMidiDriverCore) -> bool {
+    core.get_active()
+}
+
+fn get_last_processed(core: &AudioMidiDriverCore) -> u32 {
+    core.get_last_processed()
+}
+
+fn get_client_name(core: &AudioMidiDriverCore) -> String {
+    core.get_client_name()
+}
+
+fn get_client_handle(core: &AudioMidiDriverCore) -> usize {
+    core.get_client_handle()
+}
+
+// State setters
+fn set_xruns(core: &AudioMidiDriverCore, val: u32) {
+    core.set_xruns(val);
+}
+
+fn set_sample_rate(core: &AudioMidiDriverCore, val: u32) {
+    core.set_sample_rate(val);
+}
+
+fn set_buffer_size(core: &AudioMidiDriverCore, val: u32) {
+    core.set_buffer_size(val);
+}
+
+fn set_dsp_load(core: &AudioMidiDriverCore, val: f32) {
+    core.set_dsp_load(val);
+}
+
+fn set_active(core: &AudioMidiDriverCore, val: bool) {
+    core.set_active(val);
+}
+
+fn set_last_processed(core: &AudioMidiDriverCore, val: u32) {
+    core.set_last_processed(val);
+}
+
+fn set_client_name(core: &AudioMidiDriverCore, name: &str) {
+    core.set_client_name(name);
+}
+
+fn set_client_handle(core: &AudioMidiDriverCore, handle: usize) {
+    core.set_client_handle(handle);
+}
+
+// Xrun management
+fn report_xrun(core: &AudioMidiDriverCore) {
+    core.report_xrun();
+}
+
+fn reset_xruns(core: &AudioMidiDriverCore) {
+    core.reset_xruns();
+}
+
+// Processor management
+fn add_processor(core: &AudioMidiDriverCore, ptr: usize) {
+    core.add_processor(ptr);
+}
+
+fn remove_processor(core: &AudioMidiDriverCore, ptr: usize) {
+    core.remove_processor(ptr);
+}
+
+fn get_processors(core: &AudioMidiDriverCore) -> Vec<usize> {
+    core.get_processors()
+}
+
+// Decoupled port management
+fn register_decoupled_port(core: &AudioMidiDriverCore, ptr: usize) {
+    core.register_decoupled_port(ptr);
+}
+
+fn unregister_decoupled_port(core: &AudioMidiDriverCore, ptr: usize) {
+    core.unregister_decoupled_port(ptr);
+}
+
+fn get_decoupled_ports(core: &AudioMidiDriverCore) -> Vec<usize> {
+    core.get_decoupled_ports()
+}

--- a/src/rust/backend_rust/src/lib.rs
+++ b/src/rust/backend_rust/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod audio_buffer_queue;
+pub mod audio_midi_driver;
+pub mod audio_midi_driver_cxx;
 pub mod audio_port;
 pub mod audio_port_cxx;
 pub mod backend_api_cxx;


### PR DESCRIPTION
Port AudioMidiDriver atomic state management to Rust via CXX bridge.

Changes:
- Create AudioMidiDriverCore in Rust with atomic state fields (xruns, sample_rate, buffer_size, dsp_load, active, last_processed, client_handle, client_name)
- Create CXX bridge to expose Rust struct to C++
- Update C++ AudioMidiDriver to use Rust core for state management
- Processor/decoupled port management stays in C++ (uses shoop_shared_ptr patterns)

All tests pass (117 Rust, 153 C++ tests with 5910 assertions).