### PR TITLE
Restore engine rework documentation

### DIFF
--- a/ENGINE_ISSUE_ENVIRONMENT_LIMITED_TESTS.md
+++ b/ENGINE_ISSUE_ENVIRONMENT_LIMITED_TESTS.md
@@ -1,0 +1,15 @@
+# Engine verification is limited by the test environment
+
+## Issue
+
+Some engine and driver behavior cannot be exercised in environments that lack the required audio or MIDI backend devices. The resulting skipped or overridden tests leave parts of integration behavior unverified in those runs.
+
+## Known limitations
+
+- MIDI driver tests cannot use ALSA sequencing when `/dev/snd/seq` is unavailable. Runs using `SHOOP_ALLOW_MISSING_BACKENDS=1` tolerate the absent backend rather than exercising it.
+- CPAL device integration tests can be skipped when no suitable CPAL settings or device are available.
+- JACK, virtual MIDI, and physical-device behavior depends on services and devices outside the test process.
+
+## Impact
+
+A passing test run in a restricted environment does not confirm operation against the unavailable backends. Device discovery, connection handling, callback behavior, and teardown can differ from mock or skipped paths, so the affected integration coverage remains incomplete until run in a suitably provisioned environment.

--- a/ENGINE_ISSUE_EXCEPTIONAL_BLOCKING_WAITS.md
+++ b/ENGINE_ISSUE_EXCEPTIONAL_BLOCKING_WAITS.md
@@ -1,0 +1,17 @@
+# Exceptional blocking waits remain
+
+## Issue
+
+Most ordinary reads use state mirrors, but several engine workflows still require an explicit response or barrier. These paths wait for process-thread progress and therefore retain blocking or rendezvous behavior.
+
+## Affected behavior
+
+- The graph scheduler waits for a topology description before preparing a schedule.
+- Schedule installation waits for ownership of the displaced schedule to return so that it is not destroyed on the process thread.
+- Command-sequence fences wait for a specific mutation ordering point.
+- Driver-settling, queue-drain, and graph-flush operations wait for queued work to complete.
+- Some file-load delivery paths block while prepared data is handed to the backend object thread.
+
+## Impact
+
+Each wait depends on another thread or processing cycle making progress. Graph rebuilds consume command capacity and can converge slowly when the engine is busy. If these exceptional paths are called from periodic frontend polling or another latency-sensitive context, they can stall that caller and reintroduce cycle-dependent UI behavior.

--- a/ENGINE_ISSUE_OBJECT_LIFECYCLE_AND_REMOVAL.md
+++ b/ENGINE_ISSUE_OBJECT_LIFECYCLE_AND_REMOVAL.md
@@ -1,0 +1,17 @@
+# Object lifecycle and removal are incomplete
+
+## Issue
+
+Pending object creation has explicit lifecycle states, but ownership and removal after an object becomes ready are not fully defined. Dropping the final ordinary frontend handle does not remove the corresponding object from the engine session.
+
+## Affected behavior
+
+- An unreferenced pending handle can cancel creation before insertion.
+- Once insertion has completed, final-handle drop does not remove the ready loop, channel, or port.
+- Commands queued against an object retain its control until FIFO processing has drained.
+- JACK registration records retain port controls independently of ordinary frontend handles.
+- A registered port whose insertion never completes can remain pending until driver teardown.
+
+## Impact
+
+Dynamically created objects can remain in the session after they are no longer reachable from ordinary frontend code. Their topology and resources can therefore outlive the handle that appeared to own them. Retained registrations and queued dependencies also make the point at which an object should become closed or removable ambiguous.

--- a/ENGINE_ISSUE_PROCESS_OPERATION_ERROR_REPORTING.md
+++ b/ENGINE_ISSUE_PROCESS_OPERATION_ERROR_REPORTING.md
@@ -1,0 +1,17 @@
+# Process-operation error reporting is incomplete
+
+## Issue
+
+Queue admission errors are reported to callers, but errors that occur later when commands execute are not represented consistently. Some are logged, some are published asynchronously, and some process-side calls discard their result.
+
+## Affected behavior
+
+- Fire-and-forget operations can fail after their initiating API call has returned successfully.
+- Operations without a status object cannot communicate structured completion or failure to their caller.
+- Some session calls ignore returned errors.
+- Ringbuffer-content adoption reports successful queueing but only logs an execution failure.
+- External connection operations can underreport backend rejection while cached state reflects the requested change.
+
+## Impact
+
+Callers can distinguish queue admission failure from success, but cannot always determine whether the requested operation actually completed. Invalid references and backend failures can appear as silent no-ops or exist only in logs. User-visible state can temporarily or permanently disagree with engine state without a structured error attached to the operation.

--- a/ENGINE_ISSUE_PROCESS_THREAD_LOCKING_ALLOCATION_AND_COPYING.md
+++ b/ENGINE_ISSUE_PROCESS_THREAD_LOCKING_ALLOCATION_AND_COPYING.md
@@ -1,0 +1,28 @@
+# Process-thread locking, allocation, and copying
+
+## Issue
+
+Some non-steady-state engine operations still lock shared state, allocate or resize memory, and copy complete data collections on the process thread. These operations do not satisfy the engine's intended real-time constraints.
+
+## Affected behavior
+
+Known categories include:
+
+- capturing dummy audio and MIDI output;
+- legacy/non-application control paths that install channel data without the prepared-generation API;
+- executing topology, creation, loading, and response commands;
+- callback access to driver registration, connection, capture, MIDI, and plugin-host state;
+- constructing or resizing callback scratch and event collections.
+
+## Snapshot-migration status
+
+Production audio/MIDI channel publication now uses bounded preallocated update transport, prepared
+load/ringbuffer generations, immutable manifests, and off-thread endpoint retirement. Allocation
+guards cover process publication, dense MIDI blocks, prepared installation, and pooled endpoint
+destruction. This removes complete channel-content publication and application load installation
+from the remaining categories above; it does not resolve the broader command/topology and dummy
+capture work tracked by this issue.
+
+## Impact
+
+Lock contention can block the process callback. Allocation and collection growth can introduce unbounded latency. Full-content copying makes process time depend on recording or event-set size. Under load, these behaviors can cause delayed processing or audio dropouts.

--- a/ENGINE_REWORK.md
+++ b/ENGINE_REWORK.md
@@ -1,0 +1,69 @@
+# Engine control boundary
+
+Last updated 2026-08-01.
+
+## Current contract
+
+The application-facing engine boundary uses three separate mechanisms with intentionally different semantics:
+
+1. **Per-object state mirrors** for ordinary reads.
+2. **Sequenced fire-and-forget commands** for mutations.
+3. **Pending stable controls** for asynchronously created objects.
+
+Ordinary polling does not wait for an audio cycle, query the process thread, or require a globally consistent graph snapshot. A read may observe independently updated fields from nearby process points. Code that requires exact read-after-write ordering must use an explicit `CommandSequence` fence.
+
+## State mirrors
+
+Loops, audio/MIDI channels, and audio/MIDI ports each own an `Arc` mirror shared with their application handle.
+
+- Scalar fields use atomics.
+- Floating-point fields use their `f32` bit representation in `AtomicU32`.
+- Peaks use process-side atomic max and frontend-side `swap(0)` consumption.
+- Event counters use atomic accumulation and frontend-side `swap(0)` consumption.
+- Gauges such as active notes use ordinary atomic loads.
+- Channel data-dirty state compares a process-published content sequence with a frontend-owned acknowledgement sequence.
+- User-facing scalar setters write the accepted desired value into the same atomic mirror after queue admission. This prevents asynchronous initialization/save flows from reverting to an older published value; the process side republishes the authoritative value when the command executes.
+
+The former bulk object snapshot queues and global queued-cycle trust mechanism have been removed. Engine-wide counters and graph-staleness atomics remain because they are independently useful and are not object-state snapshots.
+
+## Commands and barriers
+
+Application mutations enqueue a boxed command and return `Result<CommandSequence, SendError>`.
+
+- Queue admission failure is never silently discarded.
+- A full queue logs a warning and retries after space becomes available; parked engines are pumped so retry does not deadlock before driver activation.
+- Payload ownership is preserved across retries.
+- Commands execute FIFO.
+- Scalar commands do not arm graph rebuilding; topology commands do.
+- Process-side operation errors are logged or published asynchronously where no operation-status object exists yet.
+
+`wait_for_command` is an explicit barrier for tests and workflows that truly require exact ordering. The graph scheduler also retains named response waits for topology description and prepared-schedule ownership transfer. These exceptional paths must not be used by periodic polling.
+
+## Pending object controls
+
+Loop, channel, and session-port handles contain a typed `Arc<ObjectControl<Id, Mirror>>` with:
+
+- session identity;
+- lifecycle (`Pending`, `Ready`, `Failed`, or `Closed`);
+- atomically published engine identity;
+- creation command sequence;
+- asynchronous error text;
+- the per-object mirror.
+
+Creation returns after successful enqueue, before an arena index exists. Follow-up commands capture controls and resolve identities only when they execute, so configuration and connections can be queued immediately in FIFO order. Cross-session relationships are rejected. Dropping an otherwise unreferenced pending handle cancels creation through the command's weak reference.
+
+JACK registration records retain the same audio/MIDI port control. Callbacks resolve the index only when the control is `Ready`; unresolved, failed, and closed registrations are ignored safely. Decoupled MIDI ports remain on their own stable `PortId` path because they do not belong to the session arena.
+
+## Complex data and external connections
+
+Audio/MIDI channel content and dummy output capture currently use temporary mutex-backed shared stores. This removes cycle rendezvous from getters but is not the final realtime design: process-side locking, allocation, and full-content copying remain. Detailed risks and future directions are tracked in `REMAINING_ISSUES.md`.
+
+External connection state is cached. Session-backed ports register requests in one cache; at a controlled cadence a worker takes one backend lock, bulk-enumerates the requested ports, and publishes replacement maps. Cache generations prevent stale workers from overwriting explicit mutations. The engine-update thread forwards cached maps to GUI objects asynchronously. GUI connection getters read local cached state rather than entering the backend thread through a blocking Qt call. User-triggered connect/disconnect remains a separate synchronous operation and optimistically updates local cache state.
+
+## FX chains
+
+FX chain ports are created once when the chain is created, retained as pending handles, and cloned by getters. Repeated getters do not mutate topology. Audio input/output and MIDI input/output capabilities are counted separately. Driver sample rate and buffer size are atomically published for plugin creation rather than queried from the process thread.
+
+## Verification and deferred work
+
+`PLAN.md` records the staged implementation and verification gates. `API_INVENTORY.md` records the audited API surface. `REMAINING_ISSUES.md` is the authoritative list of temporary mutexes, process-thread allocations/copies, exceptional waits, lifecycle/removal gaps, and environment-limited tests.


### PR DESCRIPTION
## Summary
- restore the engine rework overview
- retain the remaining engine concerns as focused issue documents
- keep completed content-snapshot planning and audit documents out of the final tree

## Stack
- depends on #665
- this PR contains documentation only
