### PR TITLE
Fix backend Rust/C++ allocation mismatches causing flaky crashes

### DIFF
--- a/src/backend/libshoopdaloop_backend.cpp
+++ b/src/backend/libshoopdaloop_backend.cpp
@@ -304,13 +304,13 @@ shoop_audio_driver_t *create_audio_driver (
 
 shoop_audio_driver_state_t *get_audio_driver_state(shoop_audio_driver_t *driver) {
   return api_impl<shoop_audio_driver_state_t*, log_level_debug_trace>("get_audio_driver_state", [&]() -> shoop_audio_driver_state_t* {
-    auto rval = new shoop_audio_driver_state_t;
+    auto rval = (shoop_audio_driver_state_t*) malloc(sizeof(shoop_audio_driver_state_t));
     auto d = internal_audio_driver(driver);
     if (!d) {
       return nullptr;
     }
     rval->maybe_driver_handle = d->get_maybe_client_handle();
-    rval->maybe_instance_name = d->get_client_name() ? strdup(d->get_client_name()) : "(unknown)";
+    rval->maybe_instance_name = d->get_client_name() ? strdup(d->get_client_name()) : strdup("(unknown)");
     rval->buffer_size = d->get_buffer_size();
     rval->sample_rate = d->get_sample_rate();
     rval->dsp_load_percent = d->get_dsp_load();
@@ -370,7 +370,7 @@ shoop_external_port_descriptors_t *find_external_ports(
       maybe_port_direction_filter,
       maybe_data_type_filter
     );
-    auto rval = new shoop_external_port_descriptors_t;
+    auto rval = (shoop_external_port_descriptors_t*) malloc(sizeof(shoop_external_port_descriptors_t));
     rval->n_ports = ports.size();
     rval->ports = (shoop_external_port_descriptor_t*) malloc(sizeof(shoop_external_port_descriptor_t) * ports.size());
     for(size_t i=0; i<ports.size(); i++) {
@@ -410,7 +410,7 @@ shoop_backend_session_state_info_t *get_backend_session_state(shoop_backend_sess
 
 shoop_profiling_report_t *get_profiling_report(shoop_backend_session_t *backend) {
   return api_impl<shoop_profiling_report_t*, log_level_debug_trace>("get_profiling_report", [&]() -> shoop_profiling_report_t* {
-    auto rval = new shoop_profiling_report_t;
+    auto rval = (shoop_profiling_report_t*) malloc(sizeof(shoop_profiling_report_t));
     auto internal = internal_backend_session(backend);
     if (!internal) {
       return nullptr;
@@ -422,7 +422,7 @@ shoop_profiling_report_t *get_profiling_report(shoop_backend_session_t *backend)
 
     auto r = internal->profiler->report();
 
-    auto items = new shoop_profiling_report_item_t[r.size()];
+    auto items = (shoop_profiling_report_item_t*) malloc(sizeof(shoop_profiling_report_item_t) * r.size());
     for (uint32_t idx=0; idx<r.size(); idx++) {
         auto name_str = (char*) malloc(r[idx].key.size() + 1);
         strcpy(name_str, r[idx].key.c_str());
@@ -436,7 +436,7 @@ shoop_profiling_report_t *get_profiling_report(shoop_backend_session_t *backend)
     rval->items = items;
     rval->n_items = r.size();
     return rval;
-  }, new shoop_profiling_report_t);
+  }, (shoop_profiling_report_t*) calloc(1, sizeof(shoop_profiling_report_t)));
 }
 
 shoopdaloop_loop_t *create_loop(shoop_backend_session_t *backend) {
@@ -1066,15 +1066,16 @@ void close_audio_port (shoop_backend_session_t *backend, shoopdaloop_audio_port_
 shoop_port_connections_state_t *get_audio_port_connections_state(shoopdaloop_audio_port_t *port) {
   return api_impl<shoop_port_connections_state_t*, log_level_debug_trace, log_level_warning>("get_audio_port_connections_state", [&]() {
     auto _port = internal_audio_port(port);
-    auto rval = new shoop_port_connections_state_t;
+    auto rval = (shoop_port_connections_state_t*) malloc(sizeof(shoop_port_connections_state_t));
     rval->n_ports = 0;
+    rval->ports = nullptr;
     if (!_port) {
       return rval;
     }
 
     auto connections = _port->get_port().get_external_connection_status();
     rval->n_ports = connections.size();
-    rval->ports = new shoop_port_maybe_connection_t[rval->n_ports];
+    rval->ports = (shoop_port_maybe_connection_t*) malloc(sizeof(shoop_port_maybe_connection_t) * rval->n_ports);
     uint32_t idx = 0;
     for (auto &pair : connections) {
         auto name = strdup(pair.first.c_str());
@@ -1085,7 +1086,7 @@ shoop_port_connections_state_t *get_audio_port_connections_state(shoopdaloop_aud
         idx++;
     }
     return rval;
-  }, new shoop_port_connections_state_t);
+  }, (shoop_port_connections_state_t*) calloc(1, sizeof(shoop_port_connections_state_t)));
 }
 
 void connect_audio_port_external(shoopdaloop_audio_port_t *ours, const char* external_port_name) {
@@ -1110,9 +1111,9 @@ shoop_port_connections_state_t *get_midi_port_connections_state(shoopdaloop_midi
     if (!port) { return nullptr; }
     auto connections = _port->get_port().get_external_connection_status();
 
-    auto rval = new shoop_port_connections_state_t;
+    auto rval = (shoop_port_connections_state_t*) malloc(sizeof(shoop_port_connections_state_t));
     rval->n_ports = connections.size();
-    rval->ports = new shoop_port_maybe_connection_t[rval->n_ports];
+    rval->ports = (shoop_port_maybe_connection_t*) malloc(sizeof(shoop_port_maybe_connection_t) * rval->n_ports);
     uint32_t idx = 0;
     for (auto &pair : connections) {
         rval->ports[idx].name = strdup(pair.first.c_str());
@@ -1120,7 +1121,7 @@ shoop_port_connections_state_t *get_midi_port_connections_state(shoopdaloop_midi
         idx++;
     }
     return rval;
-  }, new shoop_port_connections_state_t);
+  }, (shoop_port_connections_state_t*) calloc(1, sizeof(shoop_port_connections_state_t)));
 }
 
 shoop_port_connections_state_t *get_decoupled_midi_port_connections_state(shoopdaloop_decoupled_midi_port_t *port) {
@@ -1129,9 +1130,9 @@ shoop_port_connections_state_t *get_decoupled_midi_port_connections_state(shoopd
     if (!port) { return nullptr; }
     auto connections = _port->get_port()->get_external_connection_status();
 
-    auto rval = new shoop_port_connections_state_t;
+    auto rval = (shoop_port_connections_state_t*) malloc(sizeof(shoop_port_connections_state_t));
     rval->n_ports = connections.size();
-    rval->ports = new shoop_port_maybe_connection_t[rval->n_ports];
+    rval->ports = (shoop_port_maybe_connection_t*) malloc(sizeof(shoop_port_maybe_connection_t) * rval->n_ports);
     uint32_t idx = 0;
     for (auto &pair : connections) {
         rval->ports[idx].name = strdup(pair.first.c_str());
@@ -1139,7 +1140,7 @@ shoop_port_connections_state_t *get_decoupled_midi_port_connections_state(shoopd
         idx++;
     }
     return rval;
-  }, new shoop_port_connections_state_t);
+  }, (shoop_port_connections_state_t*) calloc(1, sizeof(shoop_port_connections_state_t)));
 }
 
 void destroy_port_connections_state(shoop_port_connections_state_t *d) {

--- a/src/rust/backend_rust/src/backend_api_cxx.rs
+++ b/src/rust/backend_rust/src/backend_api_cxx.rs
@@ -234,10 +234,8 @@ fn alloc_midi_event(data_bytes: u32) -> *mut ffi::ShoopMidiEvent {
 /// The returned pointer should be freed with destroy_midi_sequence.
 fn alloc_midi_sequence(n_events: u32) -> *mut ffi::ShoopMidiSequence {
     unsafe {
-        let events = libc::calloc(
-            n_events as usize,
-            size_of::<*mut ffi::ShoopMidiEvent>(),
-        ) as *mut *mut ffi::ShoopMidiEvent;
+        let events = libc::calloc(n_events as usize, size_of::<*mut ffi::ShoopMidiEvent>())
+            as *mut *mut ffi::ShoopMidiEvent;
         let sequence = Box::new(ffi::ShoopMidiSequence {
             n_events,
             events,

--- a/src/rust/backend_rust/src/backend_api_cxx.rs
+++ b/src/rust/backend_rust/src/backend_api_cxx.rs
@@ -234,8 +234,10 @@ fn alloc_midi_event(data_bytes: u32) -> *mut ffi::ShoopMidiEvent {
 /// The returned pointer should be freed with destroy_midi_sequence.
 fn alloc_midi_sequence(n_events: u32) -> *mut ffi::ShoopMidiSequence {
     unsafe {
-        let events = libc::malloc((n_events as usize) * size_of::<*mut ffi::ShoopMidiEvent>())
-            as *mut *mut ffi::ShoopMidiEvent;
+        let events = libc::calloc(
+            n_events as usize,
+            size_of::<*mut ffi::ShoopMidiEvent>(),
+        ) as *mut *mut ffi::ShoopMidiEvent;
         let sequence = Box::new(ffi::ShoopMidiSequence {
             n_events,
             events,
@@ -385,17 +387,16 @@ unsafe fn destroy_midi_sequence(d: *mut ffi::ShoopMidiSequence) {
     if d.is_null() {
         return;
     }
-    // Read the struct using ptr::read_unaligned to handle potential alignment issues
-    let sequence = std::ptr::read_unaligned(d);
+    // Struct allocated via Box::into_raw in Rust: reclaim with Box::from_raw.
+    let sequence = Box::from_raw(d);
     // Free each event
     for i in 0..sequence.n_events {
         let event_ptr = std::ptr::read_unaligned(sequence.events.add(i as usize));
         destroy_midi_event(event_ptr);
     }
-    // Free the events array (was allocated with malloc in C++)
+    // Events array was allocated with malloc.
     libc::free(sequence.events as *mut libc::c_void);
-    // Free the struct itself (was allocated with new in C++)
-    libc::free(d as *mut libc::c_void);
+    // sequence is dropped here
 }
 
 /// Free a profiling report struct.
@@ -406,16 +407,12 @@ unsafe fn destroy_profiling_report(d: *mut ffi::ShoopProfilingReport) {
     if d.is_null() {
         return;
     }
-    // Read the struct using ptr::read_unaligned to handle potential alignment issues
     let report = std::ptr::read_unaligned(d);
-    // Free each item's key string
     for i in 0..report.n_items {
         let item = std::ptr::read_unaligned(report.items.add(i as usize));
         libc::free(item.key as *mut libc::c_void);
     }
-    // Free the items array
     libc::free(report.items as *mut libc::c_void);
-    // Free the struct itself (was allocated with malloc/new in C++)
     libc::free(d as *mut libc::c_void);
 }
 
@@ -427,16 +424,12 @@ unsafe fn destroy_external_port_descriptors(d: *mut ffi::ShoopExternalPortDescri
     if d.is_null() {
         return;
     }
-    // Read the struct using ptr::read_unaligned to handle potential alignment issues
     let descriptors = std::ptr::read_unaligned(d);
-    // Free each port's name string
     for i in 0..descriptors.n_ports {
         let port = std::ptr::read_unaligned(descriptors.ports.add(i as usize));
         libc::free(port.name as *mut libc::c_void);
     }
-    // Free the ports array
     libc::free(descriptors.ports as *mut libc::c_void);
-    // Free the struct itself (was allocated with malloc/new in C++)
     libc::free(d as *mut libc::c_void);
 }
 
@@ -448,13 +441,10 @@ unsafe fn destroy_audio_driver_state(d: *mut ffi::ShoopAudioDriverState) {
     if d.is_null() {
         return;
     }
-    // Read the struct using ptr::read_unaligned to handle potential alignment issues
     let state = std::ptr::read_unaligned(d);
-    // Free the instance name if present
     if !state.maybe_instance_name.is_null() {
         libc::free(state.maybe_instance_name as *mut libc::c_void);
     }
-    // Free the struct itself (was allocated with new in C++)
     libc::free(d as *mut libc::c_void);
 }
 
@@ -487,16 +477,12 @@ unsafe fn destroy_port_connections_state(d: *mut ffi::ShoopPortConnectionsState)
     if d.is_null() {
         return;
     }
-    // Read the struct using ptr::read_unaligned to handle potential alignment issues
     let state = std::ptr::read_unaligned(d);
-    // Free each port's name string (allocated with strdup)
     for i in 0..state.n_ports {
         let port = std::ptr::read_unaligned(state.ports.add(i as usize));
         libc::free(port.name as *mut libc::c_void);
     }
-    // Free the ports array (allocated with new[] in C++)
     libc::free(state.ports as *mut libc::c_void);
-    // Free the struct itself (allocated with new in C++)
     libc::free(d as *mut libc::c_void);
 }
 


### PR DESCRIPTION
## Summary
Fixes allocator/ownership mismatches across the Rust/C++ backend bridge that caused flaky 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 145 tests
test audio_buffer_queue::tests::test_drop_buffer ... ok
test audio_midi_driver::tests::test_state_defaults ... ok
test audio_midi_driver::tests::test_xrun_management ... ok
test audio_buffer_queue::tests::test_two_bufs_full ... ok
test audio_midi_driver::tests::test_core_creation ... ok
test audio_buffer_queue::tests::test_single_buf_partial ... ok
test audio_midi_driver::tests::test_atomic_f32 ... ok
test audio_midi_driver::tests::test_decoupled_port_management ... ok
test audio_buffer_queue::tests::test_clone_then_drop ... ok
test audio_port::tests::test_mute_zeroes_output ... ok
test audio_buffer_queue::tests::test_single_buf_full ... ok
test audio_port::tests::test_reset_peaks ... ok
test audio_port::tests::test_audio_port_creation ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_event_zero_size ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_sequence ... ok
test audio_buffer_queue::tests::test_eviction_returns_to_pool ... ok
test backend_api_cxx::tests::test_alloc_destroy_multichannel_audio ... ok
test audio_port::tests::test_mute_control ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_event ... ok
test backend_api_cxx::tests::test_destroy_audio_driver_state_null ... ok
test backend_api_cxx::tests::test_destroy_audio_channel_state_info_null ... ok
test audio_buffer_queue::tests::test_two_bufs_partial ... ok
test backend_api_cxx::tests::test_destroy_backend_state_info_null ... ok
test audio_buffer_queue::tests::test_drop_buffer_then_change_max ... ok
test backend_api_cxx::tests::test_destroy_audio_port_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_external_port_descriptors_null ... ok
test backend_api_cxx::tests::test_destroy_midi_channel_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_midi_sequence_null ... ok
test audio_port::tests::test_process_audio ... ok
test backend_api_cxx::tests::test_destroy_midi_port_state_info_null ... ok
test audio_port::tests::test_gain_control ... ok
test backend_api_cxx::tests::test_alloc_midi_sequence_zero_events ... ok
test backend_api_cxx::tests::test_destroy_audio_channel_data_null ... ok
test backend_api_cxx::tests::test_destroy_midi_event_null ... ok
test audio_buffer_queue::tests::test_starting_state ... ok
test backend_api_cxx::tests::test_destroy_multichannel_audio_null ... ok
test audio_midi_driver::tests::test_processor_management ... ok
test backend_api_cxx::tests::test_dummy_always_supported ... ok
test backend_api_cxx::tests::test_alloc_destroy_audio_channel_data ... ok
test backend_api_cxx::tests::test_destroy_fx_chain_state_null ... ok
test backend_api_cxx::tests::test_destroy_loop_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_port_connections_state_null ... ok
test backend_api_cxx::tests::test_destroy_string_null ... ok
test backend_api_cxx::tests::test_destroy_profiling_report_null ... ok
test backend_api_cxx::tests::test_invalid_type_not_supported ... ok
test command_queue::tests::test_basic_queue_and_exec ... ok
test command_queue::tests::test_convenience_methods ... ok
test command_queue::tests::test_clear ... ok
test command_queue::tests::test_inactivity_detection ... ok
test audio_buffer_queue::tests::test_snapshot_shares_data ... ok
test command_queue::tests::test_queue_and_wait ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_request_samples ... ok
test dummy_audio_midi_driver::tests::test_pause_resume ... ok
test dummy_audio_midi_driver::tests::test_set_finish ... ok
test dummy_audio_port::tests::test_dequeue_not_enough_panics ... ok
test decoupled_midi_port::tests::test_creation ... ok
test dummy_audio_port::tests::test_queue_and_prepare ... ok
test decoupled_midi_port::tests::test_empty_pop_returns_none ... ok
test decoupled_midi_port::tests::test_push_drops_when_full ... ok
test dummy_audio_port::tests::test_queue_partial_prepare ... ok
test audio_port::tests::test_gain_applies_to_buffer ... ok
test dummy_audio_port::tests::test_request_and_dequeue ... ok
test dummy_midi_port::tests::test_clear_queues ... ok
test dummy_midi_port::tests::test_dummy_midi_port_creation ... ok
test dummy_external_connections::tests::test_find_external_ports_regex ... ok
test dummy_midi_port::tests::test_readable_buffer ... ok
test dummy_midi_port::tests::test_request_data ... ok
test dummy_external_connections::tests::test_connect_disconnect ... ok
test decoupled_midi_port::tests::test_direction ... ok
test decoupled_midi_port::tests::test_push_and_pop ... ok
test dummy_external_connections::tests::test_remove_port ... ok
test dummy_midi_port::tests::test_queue_message ... ok
test command_queue::tests::test_passthrough_mode ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_advance ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_advance_saturates_at_zero ... ok
test dummy_audio_midi_driver::tests::test_enter_mode ... ok
test dummy_audio_midi_driver::tests::test_new_defaults ... ok
test dummy_audio_port::tests::test_zero_fill ... ok
test internal_audio_port::tests::test_process_applies_gain ... ok
test internal_audio_port::tests::test_reset_peaks ... ok
test internal_midi_port::tests::test_creation ... ok
test internal_audio_port::tests::test_ringbuffer_contents ... ok
test internal_midi_port::tests::test_write_then_read_event_round_trip ... ok
test dummy_external_connections::tests::test_add_and_get_port ... ok
test dummy_external_connections::tests::test_connection_status_of_other_port ... ok
test internal_midi_port::tests::test_out_of_bounds_returns_sentinels ... ok
test dummy_midi_port::tests::test_writable_buffer ... ok
test midi_buffering_input_port::tests::test_get_event ... ok
test internal_audio_port::tests::test_buffer_pointer_non_null_after_prepare ... ok
test internal_midi_port::tests::test_prepare_clears_events ... ok
test midi_buffering_input_port::tests::test_buffer_events ... ok
test midi_buffering_input_port::tests::test_buffer_multiple_events ... ok
test midi_port::tests::test_event_counters ... ok
test midi_port::tests::test_mute_state ... ok
test internal_audio_port::tests::test_ringbuffer_config ... ok
test midi_port_base::tests::test_event_counters ... ok
test midi_port_base::tests::test_midi_port_base_creation ... ok
test midi_port_base::tests::test_midi_port_base_with_flags ... ok
test midi_port_base::tests::test_midi_state_tracking_trait ... ok
test internal_audio_port::tests::test_name_round_trip ... ok
test midi_port::tests::test_midi_port_creation ... ok
test midi_port::tests::test_output_notes_active_muted ... ok
test internal_audio_port::tests::test_creation ... ok
test midi_state_diff_tracker::tests::test_check_channel_pressure_uses_correct_byte ... ok
test midi_port::tests::test_ringbuffer_operations ... ok
test midi_port_base::tests::test_midi_ringbuffer_ops_trait ... ok
test midi_buffering_input_port::tests::test_clear_buffer ... ok
test internal_audio_port::tests::test_prepare_zero_fills ... ok
test midi_state_diff_tracker::tests::test_resolve_to_generates_messages ... ok
test midi_state_diff_tracker::tests::test_reset_clears_old_diffs ... ok
test midi_state_diff_tracker::tests::test_note_diff_tracked_correctly ... ok
test midi_buffering_input_port::tests::test_buffering_input_port_creation ... ok
test midi_state_tracker::tests::test_cc_tracking ... ok
test midi_state_tracker::tests::test_channel_pressure_tracking ... ok
test midi_state_tracker::tests::test_program_tracking ... ok
test midi_state_tracker::tests::test_state_as_messages_includes_set_cc ... ok
test midi_state_tracker::tests::test_state_as_messages_skips_unknown ... ok
test midi_port_base::tests::test_tracking_config ... ok
test midi_state_diff_tracker::tests::test_diff_tracks_cc_changes ... ok
test midi_state_tracker::tests::test_default_cc_64_and_69_are_zero ... ok
test midi_port_base::tests::test_mute_state ... ok
test midi_traits::tests::test_midi_readable_buffer_trait ... ok
test midi_port::tests::test_notes_active ... ok
test internal_audio_port::tests::test_mute_zeroes_buffer ... ok
test internal_audio_port::tests::test_mute_control ... ok
test internal_audio_port::tests::test_gain_control ... ok
test midi_state_diff_tracker::tests::test_channel_pressure_diff_uses_correct_status_byte ... ok
test midi_state_diff_tracker::tests::test_channel_pressure_independent_from_pitch_wheel ... ok
test midi_traits::tests::test_midi_state_tracking_trait ... ok
test midi_traits::tests::test_midi_ringbuffer_ops_trait ... ok
test midi_port_base::tests::test_ringbuffer_operations ... ok
test midi_state_tracker::tests::test_note_tracking ... ok
test midi_state_tracker::tests::test_clear_resets_all ... ok
test midi_state_tracker::tests::test_pitch_wheel_tracking ... ok
test refilling_pool::tests::test_deterministic_refilling_logic ... ok
test refilling_pool::tests::test_counters_and_tracking ... ok
test refilling_pool::tests::test_release ... ok
test refilling_pool::tests::test_concurrent_signal ... ok
test midi_traits::tests::test_midi_writable_buffer_trait ... ok
test refilling_pool::tests::test_new_with_invalid_config_returns_err ... ok
test refilling_pool::tests::test_heavy_concurrency_stress ... ok
test refilling_pool::tests::test_initial_state_and_prefill ... ok
test refilling_pool::tests::test_get_and_empty_fallback ... ok
test refilling_pool::tests::test_clean_shutdown ... ok
test command_queue::tests::test_panic_propagation_in_queue_and_wait ... ok

test result: ok. 145 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 32 tests
test cxx_qt_shoop::rust::qobj_file_io::tests::test_is_absolute_no ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_is_absolute_yes ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_get_current_directory ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_delete_folder_and_exists ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_basename ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_realpath ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_glob ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_class_name ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_delete_file_and_exists ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_write_read_file_roundtrip ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_make_and_extract_tarfile_roundtrip ... ok
test cxx_qt_shoop::rust::qobj_lua_engine::tests::test_basic_eval_expression_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_backend_wrapper::tests::test_class_name ... ok
test cxx_qt_shoop::rust::qobj_os_utils::tests::test_invalid_env_var ... ok
test lua_engine::tests::test_builtin_lib_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_direction ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_datatype ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_name ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_connect_after_rescan ... ok
test cxx_qt_shoop::rust::qobj_lua_engine::tests::test_basic_eval_expression_unsandboxed ... ok
test lua_engine::tests::test_callbacks_module_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_connect ... ok
test lua_engine::tests::test_basic_eval_chunk_sandboxed ... ok
test lua_qobject_callback::tests::test_basic_qobject_invokable ... ok
test lua_engine::tests::test_builtin_script_sandboxed ... ok
test lua_engine::tests::test_callbacks_module_unsandboxed ... ok
test lua_engine::tests::test_callback_unsandboxed ... ok
test cxx_qt_shoop::rust::qobj_os_utils::tests::test_valid_env_var ... ok
test lua_engine::tests::test_callback_sandboxed ... ok
test lua_engine::tests::test_basic_eval_chunk_unsandboxed ... ok
test lua_engine::tests::test_basic_eval_expression_unsandboxed ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_wait_blocking ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test dependencies::tests::test_crash_repro ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s failures (misaligned pointer dereference, double free/corruption, SIGABRT/SIGSEGV).

### Key fixes
- Ensure  zero-initializes event-pointer array via  to avoid freeing uninitialized garbage pointers.
- Normalize C++-side bridge allocations to  in places destroyed by Rust-side :
  - 
  - 
  - 
  - 
  - 
  - 
- Fix string ownership bug in  by using  instead of a string literal.
- Align Rust destroy functions with actual allocation origin for migrated types.

## Validation
- 
running 1 test
test backend_api_cxx::tests::test_alloc_destroy_midi_sequence ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 144 filtered out; finished in 0.00s passes.
- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 145 tests
test audio_buffer_queue::tests::test_eviction_returns_to_pool ... ok
test audio_midi_driver::tests::test_atomic_f32 ... ok
test audio_buffer_queue::tests::test_clone_then_drop ... ok
test audio_buffer_queue::tests::test_single_buf_partial ... ok
test audio_buffer_queue::tests::test_two_bufs_full ... ok
test audio_midi_driver::tests::test_core_creation ... ok
test audio_buffer_queue::tests::test_drop_buffer_then_change_max ... ok
test audio_midi_driver::tests::test_processor_management ... ok
test audio_buffer_queue::tests::test_starting_state ... ok
test audio_buffer_queue::tests::test_single_buf_full ... ok
test audio_buffer_queue::tests::test_drop_buffer ... ok
test audio_midi_driver::tests::test_xrun_management ... ok
test audio_buffer_queue::tests::test_two_bufs_partial ... ok
test audio_port::tests::test_mute_control ... ok
test audio_port::tests::test_gain_control ... ok
test audio_midi_driver::tests::test_state_defaults ... ok
test audio_port::tests::test_process_audio ... ok
test audio_midi_driver::tests::test_decoupled_port_management ... ok
test backend_api_cxx::tests::test_alloc_destroy_audio_channel_data ... ok
test audio_port::tests::test_mute_zeroes_output ... ok
test audio_port::tests::test_reset_peaks ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_event ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_event_zero_size ... ok
test audio_buffer_queue::tests::test_snapshot_shares_data ... ok
test backend_api_cxx::tests::test_alloc_destroy_midi_sequence ... ok
test backend_api_cxx::tests::test_alloc_destroy_multichannel_audio ... ok
test backend_api_cxx::tests::test_destroy_audio_channel_data_null ... ok
test backend_api_cxx::tests::test_destroy_audio_channel_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_audio_driver_state_null ... ok
test audio_port::tests::test_gain_applies_to_buffer ... ok
test backend_api_cxx::tests::test_destroy_audio_port_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_backend_state_info_null ... ok
test audio_port::tests::test_audio_port_creation ... ok
test backend_api_cxx::tests::test_alloc_midi_sequence_zero_events ... ok
test backend_api_cxx::tests::test_destroy_external_port_descriptors_null ... ok
test backend_api_cxx::tests::test_destroy_loop_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_fx_chain_state_null ... ok
test backend_api_cxx::tests::test_destroy_midi_channel_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_midi_event_null ... ok
test backend_api_cxx::tests::test_destroy_midi_port_state_info_null ... ok
test backend_api_cxx::tests::test_destroy_midi_sequence_null ... ok
test backend_api_cxx::tests::test_destroy_multichannel_audio_null ... ok
test backend_api_cxx::tests::test_destroy_port_connections_state_null ... ok
test backend_api_cxx::tests::test_destroy_profiling_report_null ... ok
test backend_api_cxx::tests::test_destroy_string_null ... ok
test backend_api_cxx::tests::test_dummy_always_supported ... ok
test backend_api_cxx::tests::test_invalid_type_not_supported ... ok
test command_queue::tests::test_basic_queue_and_exec ... ok
test command_queue::tests::test_clear ... ok
test command_queue::tests::test_inactivity_detection ... ok
test command_queue::tests::test_convenience_methods ... ok
test command_queue::tests::test_passthrough_mode ... ok
test command_queue::tests::test_queue_and_wait ... ok
test decoupled_midi_port::tests::test_creation ... ok
test decoupled_midi_port::tests::test_direction ... ok
test decoupled_midi_port::tests::test_empty_pop_returns_none ... ok
test decoupled_midi_port::tests::test_push_and_pop ... ok
test decoupled_midi_port::tests::test_push_drops_when_full ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_advance ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_advance_saturates_at_zero ... ok
test dummy_audio_midi_driver::tests::test_controlled_mode_request_samples ... ok
test dummy_audio_midi_driver::tests::test_enter_mode ... ok
test dummy_audio_midi_driver::tests::test_new_defaults ... ok
test dummy_audio_midi_driver::tests::test_pause_resume ... ok
test dummy_audio_midi_driver::tests::test_set_finish ... ok
test dummy_audio_port::tests::test_queue_and_prepare ... ok
test dummy_audio_port::tests::test_request_and_dequeue ... ok
test dummy_audio_port::tests::test_queue_partial_prepare ... ok
test dummy_audio_port::tests::test_zero_fill ... ok
test dummy_audio_port::tests::test_dequeue_not_enough_panics ... ok
test dummy_external_connections::tests::test_add_and_get_port ... ok
test dummy_external_connections::tests::test_connect_disconnect ... ok
test dummy_external_connections::tests::test_connection_status_of_other_port ... ok
test dummy_external_connections::tests::test_remove_port ... ok
test dummy_midi_port::tests::test_dummy_midi_port_creation ... ok
test dummy_midi_port::tests::test_queue_message ... ok
test dummy_midi_port::tests::test_clear_queues ... ok
test dummy_midi_port::tests::test_readable_buffer ... ok
test dummy_midi_port::tests::test_request_data ... ok
test dummy_midi_port::tests::test_writable_buffer ... ok
test internal_audio_port::tests::test_buffer_pointer_non_null_after_prepare ... ok
test internal_audio_port::tests::test_creation ... ok
test dummy_external_connections::tests::test_find_external_ports_regex ... ok
test internal_audio_port::tests::test_mute_zeroes_buffer ... ok
test internal_audio_port::tests::test_prepare_zero_fills ... ok
test internal_audio_port::tests::test_reset_peaks ... ok
test internal_midi_port::tests::test_write_then_read_event_round_trip ... ok
test internal_audio_port::tests::test_ringbuffer_contents ... ok
test internal_audio_port::tests::test_mute_control ... ok
test midi_buffering_input_port::tests::test_buffer_multiple_events ... ok
test internal_midi_port::tests::test_prepare_clears_events ... ok
test midi_buffering_input_port::tests::test_buffer_events ... ok
test internal_midi_port::tests::test_creation ... ok
test internal_midi_port::tests::test_out_of_bounds_returns_sentinels ... ok
test midi_buffering_input_port::tests::test_buffering_input_port_creation ... ok
test internal_audio_port::tests::test_gain_control ... ok
test internal_audio_port::tests::test_name_round_trip ... ok
test midi_buffering_input_port::tests::test_clear_buffer ... ok
test midi_buffering_input_port::tests::test_get_event ... ok
test midi_port::tests::test_notes_active ... ok
test midi_port::tests::test_midi_port_creation ... ok
test midi_port::tests::test_mute_state ... ok
test midi_port::tests::test_output_notes_active_muted ... ok
test midi_port::tests::test_event_counters ... ok
test internal_audio_port::tests::test_ringbuffer_config ... ok
test internal_audio_port::tests::test_process_applies_gain ... ok
test midi_port::tests::test_ringbuffer_operations ... ok
test midi_port_base::tests::test_event_counters ... ok
test midi_port_base::tests::test_midi_port_base_with_flags ... ok
test midi_port_base::tests::test_tracking_config ... ok
test midi_port_base::tests::test_midi_port_base_creation ... ok
test midi_port_base::tests::test_midi_state_tracking_trait ... ok
test midi_port_base::tests::test_mute_state ... ok
test midi_state_tracker::tests::test_cc_tracking ... ok
test midi_state_diff_tracker::tests::test_resolve_to_generates_messages ... ok
test midi_state_diff_tracker::tests::test_diff_tracks_cc_changes ... ok
test midi_state_diff_tracker::tests::test_channel_pressure_diff_uses_correct_status_byte ... ok
test midi_state_diff_tracker::tests::test_channel_pressure_independent_from_pitch_wheel ... ok
test midi_state_tracker::tests::test_pitch_wheel_tracking ... ok
test midi_state_diff_tracker::tests::test_reset_clears_old_diffs ... ok
test midi_traits::tests::test_midi_readable_buffer_trait ... ok
test midi_traits::tests::test_midi_ringbuffer_ops_trait ... ok
test midi_traits::tests::test_midi_state_tracking_trait ... ok
test midi_state_tracker::tests::test_state_as_messages_includes_set_cc ... ok
test midi_traits::tests::test_midi_writable_buffer_trait ... ok
test midi_state_diff_tracker::tests::test_check_channel_pressure_uses_correct_byte ... ok
test midi_state_tracker::tests::test_state_as_messages_skips_unknown ... ok
test midi_state_diff_tracker::tests::test_note_diff_tracked_correctly ... ok
test refilling_pool::tests::test_counters_and_tracking ... ok
test midi_state_tracker::tests::test_channel_pressure_tracking ... ok
test refilling_pool::tests::test_get_and_empty_fallback ... ok
test midi_state_tracker::tests::test_clear_resets_all ... ok
test midi_port_base::tests::test_ringbuffer_operations ... ok
test refilling_pool::tests::test_release ... ok
test refilling_pool::tests::test_new_with_invalid_config_returns_err ... ok
test midi_state_tracker::tests::test_program_tracking ... ok
test midi_port_base::tests::test_midi_ringbuffer_ops_trait ... ok
test midi_state_tracker::tests::test_default_cc_64_and_69_are_zero ... ok
test midi_state_tracker::tests::test_note_tracking ... ok
test refilling_pool::tests::test_deterministic_refilling_logic ... ok
test refilling_pool::tests::test_concurrent_signal ... ok
test refilling_pool::tests::test_initial_state_and_prefill ... ok
test refilling_pool::tests::test_heavy_concurrency_stress ... ok
test refilling_pool::tests::test_clean_shutdown ... ok
test command_queue::tests::test_panic_propagation_in_queue_and_wait ... ok

test result: ok. 145 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 32 tests
test cxx_qt_shoop::rust::qobj_file_io::tests::test_basename ... ok
test cxx_qt_shoop::rust::qobj_backend_wrapper::tests::test_class_name ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_class_name ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_get_current_directory ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_is_absolute_yes ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_delete_folder_and_exists ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_realpath ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_delete_file_and_exists ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_glob ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_is_absolute_no ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_write_read_file_roundtrip ... ok
test cxx_qt_shoop::rust::qobj_os_utils::tests::test_invalid_env_var ... ok
test cxx_qt_shoop::rust::qobj_os_utils::tests::test_valid_env_var ... ok
test lua_engine::tests::test_basic_eval_expression_unsandboxed ... ok
test cxx_qt_shoop::rust::qobj_lua_engine::tests::test_basic_eval_expression_unsandboxed ... ok
test lua_engine::tests::test_builtin_lib_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_make_and_extract_tarfile_roundtrip ... ok
test lua_engine::tests::test_basic_eval_chunk_unsandboxed ... ok
test lua_engine::tests::test_basic_eval_chunk_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_lua_engine::tests::test_basic_eval_expression_sandboxed ... ok
test lua_engine::tests::test_callback_unsandboxed ... ok
test lua_engine::tests::test_builtin_script_sandboxed ... ok
test lua_engine::tests::test_callbacks_module_unsandboxed ... ok
test lua_engine::tests::test_callbacks_module_sandboxed ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_direction ... ok
test lua_engine::tests::test_callback_sandboxed ... ok
test lua_qobject_callback::tests::test_basic_qobject_invokable ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_datatype ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_dont_connect_name ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_connect ... ok
test cxx_qt_shoop::rust::qobj_autoconnect::tests::test_connect_after_rescan ... ok
test cxx_qt_shoop::rust::qobj_file_io::tests::test_wait_blocking ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test dependencies::tests::test_crash_repro ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s run 10 times: 10/10 passes.
