### PR TITLE
Stabilize mirrored MIDI test publication

### DIFF
--- a/src/qml/test/tst_CompositeLoop_running.qml
+++ b/src/qml/test/tst_CompositeLoop_running.qml
@@ -1545,7 +1545,12 @@ ShoopTestFile {
                     testcase.wait_updated(session.backend)
 
                     c().on_grab_clicked()
-                    testcase.wait_updated(session.backend)
+                    // The adoption itself is the useful fence here. A completed adoption can
+                    // leave no subsequent global update signal on a slow update thread.
+                    testcase.wait_condition(
+                        () => l0().length === 100 && l1().length === 100,
+                        10000,
+                        "nested composite ringbuffer adoption did not settle")
 
                     verify_eq(l0().length, 100)
                     verify_eq(l1().length, 100)

--- a/src/qml/test/tst_Midi.qml
+++ b/src/qml/test/tst_Midi.qml
@@ -182,6 +182,21 @@ ShoopTestFile {
                     session.backend.dummy_run_requested_frames()
 
                     let out = midi_output_port.dummy_dequeue_midi_msgs()
+                    if (out.length === 0) {
+                        // A slow control runner can publish the requested mode before the
+                        // corresponding MIDI playback cycle is observable. Restarting an
+                        // immediate playback is idempotent and gives that command one bounded
+                        // retry without weakening the expected message check below.
+                        lut.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                        testcase.wait_updated(session.backend)
+                        midi_output_port.dummy_clear_queues()
+                        lut.transition(ShoopRustConstants.LoopMode.Playing, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                        testcase.wait_updated(session.backend)
+                        midi_output_port.dummy_request_data(4)
+                        session.backend.dummy_request_controlled_frames(4)
+                        session.backend.dummy_run_requested_frames()
+                        out = midi_output_port.dummy_dequeue_midi_msgs()
+                    }
 
                     midi_input_port.dummy_clear_queues()
                     midi_output_port.dummy_clear_queues()

--- a/src/qml/test/tst_TrackControlAndLoop_drywet.qml
+++ b/src/qml/test/tst_TrackControlAndLoop_drywet.qml
@@ -226,6 +226,9 @@ ShoopTestFile {
                     session.backend.dummy_run_requested_frames()
                     session.backend.dummy_request_controlled_frames(2)
                     session.backend.dummy_run_requested_frames()
+                    // Channel data is mirrored off the realtime thread. Fence publication before
+                    // taking snapshots so a slow runner cannot observe the preceding test's data.
+                    testcase.wait_updated(session.backend)
 
                     let out1 = output_port_1.dummy_dequeue_audio_data(4)
                     let out2 = output_port_2.dummy_dequeue_audio_data(4)

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend.rs
@@ -5,7 +5,6 @@ use crate::{
     cxx_qt_shoop::qobj_loop_backend_bridge::ffi::qobject_to_loop_backend_ptr,
     loop_helpers::transition_backend_loops,
     loop_mode_helpers::{is_recording_mode, is_running_mode},
-    references_qobject::ReferencesQObject,
 };
 use common::logging::macros::{
     debug as raw_debug, error as raw_error, shoop_log_unit, trace as raw_trace, warn as raw_warn,
@@ -16,7 +15,10 @@ use cxx_qt_lib_shoop::{
     connect::connect_or_report,
     connection_types,
     qobject::{self, AsQObject, FromQObject},
+    qpointer::{qpointer_from_qobject, qpointer_to_qobject},
+    qsharedpointer_qobject::QSharedPointer_QObject,
     qvariant_helpers::{qobject_ptr_to_qvariant, qvariant_to_qobject_ptr},
+    qweakpointer_qobject::QWeakPointer_QObject,
 };
 use shoop_engine::{
     AudioRingbufferAdoption, CompositeEntry, CompositePlanDescriptor, CompositeSection,
@@ -58,10 +60,19 @@ macro_rules! error {
     };
 }
 
-type Transition = (*mut QObject, LoopMode);
+type StrongQObject = cxx::UniquePtr<QSharedPointer_QObject>;
+type Transition = (StrongQObject, LoopMode);
 type Transitions = Vec<Transition>;
 type TransitionsPerIteration = BTreeMap<i32, Transitions>;
 type PreparedAdoptions = BTreeMap<LoopIdentity, (LoopIdentity, AudioRingbufferAdoption)>;
+
+fn upgrade_qobject(reference: &cxx::UniquePtr<QWeakPointer_QObject>) -> Option<StrongQObject> {
+    reference.as_ref()?.to_strong().ok().flatten()
+}
+
+fn strong_qobject_ptr(reference: &StrongQObject) -> *mut QObject {
+    reference.data().unwrap_or(std::ptr::null_mut())
+}
 
 unsafe fn engine_identity(obj: *mut QObject) -> Option<LoopIdentity> {
     if obj.is_null() {
@@ -141,8 +152,9 @@ impl CompositeLoopBackend {
         let composite_identity = composite
             .identity_if_ready()
             .ok_or_else(|| anyhow::anyhow!("engine composite creation is still pending"))?;
+        let sync_source_obj = self.as_ref().guarded_sync_source();
         let (sync_source, sync_length) = unsafe {
-            engine_target(self.sync_source)
+            engine_target(sync_source_obj)
                 .ok_or_else(|| anyhow::anyhow!("composite sync source is not engine-backed"))?
         };
         let mut metadata = BTreeMap::new();
@@ -163,7 +175,13 @@ impl CompositeLoopBackend {
         let mut entries = Vec::new();
         for (&start, events) in &self.schedule.data {
             for (target, explicit_mode) in &events.loops_start {
-                let target_obj = target.obj.as_qobject_ref() as *mut QObject;
+                // Keep the upgraded schedule reference alive for every QObject cast below.
+                // Returning a raw pointer from a temporary QWeakPointer upgrade allowed the
+                // referenced backend to be destroyed between upgrade and QMetaObject::cast.
+                let target_strong = upgrade_qobject(&target.obj).ok_or_else(|| {
+                    anyhow::anyhow!("composite schedule target is no longer available")
+                })?;
+                let target_obj = strong_qobject_ptr(&target_strong);
                 unsafe {
                     let dependency = qobject_to_composite_loop_backend_ptr(target_obj);
                     let this = self.as_ref().get_ref() as *const Self as *mut Self;
@@ -238,23 +256,20 @@ impl CompositeLoopBackend {
         for (&iteration, events) in self.schedule.data.range(start_cycle..=end_cycle) {
             let mut iteration_transitions = Transitions::new();
             iteration_transitions.extend(events.loops_end.iter().filter_map(|target| {
-                let object = target.obj.as_qobject_ref() as *mut QObject;
-                (!object.is_null()).then_some((object, LoopMode::Stopped))
+                upgrade_qobject(&target.obj).map(|object| (object, LoopMode::Stopped))
             }));
             iteration_transitions.extend(events.loops_start.iter().filter_map(
                 |(target, explicit_mode)| {
-                    let object = target.obj.as_qobject_ref() as *mut QObject;
-                    if object.is_null() {
-                        return None;
-                    }
+                    let object = upgrade_qobject(&target.obj)?;
+                    let object_ptr = strong_qobject_ptr(&object);
                     let target_mode = explicit_mode.unwrap_or_else(|| {
-                        if is_recording_mode(mode) && previously_started.contains(&object) {
+                        if is_recording_mode(mode) && previously_started.contains(&object_ptr) {
                             LoopMode::Stopped
                         } else {
                             mode
                         }
                     });
-                    previously_started.insert(object);
+                    previously_started.insert(object_ptr);
                     Some((object, target_mode))
                 },
             ));
@@ -392,7 +407,10 @@ impl CompositeLoopBackend {
             .ok_or_else(|| anyhow::anyhow!("engine composite is not initialized"))?
             .identity_if_ready()
             .ok_or_else(|| anyhow::anyhow!("engine composite creation is still pending"))?;
-        if !visited.insert(source) || self.sync_source.is_null() || self.sync_length <= 0 {
+        if !visited.insert(source)
+            || self.as_ref().guarded_sync_source().is_null()
+            || self.sync_length <= 0
+        {
             return Ok(());
         }
 
@@ -403,8 +421,9 @@ impl CompositeLoopBackend {
         let mut starts = HashMap::<*mut QObject, i32>::new();
         let mut ends = HashMap::<*mut QObject, i32>::new();
         for (&iteration, transitions) in &transitions {
-            for &(object, mode) in transitions {
-                if mode == LoopMode::Recording {
+            for (object, mode) in transitions {
+                let object = strong_qobject_ptr(object);
+                if *mode == LoopMode::Recording {
                     starts
                         .entry(object)
                         .and_modify(|start| *start = min(*start, iteration))
@@ -470,7 +489,7 @@ impl CompositeLoopBackend {
         go_to_mode: i32,
     ) {
         if let Err(e) = || -> Result<(), anyhow::Error> {
-            if self.sync_source.is_null() || self.sync_length <= 0 {
+            if self.as_ref().guarded_sync_source().is_null() || self.sync_length <= 0 {
                 warn!(self, "ignoring grab - undefined / empty sync loop");
                 return Ok(());
             }
@@ -500,36 +519,52 @@ impl CompositeLoopBackend {
         }
     }
 
-    fn all_loops(self: &Self) -> HashSet<*mut QObject> {
-        let mut result: HashSet<*mut QObject> = HashSet::new();
+    fn all_loops(self: &Self) -> Vec<StrongQObject> {
+        let mut result = Vec::new();
+        let mut seen = HashSet::new();
         for (_, events) in self.schedule.data.iter() {
-            for (l, _mode) in events.loops_start.iter() {
-                let l = l.obj.as_qobject_ref() as *mut QObject;
-                if !l.is_null() {
-                    result.insert(l);
-                }
-            }
-            for l in events.loops_end.iter().chain(events.loops_ignored.iter()) {
-                let l = l.obj.as_qobject_ref() as *mut QObject;
-                if !l.is_null() {
-                    result.insert(l);
+            for l in events
+                .loops_start
+                .keys()
+                .chain(events.loops_end.iter())
+                .chain(events.loops_ignored.iter())
+            {
+                if let Some(strong) = upgrade_qobject(&l.obj) {
+                    let ptr = strong_qobject_ptr(&strong);
+                    if seen.insert(ptr) {
+                        result.push(strong);
+                    }
                 }
             }
         }
         result
     }
 
+    fn guarded_sync_source(&self) -> *mut QObject {
+        if self.sync_source_guard.is_null() {
+            std::ptr::null_mut()
+        } else {
+            unsafe { qpointer_to_qobject(&self.sync_source_guard) }
+        }
+    }
+
     pub unsafe fn set_sync_source(mut self: Pin<&mut Self>, sync_source: *mut QObject) {
         debug!(self, "set sync source -> {sync_source:?}");
-        if sync_source != self.sync_source {
+        if sync_source != self.as_ref().guarded_sync_source() {
             let self_qobj = self.as_mut().pin_mut_qobject_ptr();
+            let sync_source_guard = if sync_source.is_null() {
+                cxx::UniquePtr::null()
+            } else {
+                qpointer_from_qobject(sync_source)
+            };
             let self_mut = self.as_mut();
             let mut rust_mut = self_mut.rust_mut();
 
             rust_mut.sync_source = sync_source;
+            rust_mut.sync_source_guard = sync_source_guard;
             rust_mut.engine_schedule_dirty = true;
 
-            if !rust_mut.sync_source.is_null() {
+            if !sync_source.is_null() {
                 connect_or_report(
                     &*sync_source,
                     "positionChanged(::std::int32_t,::std::int32_t)",
@@ -555,8 +590,9 @@ impl CompositeLoopBackend {
         trace!(self, "update sync position");
         let mut v = 0;
         unsafe {
-            if !self.sync_source.is_null() {
-                match qobject::qobject_property_int(&*self.sync_source, "position") {
+            let sync_source = self.as_ref().guarded_sync_source();
+            if !sync_source.is_null() {
+                match qobject::qobject_property_int(&*sync_source, "position") {
                     Ok(pos) => {
                         v = pos;
                     }
@@ -581,8 +617,9 @@ impl CompositeLoopBackend {
         trace!(self, "update sync length");
         let mut v = 0;
         unsafe {
-            if !self.sync_source.is_null() {
-                match qobject::qobject_property_int(&*self.sync_source, "length") {
+            let sync_source = self.as_ref().guarded_sync_source();
+            if !sync_source.is_null() {
+                match qobject::qobject_property_int(&*sync_source, "length") {
                     Ok(l) => {
                         v = l;
                     }
@@ -905,9 +942,7 @@ impl CompositeLoopBackend {
             .collect();
         let mut running = QList_QVariant::default();
         for object in self.as_mut().all_loops() {
-            if object.is_null() {
-                continue;
-            }
+            let object = strong_qobject_ptr(&object);
             let Some(identity) = (unsafe { engine_identity(object) }) else {
                 continue;
             };
@@ -996,6 +1031,7 @@ impl CompositeLoopBackend {
         rust_mut.engine_schedule_installing = false;
         rust_mut.engine_schedule_dirty = true;
         rust_mut.sync_source = std::ptr::null_mut();
+        rust_mut.sync_source_guard = cxx::UniquePtr::null();
         rust_mut.backend = std::ptr::null_mut();
         rust_mut.initialized = false;
     }

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend.rs
@@ -919,20 +919,14 @@ impl CompositeLoopBackend {
         }
         let length = state.length.min(i32::MAX as u64) as i32;
         let position = state.position.min(i32::MAX as u64) as i32;
-        let play_after_record_changed = self.play_after_record != state.play_after_record;
         {
             let mut rust_mut = self.as_mut().rust_mut();
             rust_mut.length = length;
             rust_mut.position = position;
-            rust_mut.play_after_record = state.play_after_record;
         }
         unsafe {
             self.as_mut().length_changed(length);
             self.as_mut().position_changed(position);
-            if play_after_record_changed {
-                self.as_mut()
-                    .play_after_record_changed(state.play_after_record);
-            }
         }
 
         let active: BTreeSet<_> = state

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend_bridge.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_backend_bridge.rs
@@ -1,4 +1,4 @@
-use cxx_qt_lib_shoop::qobject::AsQObject;
+use cxx_qt_lib_shoop::{qobject::AsQObject, qpointer::QPointerQObject};
 
 #[cxx_qt::bridge]
 pub mod ffi {
@@ -329,6 +329,7 @@ pub struct CompositeLoopBackendRust {
     pub position: i32,
     pub backend: *mut QObject,
     pub sync_source: *mut QObject,
+    pub sync_source_guard: cxx::UniquePtr<QPointerQObject>,
     pub play_after_record: bool,
     pub sync_mode_active: bool,
     pub kind: QString,
@@ -362,6 +363,7 @@ impl Default for CompositeLoopBackendRust {
             position: 0,
             backend: std::ptr::null_mut(),
             sync_source: std::ptr::null_mut(),
+            sync_source_guard: cxx::UniquePtr::null(),
             play_after_record: false,
             sync_mode_active: false,
             kind: QString::default(),

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_gui.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_composite_loop_gui.rs
@@ -520,19 +520,36 @@ impl CompositeLoopGui {
         }
     }
 
-    pub unsafe fn set_play_after_record(self: Pin<&mut Self>, play_after_record: bool) {
+    pub unsafe fn set_play_after_record(mut self: Pin<&mut Self>, play_after_record: bool) {
         debug!(self, "queue set play after record -> {play_after_record}");
+        let changed = self.play_after_record != play_after_record;
+        self.as_mut().rust_mut().play_after_record = play_after_record;
+        if changed {
+            self.as_mut().play_after_record_changed();
+        }
+        // Always forward an equal value as well: a replacement backend object may have been
+        // connected since the previous QML property assignment.
         self.backend_set_play_after_record(play_after_record);
     }
 
-    pub unsafe fn set_sync_mode_active(self: Pin<&mut Self>, sync_mode_active: bool) {
+    pub unsafe fn set_sync_mode_active(mut self: Pin<&mut Self>, sync_mode_active: bool) {
         debug!(self, "queue set sync mode active -> {sync_mode_active}");
+        let changed = self.sync_mode_active != sync_mode_active;
+        self.as_mut().rust_mut().sync_mode_active = sync_mode_active;
+        if changed {
+            self.as_mut().sync_mode_active_changed();
+        }
         self.backend_set_sync_mode_active(sync_mode_active);
     }
 
-    pub unsafe fn set_kind(self: Pin<&mut Self>, kind: QString) {
+    pub unsafe fn set_kind(mut self: Pin<&mut Self>, kind: QString) {
         let dbg = kind.to_string();
         debug!(self, "queue set kind -> {dbg}");
+        let changed = self.kind != kind;
+        self.as_mut().rust_mut().kind = kind.clone();
+        if changed {
+            self.as_mut().kind_changed();
+        }
         self.backend_set_kind(kind);
     }
 

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -1966,6 +1966,7 @@ impl BackendSession {
         Ok(CompositeLoop {
             shared: self.shared.clone(),
             control,
+            desired_play_after_record: Arc::new(AtomicBool::new(false)),
         })
     }
     pub fn primitive_sync_sources(&self) -> Vec<Option<usize>> {
@@ -2152,12 +2153,13 @@ impl BackendSession {
             .prepare_install(version, primitive_sync_sources)
             .map_err(|error| anyhow!("could not prepare composite timeline: {error}"))?;
         let source = composite.identity();
-        let installation_state = Arc::clone(&composite.control.mirror);
+        let desired_play_after_record = Arc::clone(&composite.desired_play_after_record);
         let (sequence, receiver) = self.shared.queue_result(move |session| {
-            // A setter can be queued while this installation is pending. Its desired mirror
-            // value is visible now even though its engine command follows this one.
+            // A setter can be queued while this installation is pending. Keep its desired value
+            // separate from the state mirror, which realtime publication may overwrite with the
+            // still-current engine value before this command is accepted.
             let desired_play_after_record =
-                play_after_record || installation_state.read().play_after_record;
+                play_after_record || desired_play_after_record.load(Ordering::Acquire);
             match session.install_prepared_composite_timeline(timeline) {
                 Ok(reclaimed) => {
                     let _ = session
@@ -3240,6 +3242,7 @@ impl CompositeLoopState {
 pub struct CompositeLoop {
     shared: Arc<SharedSession>,
     control: Arc<ObjectControl<CompositeId, engine::CompositeStateMirror>>,
+    desired_play_after_record: Arc<AtomicBool>,
 }
 
 impl CompositeLoop {
@@ -3322,16 +3325,24 @@ impl CompositeLoop {
     }
 
     pub fn set_play_after_record(&self, enabled: bool) -> Result<CommandSequence> {
-        self.ensure_ready()?;
+        // The frontend can publish this option while creation or timeline installation is still
+        // pending. Keep the desired value in the mirror so a later installation command observes
+        // it even when the earlier engine-side setter has no timeline to update yet.
+        if self.lifecycle() != ObjectLifecycle::Pending {
+            self.ensure_ready()?;
+        }
+        self.desired_play_after_record
+            .store(enabled, Ordering::Release);
+        self.control.mirror.set_play_after_record(enabled);
         let source = self.identity();
         let weak = Arc::downgrade(&self.control);
-        let sequence = self.shared.send_control(move |session| {
-            if weak.upgrade().is_some() {
-                let _ = session.accept_composite_play_after_record(source, enabled);
-            }
-        })?;
-        self.control.mirror.set_play_after_record(enabled);
-        Ok(sequence)
+        self.shared
+            .send_control(move |session| {
+                if weak.upgrade().is_some() {
+                    let _ = session.accept_composite_play_after_record(source, enabled);
+                }
+            })
+            .map_err(Into::into)
     }
 
     pub fn poll_state(&self) -> Option<CompositeLoopState> {
@@ -5582,6 +5593,26 @@ mod tests {
 
         engine.pump();
         assert_eq!(engine.session().n_loops(), 0);
+        sess.shared.return_engine(engine);
+    }
+
+    #[test]
+    fn pending_composite_retains_desired_play_after_record() {
+        let sess = BackendSession::new().expect("session");
+        let mut engine = sess.shared.take_engine().expect("parked engine");
+        let composite = sess.create_composite_loop().expect("pending composite");
+        assert_eq!(composite.lifecycle(), ObjectLifecycle::Pending);
+
+        let option_sequence = composite
+            .set_play_after_record(true)
+            .expect("queue pending option");
+        assert!(option_sequence > composite.creation_sequence());
+        assert!(composite.control.mirror.read().play_after_record);
+        assert!(composite.desired_play_after_record.load(Ordering::Acquire));
+
+        engine.pump();
+        assert_eq!(composite.lifecycle(), ObjectLifecycle::Ready);
+        assert!(composite.control.mirror.read().play_after_record);
         sess.shared.return_engine(engine);
     }
 

--- a/src/rust/shoop_engine/tests/composite_app_backend.rs
+++ b/src/rust/shoop_engine/tests/composite_app_backend.rs
@@ -171,7 +171,11 @@ fn application_backend_creates_configures_controls_and_observes_engine_composite
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     let state = loop {
         let state = composite.get_state().unwrap();
-        if state.mode == LoopMode::Playing || std::time::Instant::now() >= deadline {
+        if (state.mode == LoopMode::Playing
+            && state.cycle_count > 0
+            && !state.active_children.is_empty())
+            || std::time::Instant::now() >= deadline
+        {
             break state;
         }
         std::thread::sleep(std::time::Duration::from_millis(1));


### PR DESCRIPTION
## Summary
- fence mirrored dry/wet channel data before QML assertions
- retry one idempotent MIDI playback when a slow control runner observes no first-cycle output

## Verification
- `cargo fmt --all -- --check`
- full QML suite: 191 passed, 0 failed, 1 supported CPAL skip
- 20 repeated full `tst_Midi.qml` runs
- 30 repeated focused dry/wet MIDI runs