### PR TITLE
Harden macOS crash-handler CI behavior

### DIFF
--- a/.github/actions/test_crash_handler/action.yml
+++ b/.github/actions/test_crash_handler/action.yml
@@ -37,15 +37,22 @@ runs:
     shell: wrap-shell {0}
     run: |
       echo "=== Checking for minidump ==="
-      find crash_handler_test_dumps -name "*.dmp" -type f
-      if [ $(find crash_handler_test_dumps -name "*.dmp" -type f | wc -l) -gt 0 ]; then
-        echo "MINIDUMP_FOUND=true" | tee -a $GITHUB_OUTPUT
-        echo "SUCCESS: Minidump file was created"
-      else
-        echo "MINIDUMP_FOUND=false" | tee -a $GITHUB_OUTPUT
-        echo "FAILURE: No minidump file found in crash_handler_test_dumps/"
-        exit 1
-      fi
+      for i in 1 2 3 4 5; do
+        find crash_handler_test_dumps -name "*.dmp" -type f
+        if [ $(find crash_handler_test_dumps -name "*.dmp" -type f | wc -l) -gt 0 ]; then
+          echo "MINIDUMP_FOUND=true" | tee -a $GITHUB_OUTPUT
+          echo "SUCCESS: Minidump file was created"
+          break
+        fi
+        if [ "$i" -lt 5 ]; then
+          echo "Minidump not found yet, retrying in 1s ($i/5)..."
+          sleep 1
+        else
+          echo "MINIDUMP_FOUND=false" | tee -a $GITHUB_OUTPUT
+          echo "FAILURE: No minidump file found in crash_handler_test_dumps/"
+          exit 1
+        fi
+      done
 
   - name: Check for QML stack trace attachment
     if: always()
@@ -53,17 +60,24 @@ runs:
     run: |
       echo "=== Checking for QML stack trace attachment ==="
       # The QML stack trace is written as a separate attachment file with pattern: *.dmp.attach.qml_stack
-      find crash_handler_test_dumps -name "*.dmp.attach.qml_stack" -type f
-      if [ $(find crash_handler_test_dumps -name "*.dmp.attach.qml_stack" -type f | wc -l) -gt 0 ]; then
-        echo "QML_STACK_FOUND=true" | tee -a $GITHUB_OUTPUT
-        echo "SUCCESS: QML stack trace attachment file was created"
-        echo "=== QML stack content preview ==="
-        head -50 "$(find crash_handler_test_dumps -name '*.dmp.attach.qml_stack' | head -n1)"
-      else
-        echo "QML_STACK_FOUND=false" | tee -a $GITHUB_OUTPUT
-        echo "FAILURE (IGNORED): QML stack trace attachment file not found"
-        exit 0
-      fi
+      for i in 1 2 3 4 5; do
+        find crash_handler_test_dumps -name "*.dmp.attach.qml_stack" -type f
+        if [ $(find crash_handler_test_dumps -name "*.dmp.attach.qml_stack" -type f | wc -l) -gt 0 ]; then
+          echo "QML_STACK_FOUND=true" | tee -a $GITHUB_OUTPUT
+          echo "SUCCESS: QML stack trace attachment file was created"
+          echo "=== QML stack content preview ==="
+          head -50 "$(find crash_handler_test_dumps -name '*.dmp.attach.qml_stack' | head -n1)"
+          break
+        fi
+        if [ "$i" -lt 5 ]; then
+          echo "QML stack attachment not found yet, retrying in 1s ($i/5)..."
+          sleep 1
+        else
+          echo "QML_STACK_FOUND=false" | tee -a $GITHUB_OUTPUT
+          echo "FAILURE (IGNORED): QML stack trace attachment file not found"
+          exit 0
+        fi
+      done
 
   - name: Verify app crashed as expected
     if: always()

--- a/scripts/run_with_timeout.sh
+++ b/scripts/run_with_timeout.sh
@@ -42,7 +42,15 @@ if [[ $IS_WINDOWS -eq 1 ]]; then
     STDERR_CAPTURE_FILE="/tmp/run_with_timeout_stderr_$$"
     echo "[run_with_timeout] Windows detected: stderr will be captured to $STDERR_CAPTURE_FILE"
 fi
-# echo "[run_with_timeout] DEBUG: IS_WINDOWS=$IS_WINDOWS, uname=$(uname -s)"
+
+# macOS/BSD ps may not support "sid" output field name; use "sess" there.
+PS_SESSION_FIELD="sid"
+if [[ $IS_WINDOWS -eq 0 ]]; then
+    if ! ps -o sid= -p $$ >/dev/null 2>&1; then
+        PS_SESSION_FIELD="sess"
+    fi
+fi
+# echo "[run_with_timeout] DEBUG: IS_WINDOWS=$IS_WINDOWS, uname=$(uname -s), PS_SESSION_FIELD=$PS_SESSION_FIELD"
 
 # Helper function to format seconds as human-readable
 format_time() {
@@ -271,7 +279,7 @@ dump_process_tree() {
         fi
         echo "[run_with_timeout]   Session processes (sid=${STORED_SID:-N/A}):"
         if [[ -n "${STORED_SID:-}" ]]; then
-            ps -s "$STORED_SID" -o pid,ppid,pgid,sid,comm,args 2>/dev/null || true
+            ps -s "$STORED_SID" -o pid,ppid,pgid,${PS_SESSION_FIELD},comm,args 2>/dev/null || true
         fi
     fi
 }
@@ -694,8 +702,10 @@ STORED_Pgid=""
 if [[ $IS_WINDOWS -eq 0 ]]; then
     # Wait a tiny bit for the process to fully start
     sleep 0.1
-    STORED_SID=$(ps -o sid= -p $CHILD_PID 2>/dev/null | tr -d ' ') || true
+    STORED_SID=$(ps -o ${PS_SESSION_FIELD}= -p $CHILD_PID 2>/dev/null | tr -d ' ') || true
     STORED_Pgid=$(ps -o pgid= -p $CHILD_PID 2>/dev/null | tr -d ' ') || true
+    if [[ ! "${STORED_SID:-}" =~ ^[0-9]+$ ]]; then STORED_SID=""; fi
+    if [[ ! "${STORED_Pgid:-}" =~ ^[0-9]+$ ]]; then STORED_Pgid=""; fi
     echo "[run_with_timeout] Stored Session: ${STORED_SID:-unknown}, Stored Process Group: ${STORED_Pgid:-unknown}"
 else
     : # echo "[run_with_timeout] DEBUG: Windows path: skipping sid/pgid storage (not applicable)"

--- a/src/rust/crashhandling/src/client.rs
+++ b/src/rust/crashhandling/src/client.rs
@@ -1,6 +1,9 @@
 use crate::types::*;
 use minidumper::Client;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering as AtomicOrdering},
+    mpsc, Arc, Mutex,
+};
 use std::thread;
 use std::time::Duration;
 
@@ -9,7 +12,7 @@ shoop_log_unit!("CrashHandlingClient");
 
 /// On unix, store the server child PID for reaping using atexit
 #[cfg(unix)]
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 #[cfg(unix)]
 static SERVER_PID: AtomicI32 = AtomicI32::new(-1);
 #[cfg(unix)]
@@ -470,81 +473,26 @@ pub fn crashhandling_client(
         let clients_access: Arc<Mutex<(Client, Client)>> = Arc::new(Mutex::new((client, client2)));
         let handler_clients_access = clients_access.clone();
         let ping_clients_access = clients_access.clone();
+        let crash_seen = Arc::new(AtomicBool::new(false));
+        let dump_requested = Arc::new(AtomicBool::new(false));
+        let attachments_sent = Arc::new(AtomicBool::new(false));
+
+        let handler_crash_seen = crash_seen.clone();
+        let handler_dump_requested = dump_requested.clone();
 
         #[allow(unsafe_code)]
         let handler_closure = unsafe {
             crash_handler::make_crash_event(move |crash_context: &crash_handler::CrashContext| {
-                eprintln!("Client: crash_handler callback invoked!");
+                handler_crash_seen.store(true, AtomicOrdering::SeqCst);
                 let guard = handler_clients_access
                     .as_ref()
                     .lock()
                     .unwrap_or_else(|e| e.into_inner());
-                let (client1, client2) = &*guard;
+                let (client1, _) = &*guard;
 
-                let thread_name = crate::registered_threads::current_thread_registered_name()
-                    .unwrap_or("unknown".to_string());
-                if let Err(e) = client1.send_message(
-                    CrashHandlingMessageType::SetJson as u32,
-                    format!("{{\"tags\":{{\"thread_name\":\"{thread_name}\"}}}}"),
-                ) {
-                    eprintln!("Failed to send thread name to crash handler: {}", e);
-                }
-
-                // Send a ping to the server, this ensures that all messages that have been sent
-                // are "flushed" before the crash event is sent. This is only really useful
-                // on macos where messages and crash events are sent via different, unsynchronized,
-                // methods which can result in the crash event closing the server before
-                // the non-crash messages are received/processed
-                if let Err(e) = client1.ping() {
-                    eprintln!("Failed to ping client1: {}", e);
-                }
-                if let Err(e) = client2.ping() {
-                    eprintln!("Failed to ping client2: {}", e);
-                }
-
-                println!("Crash detected - requesting minidump");
-                eprintln!("Client: calling client1.request_dump()...");
-
-                let handled: bool;
-                match client1.request_dump(crash_context) {
-                    Ok(_) => {
-                        handled = true;
-                        println!("Requested minidump.");
-                        eprintln!("Client: request_dump succeeded!");
-                    }
-                    Err(e) => {
-                        handled = false;
-                        println!("Failed to report crash to handling process: {e}");
-                        eprintln!("Client: request_dump FAILED: {:?}", e);
-                    }
-                }
-                eprintln!("Client: request_dump complete, handled={}", handled);
-
-                // Send additional crash data if possible over the 2nd connection
-                if let Some(on_crash_callback) = &on_crash_callback {
-                    for additional_info in on_crash_callback() {
-                        let id = &additional_info.id;
-                        println!("Got additional crash info '{id}'");
-
-                        let buf = match serde_json::to_string(&additional_info) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                eprintln!("Failed to serialize additional info: {}", e);
-                                continue;
-                            }
-                        };
-                        match client2.send_message(
-                            CrashHandlingMessageType::AdditionalCrashAttachment as usize as u32,
-                            buf,
-                        ) {
-                            Ok(_) => {
-                                println!("Sent additional crash info message");
-                            }
-                            Err(err) => {
-                                println!("Failed to send additional crash info message: {}", err)
-                            }
-                        }
-                    }
+                let handled = client1.request_dump(crash_context).is_ok();
+                if handled {
+                    handler_dump_requested.store(true, AtomicOrdering::SeqCst);
                 }
 
                 crash_handler::CrashEventResult::Handled(handled)
@@ -621,6 +569,31 @@ pub fn crashhandling_client(
                     match client2.ping() {
                         Ok(_) => (),
                         Err(e) => warn!("Failed to ping crash handling server. {}", e),
+                    }
+
+                    if crash_seen.load(AtomicOrdering::SeqCst)
+                        && dump_requested.load(AtomicOrdering::SeqCst)
+                        && !attachments_sent.load(AtomicOrdering::SeqCst)
+                    {
+                        if let Some(on_crash_callback) = &on_crash_callback {
+                            for additional_info in on_crash_callback() {
+                                let buf = match serde_json::to_string(&additional_info) {
+                                    Ok(s) => s,
+                                    Err(e) => {
+                                        warn!("Failed to serialize additional crash info: {}", e);
+                                        continue;
+                                    }
+                                };
+                                if let Err(err) = client2.send_message(
+                                    CrashHandlingMessageType::AdditionalCrashAttachment as usize
+                                        as u32,
+                                    buf,
+                                ) {
+                                    warn!("Failed to send additional crash info message: {}", err);
+                                }
+                            }
+                        }
+                        attachments_sent.store(true, AtomicOrdering::SeqCst);
                     }
 
                     // Periodically check if the server child has exited and reap it.


### PR DESCRIPTION
## Summary
- Fix scripts/run_with_timeout.sh session-id detection on macOS/BSD by falling back from sid to sess and validating numeric SID/PGID values.
- Make crash callback path in Rust crash handling client minimal (request minidump only) to reduce crash-context deadlock/race risk.
- Keep QML attachment behavior by sending additional crash attachments from the normal background thread after dump request succeeds.
- Add short retry windows in crash-handler CI checks for both minidump and QML attachment files to reduce timing flakiness on macOS.

## Motivation
macOS CI crash-handler test was flaky, with callback invocation observed but minidump checks sometimes failing. This change reduces unsafe work done inside crash callback context and makes checks more tolerant of small write delays.

## Notes
- Ran cargo fmt --all.
