### PR TITLE
Fix graph rebuild synchronization

### DIFF
--- a/.github/actions/process_crashdumps/action.yml
+++ b/.github/actions/process_crashdumps/action.yml
@@ -73,6 +73,7 @@ runs:
 
         SENTRY_ATTACHMENTS=""
         for f in $dump.attach.*; do
+          [ -f "$f" ] || continue
           ATTACHMENT_ID=$(basename $f | sed 's/^.*\.//')
           SENTRY_ATTACHMENTS="$SENTRY_ATTACHMENTS -F $f=@$f"
         done

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_backend_wrapper.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_backend_wrapper.rs
@@ -243,12 +243,14 @@ impl BackendWrapper {
             let engine_update_thread = crate::engine_update_thread::get_engine_update_thread();
             let engine_update_thread_obj = engine_update_thread.ref_qobject_ptr();
 
+            // BackendWrapper is a QQuickItem and must only be touched on the GUI thread.
+            // A direct connection races update delivery with QML object destruction.
             connect::connect_or_report(
                 &*engine_update_thread_obj,
                 "update()",
                 &*obj_qobject,
                 "update_on_other_thread()",
-                connection_types::DIRECT_CONNECTION,
+                connection_types::QUEUED_CONNECTION,
             );
         }
 

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_backend.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_backend.rs
@@ -17,6 +17,7 @@ use cxx_qt_lib_shoop::{
     connect::connect_or_report,
     connection_types,
     qobject::{qobject_property_bool, qobject_property_string, AsQObject, FromQObject},
+    qpointer::{qpointer_from_qobject, qpointer_to_qobject},
     qsharedpointer_qobject::QSharedPointer_QObject,
     qvariant_helpers::qvariant_to_qsharedpointer_qobject,
     qweakpointer_qobject::QWeakPointer_QObject,
@@ -47,6 +48,14 @@ macro_rules! error {
 }
 
 impl PortBackend {
+    fn live_backend(&self) -> *mut QObject {
+        if self.backend_guard.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe { qpointer_to_qobject(&self.backend_guard) }
+        }
+    }
+
     pub fn update(mut self: Pin<&mut PortBackend>) {
         if self.maybe_backend_port.is_none() {
             return;
@@ -286,7 +295,8 @@ impl PortBackend {
                 let min_n_ringbuffer_samples: i32 = self
                     .min_n_ringbuffer_samples
                     .ok_or(anyhow!("min_n_ringbuffer_samples not set"))?;
-                let backend = BackendWrapper::from_qobject_ref_ptr(self.backend as *const QObject)?;
+                let backend =
+                    BackendWrapper::from_qobject_ref_ptr(self.live_backend() as *const QObject)?;
 
                 debug!(self, "Opening driver port for: {name_hint}");
 
@@ -337,11 +347,11 @@ impl PortBackend {
 
         let mut non_ready_vars: HashSet<String> = HashSet::new();
         unsafe {
-            if self.backend.is_null() {
+            let backend = self.live_backend();
+            if backend.is_null() {
                 non_ready_vars.insert("backend".to_string());
-            }
-            if !self.backend.is_null() {
-                let ready = if let Some(backend_ref) = self.backend.as_ref() {
+            } else {
+                let ready = if let Some(backend_ref) = backend.as_ref() {
                     qobject_property_bool(backend_ref, "ready").unwrap_or(false)
                 } else {
                     false
@@ -600,8 +610,14 @@ impl PortBackend {
             return;
         }
         if self.backend != backend {
+            let backend_guard = if backend.is_null() {
+                cxx::UniquePtr::null()
+            } else {
+                unsafe { qpointer_from_qobject(backend) }
+            };
             let mut rust_mut = self.as_mut().rust_mut();
             rust_mut.backend = backend;
+            rust_mut.backend_guard = backend_guard;
             unsafe {
                 if !backend.is_null() {
                     let self_qobject = port_backend_qobject_from_ptr(

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_backend_bridge.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_backend_bridge.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use crate::any_backend_port::{AnyBackendPort, AnyBackendPortState};
 use common::logging::macros::*;
-use cxx_qt_lib_shoop::{qobject::AsQObject, qweakpointer_qobject::QWeakPointer_QObject};
+use cxx_qt_lib_shoop::{
+    qobject::AsQObject, qpointer::QPointerQObject, qweakpointer_qobject::QWeakPointer_QObject,
+};
 use shoop_engine::{PortConnectability, PortDataType};
 
 shoop_log_unit!("Frontend.Port");
@@ -346,6 +348,7 @@ pub struct PortBackendRust {
     // Properties
     pub initialized: bool,
     pub backend: *mut QObject,
+    pub backend_guard: cxx::UniquePtr<QPointerQObject>,
     pub internal_port_connections: QList_QVariant,
     pub frontend_object: *mut QObject,
 
@@ -368,6 +371,7 @@ impl Default for PortBackendRust {
         PortBackendRust {
             initialized: false,
             backend: std::ptr::null_mut(),
+            backend_guard: cxx::UniquePtr::null(),
             name_hint: None,
             input_connectability: None,
             output_connectability: None,

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_gui.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_port_gui.rs
@@ -149,7 +149,7 @@ impl PortGui {
                         "backend_set_backend(QObject*)",
                         backend_ref,
                         "set_backend(QObject*)",
-                        connection_types::QUEUED_CONNECTION,
+                        connection_types::BLOCKING_QUEUED_CONNECTION,
                     );
                     connect_or_report(
                         self_ref,

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -991,7 +991,10 @@ impl SharedSession {
             .as_mut()
         {
             e.pump();
-            return Ok(f(e.session_mut()));
+            let result = f(e.session_mut());
+            // A direct query may mutate the topology, so publish its staleness before return.
+            e.publish_graph_staleness();
+            return Ok(result);
         }
         // A driver owns the engine; the queue is the only way in.
         //

--- a/src/rust/shoop_engine/src/engine.rs
+++ b/src/rust/shoop_engine/src/engine.rs
@@ -528,7 +528,7 @@ impl Engine {
     ///
     /// Written after commands are applied, because applying them is what makes it stale, and
     /// the control side's decision to rebuild is only as good as the moment this reflects.
-    fn publish_graph_staleness(&self) {
+    pub(crate) fn publish_graph_staleness(&self) {
         self.stats
             .graph_stale
             .store(!self.session.graph_up_to_date(), Ordering::Relaxed);

--- a/src/rust/shoop_engine/src/graph_scheduler.rs
+++ b/src/rust/shoop_engine/src/graph_scheduler.rs
@@ -241,22 +241,32 @@ mod tests {
     }
 
     /// The property that makes this starvation-free: continued churn must not push the
-    /// deadline out. An idle-debounce would apply zero times here.
+    /// deadline out. An idle-debounce would replace the first deadline on every arm.
     #[test]
     fn continuous_churn_does_not_postpone_the_deadline() {
         let (n, apply) = counter();
-        let window = Duration::from_millis(10);
-        let s = GraphScheduler::start(window, apply);
+        let s = GraphScheduler::start(Duration::from_secs(30), apply);
 
-        let start = Instant::now();
-        while start.elapsed() < Duration::from_millis(120) {
+        s.arm();
+        let first_deadline = s
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .deadline;
+        for _ in 0..100 {
             s.arm();
-            thread::sleep(Duration::from_millis(1));
         }
-        thread::sleep(Duration::from_millis(40));
+        let deadline_after_churn = s
+            .shared
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .deadline;
 
-        // Bounded below: staleness never exceeded one window despite unbroken churn.
-        check!(n.load(Ordering::Relaxed) >= 2);
+        check!(deadline_after_churn == first_deadline);
+        s.flush_blocking();
+        check!(n.load(Ordering::Relaxed) == 1);
         drop(s);
     }
 


### PR DESCRIPTION
## Summary
- publish graph staleness after direct parked-engine queries without draining newly queued commands
- ensure topology mutations made before driver ownership trigger a schedule rebuild
- deliver `BackendWrapper` updates on its owning GUI thread to avoid teardown races
- make the graph-scheduler churn test verify its invariant without host-timing assumptions
- skip nonexistent crash-dump attachment globs during Sentry upload

## Testing
- `cargo fmt --all -- --check`
- `audio_port_peak_state_is_per_poll_cycle` passed 20 consecutive runs
- `continuous_churn_does_not_postpone_the_deadline` passed 100 consecutive runs
- `RUSTFLAGS="-D warnings" cargo build -p shoop_engine --features app_backend`
- attachment upload loop tested with a dump that has no attachments
- frontend `cargo check` attempted; blocked locally by missing system `lua54.pc`
