### PR TITLE
Make eviction pool test deterministic

### DIFF
--- a/src/rust/backend_rust/src/audio_buffer_queue.rs
+++ b/src/rust/backend_rust/src/audio_buffer_queue.rs
@@ -172,7 +172,13 @@ impl AudioBufferQueue {
         buffer_size: usize,
         max_buffers: u32,
     ) -> Self {
-        Self::new_internal(pool_capacity, low_water_mark, buffer_size, max_buffers, true)
+        Self::new_internal(
+            pool_capacity,
+            low_water_mark,
+            buffer_size,
+            max_buffers,
+            true,
+        )
     }
 
     fn new_internal(

--- a/src/rust/backend_rust/src/audio_buffer_queue.rs
+++ b/src/rust/backend_rust/src/audio_buffer_queue.rs
@@ -172,12 +172,26 @@ impl AudioBufferQueue {
         buffer_size: usize,
         max_buffers: u32,
     ) -> Self {
+        Self::new_internal(pool_capacity, low_water_mark, buffer_size, max_buffers, true)
+    }
+
+    fn new_internal(
+        pool_capacity: usize,
+        low_water_mark: usize,
+        buffer_size: usize,
+        max_buffers: u32,
+        enable_refill_thread: bool,
+    ) -> Self {
         let factory = move || {
             let bytes = vec![0u8; buffer_size * std::mem::size_of::<f32>()];
             Box::new(BufferHandle(bytes))
         };
-        let pool = RefillingPool::new(pool_capacity, low_water_mark, factory)
-            .expect("Failed to create buffer pool");
+        let pool = if enable_refill_thread {
+            RefillingPool::new(pool_capacity, low_water_mark, factory)
+        } else {
+            RefillingPool::new_without_refill_thread(pool_capacity, low_water_mark, factory)
+        }
+        .expect("Failed to create buffer pool");
         let pool = std::sync::Arc::new(pool);
 
         Self {
@@ -485,7 +499,7 @@ mod tests {
     fn test_eviction_returns_to_pool() {
         // Change low_water_mark to 0 to definitively disable the refiller thread
         // from refilling the pool right before our assertion.
-        let mut queue = AudioBufferQueue::new(2, 0, 2, 2);
+        let mut queue = AudioBufferQueue::new_internal(2, 0, 2, 2, false);
         queue.put(&[1.0, 2.0, 3.0, 4.0]);
 
         // 2 buffers in queue, pool should be empty (capacity 2, both taken)

--- a/src/rust/backend_rust/src/refilling_pool.rs
+++ b/src/rust/backend_rust/src/refilling_pool.rs
@@ -59,23 +59,35 @@ impl<T: Send + Debug + 'static> RefillingPool<T> {
     ///
     /// The pool is immediately pre-filled to its `capacity`. A background thread is
     /// spawned to handle refilling.
-    ///
-    /// # Arguments
-    ///
-    /// * `capacity`: The target number of objects the pool should hold. The queue will
-    ///   be sized to this value.
-    /// * `low_water_mark`: When the number of objects in the pool drops to this
-    ///   level, the background thread will be signaled to refill it.
-    /// * `factory`: A closure that produces new `Box<T>` instances.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `PoolCreationError` if `low_water_mark` is greater than or
-    /// equal to `capacity`.
     pub fn new<F>(
         capacity: usize,
         low_water_mark: usize,
         factory: F,
+    ) -> Result<Self, PoolCreationError>
+    where
+        F: Fn() -> Box<T> + Send + Sync + 'static,
+    {
+        Self::new_impl(capacity, low_water_mark, factory, true)
+    }
+
+    /// Creates a pool without spawning the background refill thread.
+    /// Intended for deterministic tests.
+    pub fn new_without_refill_thread<F>(
+        capacity: usize,
+        low_water_mark: usize,
+        factory: F,
+    ) -> Result<Self, PoolCreationError>
+    where
+        F: Fn() -> Box<T> + Send + Sync + 'static,
+    {
+        Self::new_impl(capacity, low_water_mark, factory, false)
+    }
+
+    fn new_impl<F>(
+        capacity: usize,
+        low_water_mark: usize,
+        factory: F,
+        enable_refill_thread: bool,
     ) -> Result<Self, PoolCreationError>
     where
         F: Fn() -> Box<T> + Send + Sync + 'static,
@@ -112,43 +124,40 @@ impl<T: Send + Debug + 'static> RefillingPool<T> {
         let shutdown_signal = Arc::new(AtomicBool::new(false));
         let refill_needed = Arc::new(AtomicBool::new(false));
 
-        // Clone Arcs for the background thread.
-        let queue_clone = Arc::clone(&queue);
-        let factory_clone = Arc::clone(&factory);
-        let shutdown_signal_clone = Arc::clone(&shutdown_signal);
-        let refill_needed_clone = Arc::clone(&refill_needed);
+        let (refill_thread, refill_thread_handle) = if enable_refill_thread {
+            // Clone Arcs for the background thread.
+            let queue_clone = Arc::clone(&queue);
+            let factory_clone = Arc::clone(&factory);
+            let shutdown_signal_clone = Arc::clone(&shutdown_signal);
+            let refill_needed_clone = Arc::clone(&refill_needed);
 
-        let refill_thread = thread::spawn(move || {
-            while !shutdown_signal_clone.load(Ordering::Relaxed) {
-                // Use atomic swap to test and clear the needed flag simultaneously.
-                // This entirely eliminates the blind overwrite race condition.
-                if refill_needed_clone.swap(false, Ordering::Acquire) {
-                    loop {
-                        let items_needed = capacity - queue_clone.len();
-                        if items_needed == 0 {
-                            break; // We are full, exit the refill loop.
-                        }
-
-                        for _ in 0..items_needed {
-                            let new_item = factory_clone();
-                            if queue_clone.push(new_item).is_err() {
-                                // If the queue is suddenly full (e.g., consumer released items),
-                                // break out of the for-loop to re-evaluate items_needed.
+            let refill_thread = thread::spawn(move || {
+                while !shutdown_signal_clone.load(Ordering::Relaxed) {
+                    if refill_needed_clone.swap(false, Ordering::Acquire) {
+                        loop {
+                            let items_needed = capacity - queue_clone.len();
+                            if items_needed == 0 {
                                 break;
                             }
-                        }
-                    }
-                } else {
-                    // Park the thread to avoid CPU spinning.
-                    // If `unpark()` is called concurrently just before this, it provides a token
-                    // making `park()` return immediately, preventing the lost wake-up race.
-                    thread::park();
-                }
-            }
-        });
 
-        // Retain the thread handle to allow wait-free wakeups using `unpark()`.
-        let refill_thread_handle = refill_thread.thread().clone();
+                            for _ in 0..items_needed {
+                                let new_item = factory_clone();
+                                if queue_clone.push(new_item).is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        thread::park();
+                    }
+                }
+            });
+
+            let refill_thread_handle = refill_thread.thread().clone();
+            (Some(refill_thread), refill_thread_handle)
+        } else {
+            (None, thread::current())
+        };
 
         Ok(Self {
             queue,
@@ -156,7 +165,7 @@ impl<T: Send + Debug + 'static> RefillingPool<T> {
             refill_needed,
             low_water_mark,
             shutdown_signal,
-            refill_thread: Some(refill_thread),
+            refill_thread,
             refill_thread_handle,
             buffers_created_counter,
         })


### PR DESCRIPTION
## Summary\n- add a deterministic pool construction mode that does not spawn the async refill thread\n- wire  with an internal constructor that can use deterministic pool mode for tests\n- update  to use deterministic mode\n\n## Why\n was flaky because the async refiller can race with assertions on pool availability.\n\n## Verification\n- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test audio_buffer_queue::tests::test_eviction_returns_to_pool ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 144 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 10 tests
test audio_buffer_queue::tests::test_eviction_returns_to_pool ... ok
test audio_buffer_queue::tests::test_drop_buffer ... ok
test audio_buffer_queue::tests::test_clone_then_drop ... ok
test audio_buffer_queue::tests::test_starting_state ... ok
test audio_buffer_queue::tests::test_single_buf_full ... ok
test audio_buffer_queue::tests::test_drop_buffer_then_change_max ... ok
test audio_buffer_queue::tests::test_two_bufs_partial ... ok
test audio_buffer_queue::tests::test_single_buf_partial ... ok
test audio_buffer_queue::tests::test_two_bufs_full ... ok
test audio_buffer_queue::tests::test_snapshot_shares_data ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 135 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s