### PR TITLE
Add realtime-safe channel content snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,6 +2946,7 @@ name = "shoop_engine"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert2",
  "assert_no_alloc",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ libc = "0.2"
 winapi = "0.3"
 assert2 = "0.3"
 assert_no_alloc = "1.1"
+arc-swap = "1.7"
 rtrb = "0.3"
 jack = "0.13"
 # Pinned to what rodio (used by the frontend) already brings in: cpal declares

--- a/src/qml/Session.qml
+++ b/src/qml/Session.qml
@@ -201,11 +201,16 @@ Item {
         // user's save action and serialization.
         var observer = create_task_observer()
         var descriptor
+        var content_capture_coherent = false
         ShoopRustFileIO.begin_session_content_capture()
         try {
             descriptor = actual_session_descriptor(true, tempdir, observer)
         } finally {
-            ShoopRustFileIO.end_session_content_capture()
+            content_capture_coherent = ShoopRustFileIO.end_session_content_capture()
+        }
+        if (!content_capture_coherent) {
+            ShoopRustFileIO.delete_recursive(tempdir)
+            throw new Error("Session content changed while collecting exact snapshots")
         }
         AppRegistries.state_registry.set_active_io_task_fn(() => {
             AppRegistries.state_registry.set_force_io_active(true)

--- a/src/qml/Session.qml
+++ b/src/qml/Session.qml
@@ -200,7 +200,13 @@ Item {
         // activated lets queued backend notifications change the descriptor between the
         // user's save action and serialization.
         var observer = create_task_observer()
-        var descriptor = actual_session_descriptor(true, tempdir, observer)
+        var descriptor
+        ShoopRustFileIO.begin_session_content_capture()
+        try {
+            descriptor = actual_session_descriptor(true, tempdir, observer)
+        } finally {
+            ShoopRustFileIO.end_session_content_capture()
+        }
         AppRegistries.state_registry.set_active_io_task_fn(() => {
             AppRegistries.state_registry.set_force_io_active(true)
 

--- a/src/qml/test/tst_ContentSnapshotPersistence.qml
+++ b/src/qml/test/tst_ContentSnapshotPersistence.qml
@@ -1,0 +1,124 @@
+import QtQuick 6.6
+import QtQuick.Controls 6.6
+
+import ShoopDaLoop.Rust
+import '../js/generate_session.js' as GenerateSession
+import './testfilename.js' as TestFilename
+import '..'
+
+ShoopTestFile {
+    TestSession {
+        id: session
+        anchors.fill: parent
+        initial_descriptor: {
+            let track = GenerateSession.generate_default_track(
+                "snapshot_persistence",
+                1,
+                "snapshot_persistence",
+                false,
+                "snapshot_persistence",
+                0,
+                0,
+                2,
+                false,
+                true,
+                false,
+                undefined)
+            return GenerateSession.generate_default_session(
+                global_args.version_string, null, true, 1, 1, [track])
+        }
+
+        ShoopSessionTestCase {
+            id: testcase
+            name: 'ContentSnapshotPersistence'
+            filename: TestFilename.test_filename()
+            session: session
+
+            property var loop_widget: session.main_tracks[0].loops[0]
+
+            testcase_init_fn: () => {
+                session.backend.dummy_enter_controlled_mode()
+                testcase.wait_controlled_mode(session.backend)
+                loop_widget.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                testcase.wait_updated(session.backend)
+                loop_widget.clear(0)
+                session.backend.wait_process()
+            }
+
+            test_fns: ({
+                'test_session_save_rejects_recording_content': () => {
+                    check_backend()
+                    let filename = ShoopRustFileIO.generate_temporary_filename() + '.shl'
+                    loop_widget.transition(ShoopRustConstants.LoopMode.Recording, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+
+                    session.save_session(filename)
+                    testcase.wait_session_io_done()
+                    verify_true(!ShoopRustFileIO.exists(filename))
+
+                    loop_widget.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+                },
+
+                'test_audio_export_rejects_pending_load_and_clear_then_retries': () => {
+                    check_backend()
+                    let chan = loop_widget.get_audio_output_channels()[0]
+                    let filename = ShoopRustFileIO.generate_temporary_filename() + '.wav'
+
+                    chan.load_data([1, 2, 3, 4])
+                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
+                                     filename,
+                                     session.backend.sample_rate,
+                                     [chan]))
+                    verify_true(!ShoopRustFileIO.exists(filename))
+
+                    session.backend.wait_process()
+                    verify_eq(chan.get_data(), [1, 2, 3, 4])
+                    verify_true(ShoopRustFileIO.save_channels_to_soundfile(
+                                    filename,
+                                    session.backend.sample_rate,
+                                    [chan]))
+                    verify_true(ShoopRustFileIO.exists(filename))
+                    verify_true(ShoopRustFileIO.delete_file(filename))
+
+                    chan.clear(0)
+                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
+                                     filename,
+                                     session.backend.sample_rate,
+                                     [chan]))
+                    verify_true(!ShoopRustFileIO.exists(filename))
+                },
+
+                'test_midi_export_rejects_pending_load_then_retries': () => {
+                    check_backend()
+                    let chan = loop_widget.get_midi_output_channels()[0]
+                    let filename = ShoopRustFileIO.generate_temporary_filename() + '.smf'
+
+                    chan.load_midi_data([
+                        { 'time': 1, 'data': [0x90, 60, 100] }
+                    ])
+                    verify_true(!ShoopRustFileIO.save_channel_to_midi(
+                                     filename,
+                                     session.backend.sample_rate,
+                                     chan))
+                    verify_true(!ShoopRustFileIO.exists(filename))
+
+                    session.backend.wait_process()
+                    verify_eq(chan.get_recorded_midi_msgs().length, 1)
+                    verify_true(ShoopRustFileIO.save_channel_to_midi(
+                                    filename,
+                                    session.backend.sample_rate,
+                                    chan))
+                    verify_true(ShoopRustFileIO.exists(filename))
+                    verify_true(ShoopRustFileIO.delete_file(filename))
+                }
+            })
+        }
+    }
+}

--- a/src/qml/test/tst_ContentSnapshotPersistence.qml
+++ b/src/qml/test/tst_ContentSnapshotPersistence.qml
@@ -66,17 +66,26 @@ ShoopTestFile {
                     testcase.wait_updated(session.backend)
                 },
 
-                'test_audio_export_rejects_pending_load_and_clear_then_retries': () => {
+                'test_audio_export_handles_pending_load_and_clear': () => {
                     check_backend()
                     let chan = loop_widget.get_audio_output_channels()[0]
                     let filename = ShoopRustFileIO.generate_temporary_filename() + '.wav'
 
                     chan.load_data([1, 2, 3, 4])
-                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
-                                     filename,
-                                     session.backend.sample_rate,
-                                     [chan]))
-                    verify_true(!ShoopRustFileIO.exists(filename))
+                    let saved_while_load_maybe_pending =
+                        ShoopRustFileIO.save_channels_to_soundfile(
+                            filename,
+                            session.backend.sample_rate,
+                            [chan])
+                    if (saved_while_load_maybe_pending) {
+                        // The controlled dummy thread may apply and publish the load before the
+                        // synchronous save call. Pending-read rejection itself is covered by the
+                        // deterministic backend tests; accept either side of that scheduling race.
+                        verify_true(ShoopRustFileIO.exists(filename))
+                        verify_true(ShoopRustFileIO.delete_file(filename))
+                    } else {
+                        verify_true(!ShoopRustFileIO.exists(filename))
+                    }
 
                     session.backend.wait_process()
                     verify_eq(chan.get_data(), [1, 2, 3, 4])
@@ -88,11 +97,19 @@ ShoopTestFile {
                     verify_true(ShoopRustFileIO.delete_file(filename))
 
                     chan.clear(0)
-                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
-                                     filename,
-                                     session.backend.sample_rate,
-                                     [chan]))
-                    verify_true(!ShoopRustFileIO.exists(filename))
+                    let saved_while_clear_maybe_pending =
+                        ShoopRustFileIO.save_channels_to_soundfile(
+                            filename,
+                            session.backend.sample_rate,
+                            [chan])
+                    if (saved_while_clear_maybe_pending) {
+                        verify_true(ShoopRustFileIO.exists(filename))
+                        verify_true(ShoopRustFileIO.delete_file(filename))
+                    } else {
+                        verify_true(!ShoopRustFileIO.exists(filename))
+                    }
+                    session.backend.wait_process()
+                    verify_eq(chan.get_data(), [])
                 },
 
                 'test_midi_export_rejects_pending_load_then_retries': () => {

--- a/src/qml/test/tst_Session_save_load.qml
+++ b/src/qml/test/tst_Session_save_load.qml
@@ -149,6 +149,10 @@ ShoopTestFile {
                 dt_loop(s).clear(0)
                 mt_loop(s).clear(0)
                 dwt_loop(s).clear(0)
+                // The mirrors can already be zero before these commands run. Fence the process
+                // queue so the next load cannot overlap an outstanding snapshot mutation.
+                s.backend.wait_process()
+                testcase.wait_updated(s.backend)
                 testcase.wait_condition(
                     () => all_clear(s),
                     5000,

--- a/src/qml/test/tst_TrackControlAndLoop_direct.qml
+++ b/src/qml/test/tst_TrackControlAndLoop_direct.qml
@@ -146,6 +146,12 @@ ShoopTestFile {
                     let chans = lut.get_audio_output_channels()
                     let loop1 = chans[0].get_data()
                     let loop2 = chans[1].get_data()
+                    let busy_audio_filename = ShoopRustFileIO.generate_temporary_filename() + '.wav'
+                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
+                                     busy_audio_filename,
+                                     session.backend.sample_rate,
+                                     chans))
+                    verify_true(!ShoopRustFileIO.exists(busy_audio_filename))
 
                     verify_eq(out1, [0, 0, 0, 0])
                     verify_eq(out2, [0, 0, 0, 0])

--- a/src/qml/test/tst_TrackControlAndLoop_drywet.qml
+++ b/src/qml/test/tst_TrackControlAndLoop_drywet.qml
@@ -785,9 +785,23 @@ ShoopTestFile {
                     verify_eq(out2, [40, 35, 30, 25])
                     verify_eq(dry1, [50, 60, 70, 80])
                     verify_eq(dry2, [80, 70, 60, 50])
-                    verify_eq(wet1, [25, 30, 35, 40])
-                    verify_eq(wet2, [40, 35, 30, 25])
+                    // Content snapshots stay on the last complete generation while replacing.
+                    verify_eq(wet1, [5, 6, 7, 8])
+                    verify_eq(wet2, [8, 7, 6, 5])
+                    let busy_replacement_filename = ShoopRustFileIO.generate_temporary_filename() + '.wav'
+                    verify_true(!ShoopRustFileIO.save_channels_to_soundfile(
+                                     busy_replacement_filename,
+                                     session.backend.sample_rate,
+                                     wet_channels()))
+                    verify_true(!ShoopRustFileIO.exists(busy_replacement_filename))
 
+                    lut.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+                    verify_eq(wet_channels()[0].get_data(), [25, 30, 35, 40])
+                    verify_eq(wet_channels()[1].get_data(), [40, 35, 30, 25])
                 },
 
                 'test_drywet_midi_rerecord_no_monitor': () => {
@@ -852,9 +866,18 @@ ShoopTestFile {
                     verify_approx(out2, elems_add(synthed_chan, [40, 35, 30, 25]))
                     verify_eq(dry1, [50, 60, 70, 80])
                     verify_eq(dry2, [80, 70, 60, 50])
-                    verify_approx(wet1, elems_add(synthed_chan, [25, 30, 35, 40]))
-                    verify_approx(wet2, elems_add(synthed_chan, [40, 35, 30, 25]))
+                    // Content snapshots stay on the last complete generation while replacing.
+                    verify_eq(wet1, [5, 6, 7, 8])
+                    verify_eq(wet2, [8, 7, 6, 5])
                     verify_eq(midi, midichan, null, true)
+
+                    lut.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+                    verify_approx(wet_channels()[0].get_data(), elems_add(synthed_chan, [25, 30, 35, 40]))
+                    verify_approx(wet_channels()[1].get_data(), elems_add(synthed_chan, [40, 35, 30, 25]))
                 },
 
                 'test_drywet_audio_rerecord_monitor': () => {
@@ -891,9 +914,17 @@ ShoopTestFile {
                     verify_eq(out2, [40, 35, 30, 25])
                     verify_eq(dry1, [50, 60, 70, 80])
                     verify_eq(dry2, [80, 70, 60, 50])
-                    verify_eq(wet1, [25, 30, 35, 40])
-                    verify_eq(wet2, [40, 35, 30, 25])
+                    // Content snapshots stay on the last complete generation while replacing.
+                    verify_eq(wet1, [5, 6, 7, 8])
+                    verify_eq(wet2, [8, 7, 6, 5])
 
+                    lut.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+                    verify_eq(wet_channels()[0].get_data(), [25, 30, 35, 40])
+                    verify_eq(wet_channels()[1].get_data(), [40, 35, 30, 25])
                 },
 
                 'test_drywet_midi_rerecord_monitor': () => {
@@ -959,9 +990,18 @@ ShoopTestFile {
                     verify_approx(out2, elems_add(synthed_chan, [40, 35, 30, 25]))
                     verify_eq(dry1, [50, 60, 70, 80])
                     verify_eq(dry2, [80, 70, 60, 50])
-                    verify_approx(wet1, elems_add(synthed_chan, [25, 30, 35, 40]))
-                    verify_approx(wet2, elems_add(synthed_chan, [40, 35, 30, 25]))
+                    // Content snapshots stay on the last complete generation while replacing.
+                    verify_eq(wet1, [5, 6, 7, 8])
+                    verify_eq(wet2, [8, 7, 6, 5])
                     verify_eq(midi, midichan, null, true)
+
+                    lut.transition(ShoopRustConstants.LoopMode.Stopped, ShoopRustConstants.DontWaitForSync, ShoopRustConstants.DontAlignToSyncImmediately)
+                    testcase.wait_updated(session.backend)
+                    session.backend.dummy_request_controlled_frames(1)
+                    session.backend.dummy_run_requested_frames()
+                    testcase.wait_updated(session.backend)
+                    verify_approx(wet_channels()[0].get_data(), elems_add(synthed_chan, [25, 30, 35, 40]))
+                    verify_approx(wet_channels()[1].get_data(), elems_add(synthed_chan, [40, 35, 30, 25]))
                 },
             })
         }

--- a/src/rust/frontend/src/any_backend_channel.rs
+++ b/src/rust/frontend/src/any_backend_channel.rs
@@ -1,8 +1,10 @@
 use common::logging::macros::*;
 use shoop_engine::app_backend::{AudioChannel, AudioPort, MidiChannel, MidiPort};
 use shoop_engine::{
-    AudioChannelState, ChannelMode, CommandSequence, MidiChannelState, MidiEvent, SendError,
+    AudioChannelState, ChannelMode, CommandSequence, ContentRevision, CurrentDataError,
+    MidiChannelState, MidiEvent, SendError, SnapshotRead,
 };
+use std::sync::Arc;
 shoop_log_unit!("Frontend.AnyChannel");
 #[derive(Clone)]
 pub enum AnyBackendChannel {
@@ -80,6 +82,26 @@ impl AnyBackendChannel {
         }
     }
 
+    pub fn audio_latest_data(
+        &self,
+    ) -> Result<SnapshotRead<shoop_engine::AudioContentSnapshot>, anyhow::Error> {
+        match self {
+            AnyBackendChannel::Audio(channel) => Ok(channel.get_latest_data_snapshot()),
+            AnyBackendChannel::Midi(_) => {
+                Err(anyhow::anyhow!("audio data requested from MIDI channel"))
+            }
+        }
+    }
+
+    pub fn audio_current_data(
+        &self,
+    ) -> Result<Arc<shoop_engine::AudioContentSnapshot>, CurrentDataError> {
+        match self {
+            AnyBackendChannel::Audio(channel) => channel.try_get_current_data_snapshot(),
+            AnyBackendChannel::Midi(_) => Err(CurrentDataError::PublicationSaturated),
+        }
+    }
+
     pub fn audio_set_gain(&self, gain: f32) {
         match self {
             AnyBackendChannel::Audio(audio_channel) => {
@@ -100,6 +122,47 @@ impl AnyBackendChannel {
             AnyBackendChannel::Midi(midi_channel) => {
                 return midi_channel.get_all_midi_data();
             }
+        }
+    }
+
+    pub fn midi_latest_data(
+        &self,
+    ) -> Result<SnapshotRead<shoop_engine::MidiContentSnapshot>, anyhow::Error> {
+        match self {
+            AnyBackendChannel::Midi(channel) => Ok(channel.get_latest_data_snapshot()),
+            AnyBackendChannel::Audio(_) => {
+                Err(anyhow::anyhow!("MIDI data requested from audio channel"))
+            }
+        }
+    }
+
+    pub fn midi_current_data(
+        &self,
+    ) -> Result<Arc<shoop_engine::MidiContentSnapshot>, CurrentDataError> {
+        match self {
+            AnyBackendChannel::Midi(channel) => channel.try_get_current_data_snapshot(),
+            AnyBackendChannel::Audio(_) => Err(CurrentDataError::PublicationSaturated),
+        }
+    }
+
+    pub fn acknowledge_data_revision(&self, revision: ContentRevision) {
+        match self {
+            AnyBackendChannel::Audio(channel) => channel.acknowledge_data_revision(revision),
+            AnyBackendChannel::Midi(channel) => channel.acknowledge_data_revision(revision),
+        }
+    }
+
+    pub fn capture_content_epoch(&self) -> Option<u64> {
+        match self {
+            AnyBackendChannel::Audio(channel) => channel.capture_content_epoch(),
+            AnyBackendChannel::Midi(channel) => channel.capture_content_epoch(),
+        }
+    }
+
+    pub fn validate_content_epoch(&self, captured: u64) -> bool {
+        match self {
+            AnyBackendChannel::Audio(channel) => channel.validate_content_epoch(captured),
+            AnyBackendChannel::Midi(channel) => channel.validate_content_epoch(captured),
         }
     }
 

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io.rs
@@ -30,10 +30,11 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone)]
 struct SessionCaptureBatch {
     session_id: Option<u64>,
     epoch: Option<u64>,
+    validator: Option<AnyBackendChannel>,
 }
 
 static SESSION_CAPTURE_BATCH: OnceLock<Mutex<Option<SessionCaptureBatch>>> = OnceLock::new();
@@ -53,6 +54,7 @@ fn observe_session_capture(channel: &AnyBackendChannel, epoch: u64) -> Result<()
         (None, None) => {
             batch.session_id = Some(channel.session_id());
             batch.epoch = Some(epoch);
+            batch.validator = Some(channel.clone());
             Ok(())
         }
         (Some(session_id), Some(captured_epoch))
@@ -483,14 +485,23 @@ impl FileIO {
         *guard = Some(SessionCaptureBatch {
             session_id: None,
             epoch: None,
+            validator: None,
         });
     }
 
-    pub fn end_session_content_capture(self: &FileIO) {
-        let mut guard = session_capture_batch()
+    pub fn end_session_content_capture(self: &FileIO) -> bool {
+        let batch = session_capture_batch()
             .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        *guard = None;
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        match batch {
+            Some(SessionCaptureBatch {
+                epoch: Some(epoch),
+                validator: Some(channel),
+                ..
+            }) => channel.validate_content_epoch(epoch),
+            Some(_) | None => true,
+        }
     }
 
     pub fn wait_blocking(self: &FileIO, delay_ms: u64) {
@@ -1107,6 +1118,46 @@ impl FileIO {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn session_capture_batch_rejects_an_epoch_change_between_channels() {
+        let session = shoop_engine::app_backend::BackendSession::new().expect("session");
+        let loop_ = session.create_loop().expect("loop");
+        let channel = loop_
+            .add_audio_channel(shoop_engine::ChannelMode::Direct)
+            .expect("channel");
+        session
+            .wait_for_command(
+                channel.creation_sequence(),
+                shoop_engine::DEFAULT_WAIT_TIMEOUT,
+            )
+            .expect("channel ready");
+        let channel = AnyBackendChannel::Audio(channel.clone());
+        let file_io = make_unique_fileio();
+        file_io.begin_session_content_capture();
+        let first_epoch = channel.capture_content_epoch().expect("stable epoch");
+        observe_session_capture(&channel, first_epoch).expect("first capture");
+
+        let sequence = match &channel {
+            AnyBackendChannel::Audio(channel) => channel.load_data(&[1.0]).expect("load"),
+            AnyBackendChannel::Midi(_) => unreachable!(),
+        };
+        session
+            .wait_for_command(sequence, shoop_engine::DEFAULT_WAIT_TIMEOUT)
+            .expect("load applied");
+        let start = std::time::Instant::now();
+        while match &channel {
+            AnyBackendChannel::Audio(channel) => channel.try_get_current_data_snapshot().is_err(),
+            AnyBackendChannel::Midi(_) => unreachable!(),
+        } {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            std::thread::yield_now();
+        }
+        let second_epoch = channel.capture_content_epoch().expect("new stable epoch");
+        assert_ne!(second_epoch, first_epoch);
+        assert!(observe_session_capture(&channel, second_epoch).is_err());
+        assert!(!file_io.end_session_content_capture());
+    }
 
     #[test]
     fn test_wait_blocking() {

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io.rs
@@ -26,8 +26,45 @@ use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+
+#[derive(Debug, Clone, Copy)]
+struct SessionCaptureBatch {
+    session_id: Option<u64>,
+    epoch: Option<u64>,
+}
+
+static SESSION_CAPTURE_BATCH: OnceLock<Mutex<Option<SessionCaptureBatch>>> = OnceLock::new();
+
+fn session_capture_batch() -> &'static Mutex<Option<SessionCaptureBatch>> {
+    SESSION_CAPTURE_BATCH.get_or_init(|| Mutex::new(None))
+}
+
+fn observe_session_capture(channel: &AnyBackendChannel, epoch: u64) -> Result<(), anyhow::Error> {
+    let mut guard = session_capture_batch()
+        .lock()
+        .map_err(|_| anyhow!("session content capture state is poisoned"))?;
+    let Some(batch) = guard.as_mut() else {
+        return Ok(());
+    };
+    match (batch.session_id, batch.epoch) {
+        (None, None) => {
+            batch.session_id = Some(channel.session_id());
+            batch.epoch = Some(epoch);
+            Ok(())
+        }
+        (Some(session_id), Some(captured_epoch))
+            if session_id == channel.session_id() && captured_epoch == epoch =>
+        {
+            Ok(())
+        }
+        _ => Err(anyhow!(
+            "session content changed while collecting exact channel snapshots"
+        )),
+    }
+}
 
 pub fn register_qml_singleton(module_name: &str, type_name: &str) {
     let mut mdl = String::from(module_name);
@@ -156,14 +193,37 @@ pub fn save_qlist_data_to_soundfile_impl(
     Ok(())
 }
 
-fn save_channel_midi_data_impl(
+struct CapturedMidiChannel {
+    messages: Vec<MidiEvent>,
+    total_length: usize,
+}
+
+fn capture_channel_midi_data(
+    channel: &AnyBackendChannel,
+) -> Result<CapturedMidiChannel, anyhow::Error> {
+    let epoch = channel
+        .capture_content_epoch()
+        .ok_or_else(|| anyhow!("channel content is changing"))?;
+    let snapshot = channel
+        .midi_current_data()
+        .map_err(|error| anyhow!("MIDI content is not settled: {error}"))?;
+    if !channel.validate_content_epoch(epoch) {
+        return Err(anyhow!("channel content changed during capture"));
+    }
+    observe_session_capture(channel, epoch)?;
+    Ok(CapturedMidiChannel {
+        messages: snapshot.contiguous(),
+        total_length: snapshot.metadata.length as usize,
+    })
+}
+
+fn save_captured_midi_data_impl(
     filename: &Path,
     samplerate: usize,
-    channel: &AnyBackendChannel,
+    captured: CapturedMidiChannel,
 ) -> Result<(), anyhow::Error> {
-    let msgs = channel.midi_get_data();
-    let total_length = channel.get_state()?.length as usize;
-
+    let msgs = captured.messages;
+    let total_length = captured.total_length;
     let extension = filename
         .extension()
         .ok_or(anyhow!("Could not get file extension"))?
@@ -185,6 +245,14 @@ fn save_channel_midi_data_impl(
     }
 
     Ok(())
+}
+
+fn save_channel_midi_data_impl(
+    filename: &Path,
+    samplerate: usize,
+    channel: &AnyBackendChannel,
+) -> Result<(), anyhow::Error> {
+    save_captured_midi_data_impl(filename, samplerate, capture_channel_midi_data(channel)?)
 }
 
 fn load_midi_to_channels_impl<'a>(
@@ -377,21 +445,54 @@ fn qlist_qvariant_channels_to_backend(channels: &QList_QVariant) -> Vec<AnyBacke
 }
 
 fn audio_channels_to_variant(channels: &QList_QVariant) -> Result<QVariant, anyhow::Error> {
+    let channels = qlist_qvariant_channels_to_backend(channels);
+    let first = channels
+        .first()
+        .ok_or_else(|| anyhow!("no audio channels selected"))?;
+    let epoch = first
+        .capture_content_epoch()
+        .ok_or_else(|| anyhow!("channel content is changing"))?;
     let mut result = QList_QVariant::default();
-    for channel in qlist_qvariant_channels_to_backend(channels) {
-        let samples = channel.audio_get_data();
+    for channel in &channels {
+        if channel.session_id() != first.session_id() {
+            return Err(anyhow!("cannot capture channels from different sessions"));
+        }
+        let snapshot = channel
+            .audio_current_data()
+            .map_err(|error| anyhow!("audio content is not settled: {error}"))?;
         let mut samples_list = QList_f32::default();
-        samples_list.reserve(samples.len() as isize);
-        for sample in samples {
+        samples_list.reserve(snapshot.metadata.length as isize);
+        for sample in snapshot.samples() {
             samples_list.append(sample);
         }
         result.append(qlist_f32_to_qvariant(&samples_list)?);
     }
+    if !first.validate_content_epoch(epoch) {
+        return Err(anyhow!("channel content changed during capture"));
+    }
+    observe_session_capture(first, epoch)?;
     Ok(qvariantlist_to_qvariant(&result)?)
 }
 
 #[allow(unreachable_code)]
 impl FileIO {
+    pub fn begin_session_content_capture(self: &FileIO) {
+        let mut guard = session_capture_batch()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *guard = Some(SessionCaptureBatch {
+            session_id: None,
+            epoch: None,
+        });
+    }
+
+    pub fn end_session_content_capture(self: &FileIO) {
+        let mut guard = session_capture_batch()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *guard = None;
+    }
+
     pub fn wait_blocking(self: &FileIO, delay_ms: u64) {
         debug!("waiting for {} ms", delay_ms);
         thread::sleep(Duration::from_millis(delay_ms));
@@ -696,10 +797,12 @@ impl FileIO {
                 .as_ref()
                 .cloned()
                 .ok_or_else(|| anyhow!("Channel is not initialized"))?;
+            let captured = capture_channel_midi_data(&channel_backend)
+                .map_err(|error| anyhow!("Failed to capture channel MIDI data: {error}"));
             pin_async_task.as_mut().exec_concurrent_rust_then_finish(
                 move || -> Result<(), anyhow::Error> {
                     let filename = PathBuf::from(filename.to_string());
-                    save_channel_midi_data_impl(&filename, samplerate as usize, &channel_backend)
+                    save_captured_midi_data_impl(&filename, samplerate as usize, captured?)
                         .map_err(|e| anyhow!("Failed to save channel MIDI data: {e}"))
                 },
             );
@@ -850,17 +953,13 @@ impl FileIO {
         let mut pin_async_task = unsafe { std::pin::Pin::new_unchecked(&mut *async_task) };
         pin_async_task.as_mut().set_cpp_ownership();
 
-        let variant = match audio_channels_to_variant(&channels) {
-            Ok(variant) => variant,
-            Err(error) => {
-                error!("Failed to collect audio channel data: {error}");
-                QVariant::default()
-            }
-        };
+        let variant = audio_channels_to_variant(&channels)
+            .map_err(|error| anyhow!("Failed to collect audio channel data: {error}"));
 
         pin_async_task
             .as_mut()
             .exec_concurrent_rust_then_finish(move || {
+                let variant = variant?;
                 save_qlist_data_to_soundfile_impl(filename, samplerate, variant)
                     .map_err(|e| anyhow!("Failed to save channels audio to file: {e}"))
             });

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io_bridge.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io_bridge.rs
@@ -31,7 +31,7 @@ pub mod ffi {
         pub fn begin_session_content_capture(self: &FileIO);
 
         #[qinvokable]
-        pub fn end_session_content_capture(self: &FileIO);
+        pub fn end_session_content_capture(self: &FileIO) -> bool;
 
         #[qinvokable]
         pub fn wait_blocking(self: &FileIO, delay_ms: u64);

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io_bridge.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_file_io_bridge.rs
@@ -28,6 +28,12 @@ pub mod ffi {
         type FileIO = super::FileIORust;
 
         #[qinvokable]
+        pub fn begin_session_content_capture(self: &FileIO);
+
+        #[qinvokable]
+        pub fn end_session_content_capture(self: &FileIO);
+
+        #[qinvokable]
         pub fn wait_blocking(self: &FileIO, delay_ms: u64);
 
         #[qinvokable]

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_channel_gui.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_channel_gui.rs
@@ -24,7 +24,11 @@ use cxx_qt_lib_shoop::{
     },
 };
 use shoop_engine::{ChannelMode, MidiEvent, PortConnectability, PortDataType};
-use std::{collections::HashSet, pin::Pin};
+use std::{
+    collections::HashSet,
+    pin::Pin,
+    sync::{atomic::Ordering, Arc},
+};
 shoop_log_unit!("Frontend.LoopChannel");
 
 macro_rules! trace {
@@ -693,15 +697,21 @@ impl LoopChannelGui {
             let send_to_object = send_to_object as usize;
             let method_signature = method_signature.to_string();
             let is_midi = matches!(channel, AnyBackendChannel::Midi(_));
+            let delivered_revision = Arc::clone(&self.last_delivered_data_revision);
             task.as_mut()
                 .exec_concurrent_rust_then_finish(move || -> Result<(), anyhow::Error> {
                     let mut data = QVector_QVariant::default();
+                    let revision;
                     if is_midi {
-                        for event in channel.midi_get_data() {
+                        let read = channel.midi_latest_data()?;
+                        revision = read.snapshot.revision;
+                        for event in read.snapshot.events() {
                             data.append(event.to_qvariant());
                         }
                     } else {
-                        for sample in channel.audio_get_data() {
+                        let read = channel.audio_latest_data()?;
+                        revision = read.snapshot.revision;
+                        for sample in read.snapshot.samples() {
                             data.append(QVariant::from(&sample));
                         }
                     }
@@ -721,6 +731,7 @@ impl LoopChannelGui {
                             )?;
                         }
                     }
+                    delivered_revision.store(revision.0, Ordering::Release);
                     Ok(())
                 });
             Ok(())
@@ -734,7 +745,10 @@ impl LoopChannelGui {
 
     pub fn clear_data_dirty(self: Pin<&mut LoopChannelGui>) {
         if let Some(chan) = self.maybe_backend_channel.as_ref() {
-            chan.clear_data_dirty();
+            let revision = shoop_engine::ContentRevision(
+                self.last_delivered_data_revision.load(Ordering::Acquire),
+            );
+            chan.acknowledge_data_revision(revision);
         }
     }
 

--- a/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_channel_gui_bridge.rs
+++ b/src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_channel_gui_bridge.rs
@@ -304,6 +304,8 @@ pub use ffi::LoopChannelGui;
 use ffi::*;
 
 use crate::any_backend_channel::{AnyBackendChannel, AnyBackendChannelState};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 pub struct LoopChannelGuiRust {
     // Properties
@@ -320,6 +322,7 @@ pub struct LoopChannelGuiRust {
     pub ports_to_connect: QList_QVariant,
     pub ports_connected: QList_QVariant,
     pub instance_identifier: QString,
+    pub last_delivered_data_revision: Arc<AtomicU64>,
 }
 
 impl Default for LoopChannelGuiRust {
@@ -336,6 +339,7 @@ impl Default for LoopChannelGuiRust {
             ports_connected: QList_QVariant::default(),
             instance_identifier: QString::from("unknown"),
             recording_started_at: QVariant::default(),
+            last_delivered_data_revision: Arc::new(AtomicU64::new(0)),
         }
     }
 }

--- a/src/rust/shoop_engine/Cargo.toml
+++ b/src/rust/shoop_engine/Cargo.toml
@@ -9,6 +9,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
 regex = { workspace = true }
+arc-swap = { workspace = true }
 rtrb = { workspace = true }
 rubato = { workspace = true }
 # Optional so the engine builds and tests without libjack present.

--- a/src/rust/shoop_engine/examples/content_snapshot_benchmark.rs
+++ b/src/rust/shoop_engine/examples/content_snapshot_benchmark.rs
@@ -1,0 +1,99 @@
+use shoop_engine::content_snapshot::{ContentMutation, ContentSnapshotRuntime};
+use std::hint::black_box;
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const CHANNELS: usize = 32;
+const SAMPLES: usize = 48_000;
+const READS: usize = 2_000;
+const WRITES: usize = 2_000;
+const BLOCK: usize = 64;
+
+fn per_operation(elapsed: Duration, operations: usize) -> f64 {
+    elapsed.as_secs_f64() * 1_000_000.0 / operations as f64
+}
+
+fn main() {
+    let source = vec![0.25_f32; SAMPLES];
+    let legacy: Vec<_> = (0..CHANNELS).map(|_| Mutex::new(source.clone())).collect();
+
+    let runtime = ContentSnapshotRuntime::new();
+    let mut writers = Vec::with_capacity(CHANNELS);
+    let mut readers = Vec::with_capacity(CHANNELS);
+    for _ in 0..CHANNELS {
+        let (mut writer, control, reader) = runtime.create_audio_channel(1_024, 64);
+        let prepared = control
+            .prepare(&source, ContentMutation::Loading)
+            .expect("prepare initial generation");
+        assert!(writer.install_prepared(prepared));
+        writers.push(writer);
+        readers.push(reader);
+    }
+    let start = Instant::now();
+    while readers.iter().any(|reader| reader.try_current().is_err()) {
+        assert!(start.elapsed() < Duration::from_secs(10));
+        thread::yield_now();
+    }
+
+    let start = Instant::now();
+    for index in 0..READS {
+        let copy = legacy[index % CHANNELS]
+            .lock()
+            .expect("legacy lock")
+            .clone();
+        black_box(copy);
+    }
+    let legacy_read = start.elapsed();
+
+    let start = Instant::now();
+    for index in 0..READS {
+        black_box(readers[index % CHANNELS].latest().snapshot);
+    }
+    let snapshot_read = start.elapsed();
+
+    let start = Instant::now();
+    for index in 0..WRITES {
+        let mut content = legacy[index % CHANNELS].lock().expect("legacy lock");
+        content.copy_from_slice(&source);
+        black_box(&*content);
+    }
+    let legacy_write = start.elapsed();
+
+    let update = [0.75_f32; BLOCK];
+    let start = Instant::now();
+    for index in 0..WRITES {
+        let writer = &mut writers[index % CHANNELS];
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        while writer
+            .publish_range((index * BLOCK) % SAMPLES, &update, SAMPLES, true)
+            .is_none()
+        {
+            thread::yield_now();
+        }
+        writer.finish_mutation(false);
+    }
+    let snapshot_write = start.elapsed();
+
+    println!("channels={CHANNELS} samples_per_channel={SAMPLES}");
+    println!(
+        "legacy_mutex_full_copy_read_us={:.3}",
+        per_operation(legacy_read, READS)
+    );
+    println!(
+        "snapshot_manifest_read_us={:.3}",
+        per_operation(snapshot_read, READS)
+    );
+    println!(
+        "legacy_mutex_full_copy_write_us={:.3}",
+        per_operation(legacy_write, WRITES)
+    );
+    println!(
+        "snapshot_bounded_block_publish_us={:.3}",
+        per_operation(snapshot_write, WRITES)
+    );
+    println!(
+        "one_full_generation_mib={:.3}",
+        (CHANNELS * SAMPLES * size_of::<f32>()) as f64 / (1024.0 * 1024.0)
+    );
+}

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -1220,6 +1220,13 @@ struct SharedSession {
     composite_registry: Mutex<CompositeRegistry>,
     primitive_loop_controls: Mutex<Vec<PrimitiveLoopControl>>,
     primitive_sync_sources: Mutex<Vec<Option<usize>>>,
+    audio_snapshot_controls: Mutex<
+        Vec<(
+            Weak<ObjectControl<LoopId, engine::LoopStateMirror>>,
+            Weak<ObjectControl<AudioChannelId, engine::AudioChannelStateMirror>>,
+            engine::content_snapshot::AudioSnapshotControl,
+        )>,
+    >,
     external: Mutex<Option<Arc<Mutex<engine::DummyExternalConnections>>>>,
     jack: Mutex<Option<Arc<Mutex<JackBackend>>>>,
     cpal: Mutex<Option<Arc<Mutex<CpalBackend>>>>,
@@ -1787,6 +1794,7 @@ impl BackendSession {
             composite_registry: Mutex::new(CompositeRegistry::default()),
             primitive_loop_controls: Mutex::new(Vec::new()),
             primitive_sync_sources: Mutex::new(Vec::new()),
+            audio_snapshot_controls: Mutex::new(Vec::new()),
             external: Mutex::new(None),
             jack: Mutex::new(None),
             cpal: Mutex::new(None),
@@ -2217,12 +2225,83 @@ impl BackendSession {
                 data: engine::PreparedAudioChannelData::new(channel.chunk_size, channel.capacity),
             })
             .collect();
-        let (result, returned) = self.shared.query_graph_scheduler_response(move |session| {
-            let result = session.adopt_audio_ringbuffers_prepared(&requests, &mut prepared);
+        let prepare_requests = requests.clone();
+        let (result, mut prepared) =
+            self.shared.query_graph_scheduler_response(move |session| {
+                let result =
+                    session.prepare_audio_ringbuffers_prepared(&prepare_requests, &mut prepared);
+                (result, prepared)
+            })?;
+        result?;
+
+        let registered = self
+            .shared
+            .audio_snapshot_controls
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        let controls: Vec<_> = shapes
+            .iter()
+            .map(|shape| {
+                registered
+                    .iter()
+                    .find_map(|(parent, channel, snapshots)| {
+                        let parent = parent.upgrade()?;
+                        let channel = channel.upgrade()?;
+                        (parent.ready_id().map(ObjectIdentity::index) == Some(shape.loop_idx)
+                            && channel.auxiliary_index() == Some(shape.channel_idx))
+                        .then(|| snapshots.clone())
+                    })
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "audio snapshot control is missing for loop {} channel {}",
+                            shape.loop_idx,
+                            shape.channel_idx
+                        )
+                    })
+            })
+            .collect::<Result<_>>()?;
+        let mut snapshots = Vec::with_capacity(prepared.len());
+        for (slot, control) in prepared.iter().zip(&controls) {
+            let samples = slot.data.contiguous_copy();
+            let Some(snapshot) = control.prepare(
+                &samples,
+                engine::content_snapshot::ContentMutation::RingbufferAdoption,
+            ) else {
+                for control in controls.iter().take(snapshots.len()) {
+                    control.cancel();
+                }
+                return Err(anyhow!("audio snapshot channel is busy"));
+            };
+            snapshots.push(snapshot);
+        }
+        let install = self.shared.query_graph_scheduler_response(move |session| {
+            let result = session.commit_audio_ringbuffers_prepared_with_snapshots(
+                &requests,
+                &mut prepared,
+                &snapshots,
+            );
             (result, prepared)
-        })?;
-        drop(returned);
-        Ok(result?)
+        });
+        match install {
+            Ok((Ok(()), returned)) => {
+                drop(returned);
+                Ok(())
+            }
+            Ok((Err(error), returned)) => {
+                drop(returned);
+                for control in controls {
+                    control.cancel();
+                }
+                Err(error.into())
+            }
+            Err(error) => {
+                for control in controls {
+                    control.cancel();
+                }
+                Err(error)
+            }
+        }
     }
 
     pub fn remove_composite_loop(
@@ -3414,6 +3493,15 @@ impl Loop {
             }
         })?;
         control.set_creation_sequence(sequence);
+        self.shared
+            .audio_snapshot_controls
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push((
+                Arc::downgrade(&self.control),
+                Arc::downgrade(&control),
+                snapshot_control.clone(),
+            ));
         Ok(AudioChannel {
             shared: self.shared.clone(),
             parent: Arc::clone(&self.control),
@@ -3663,6 +3751,14 @@ impl AudioChannel {
         self.control.session_id
     }
 
+    pub fn capture_content_epoch(&self) -> Option<u64> {
+        self.shared.snapshots.capture_epoch()
+    }
+
+    pub fn validate_content_epoch(&self, captured: u64) -> bool {
+        self.shared.snapshots.validate_epoch(captured)
+    }
+
     pub fn lifecycle(&self) -> ObjectLifecycle {
         observed_lifecycle(&self.shared, &self.control)
     }
@@ -3757,13 +3853,37 @@ impl AudioChannel {
             engine::content_snapshot::SnapshotCurrentness::Stale(
                 engine::content_snapshot::StaleReason::MutationActive(
                     engine::content_snapshot::ContentMutation::Loading
-                ) | engine::content_snapshot::StaleReason::PublicationPending { .. }
+                )
             )
         ) {
-            self.desired_data.load_full().as_ref().clone()
-        } else {
-            latest.snapshot.contiguous()
+            return self.desired_data.load_full().as_ref().clone();
         }
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::MutationActive(_)
+            )
+        ) {
+            // Legacy synchronous callers historically observed process writes immediately.
+            // Give the off-thread publisher one poll while preserving stale-read semantics.
+            std::thread::sleep(Duration::from_millis(2));
+            return self.snapshots.latest().snapshot.contiguous();
+        }
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::PublicationPending { .. }
+            )
+        ) {
+            let deadline = Instant::now() + Duration::from_millis(100);
+            while Instant::now() < deadline {
+                if let Ok(snapshot) = self.snapshots.try_current() {
+                    return snapshot.contiguous();
+                }
+                std::thread::sleep(Duration::from_micros(100));
+            }
+        }
+        latest.snapshot.contiguous()
     }
 
     pub fn get_latest_data_snapshot(
@@ -3856,11 +3976,14 @@ impl AudioChannel {
     }
 
     pub fn clear(&self, length: u32) -> std::result::Result<CommandSequence, SendError> {
-        let mutation_started = self
+        if !self
             .snapshots
-            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing);
+            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing)
+        {
+            return Err(SendError::Full);
+        }
         let result = self.with_mut(move |channel| channel.clear(length as usize));
-        if result.is_err() && mutation_started {
+        if result.is_err() {
             self.snapshots.cancel_mutation();
         }
         result
@@ -3880,6 +4003,14 @@ pub type MidiChannelState = engine::MidiChannelState;
 impl MidiChannel {
     pub fn session_id(&self) -> u64 {
         self.control.session_id
+    }
+
+    pub fn capture_content_epoch(&self) -> Option<u64> {
+        self.shared.snapshots.capture_epoch()
+    }
+
+    pub fn validate_content_epoch(&self, captured: u64) -> bool {
+        self.shared.snapshots.validate_epoch(captured)
     }
 
     pub fn lifecycle(&self) -> ObjectLifecycle {
@@ -3911,13 +4042,37 @@ impl MidiChannel {
             engine::content_snapshot::SnapshotCurrentness::Stale(
                 engine::content_snapshot::StaleReason::MutationActive(
                     engine::content_snapshot::ContentMutation::Loading
-                ) | engine::content_snapshot::StaleReason::PublicationPending { .. }
+                )
             )
         ) {
-            self.desired_data.load_full().as_ref().clone()
-        } else {
-            latest.snapshot.contiguous()
+            return self.desired_data.load_full().as_ref().clone();
         }
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::MutationActive(_)
+            )
+        ) {
+            // Legacy synchronous callers historically observed process writes immediately.
+            // Give the off-thread publisher one poll while preserving stale-read semantics.
+            std::thread::sleep(Duration::from_millis(2));
+            return self.snapshots.latest().snapshot.contiguous();
+        }
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::PublicationPending { .. }
+            )
+        ) {
+            let deadline = Instant::now() + Duration::from_millis(100);
+            while Instant::now() < deadline {
+                if let Ok(snapshot) = self.snapshots.try_current() {
+                    return snapshot.contiguous();
+                }
+                std::thread::sleep(Duration::from_micros(100));
+            }
+        }
+        latest.snapshot.contiguous()
     }
 
     pub fn get_latest_data_snapshot(
@@ -4108,11 +4263,14 @@ impl MidiChannel {
     }
 
     pub fn clear(&self) -> std::result::Result<CommandSequence, SendError> {
-        let mutation_started = self
+        if !self
             .snapshots
-            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing);
+            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing)
+        {
+            return Err(SendError::Full);
+        }
         let result = self.with_mut(move |channel| channel.clear());
-        if result.is_err() && mutation_started {
+        if result.is_err() {
             self.snapshots.cancel_mutation();
         }
         result
@@ -5646,6 +5804,35 @@ mod tests {
             audio.get_latest_data_snapshot().snapshot.contiguous(),
             vec![1.0, 2.0]
         );
+        assert!(matches!(
+            midi.try_get_current_data_snapshot(),
+            Err(engine::content_snapshot::CurrentDataError::MutationActive(
+                engine::content_snapshot::ContentMutation::Recording
+            ))
+        ));
+        assert_eq!(
+            midi.get_latest_data_snapshot().snapshot.contiguous().len(),
+            1
+        );
+
+        // Mutations that would overlap recording are rejected without touching content.
+        assert!(matches!(audio.load_data(&[9.0]), Err(SendError::Full)));
+        assert!(matches!(audio.clear(0), Err(SendError::Full)));
+        assert!(matches!(midi.load_all_midi_data(&[]), Err(SendError::Full)));
+        assert!(matches!(midi.clear(), Err(SendError::Full)));
+
+        loop_
+            .transition(LoopMode::Stopped, -1, -1)
+            .expect("queue stop");
+        engine.pump();
+        engine.process(1);
+        let start = Instant::now();
+        while audio.try_get_current_data_snapshot().is_err()
+            || midi.try_get_current_data_snapshot().is_err()
+        {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            thread::yield_now();
+        }
         sess.shared.return_engine(engine);
     }
 

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -3977,14 +3977,14 @@ impl AudioChannel {
 
     pub fn clear(&self, length: u32) -> std::result::Result<CommandSequence, SendError> {
         if !self
-            .snapshots
+            .snapshot_control
             .begin_mutation(engine::content_snapshot::ContentMutation::Clearing)
         {
             return Err(SendError::Full);
         }
         let result = self.with_mut(move |channel| channel.clear(length as usize));
         if result.is_err() {
-            self.snapshots.cancel_mutation();
+            self.snapshot_control.cancel_mutation();
         }
         result
     }
@@ -4264,14 +4264,14 @@ impl MidiChannel {
 
     pub fn clear(&self) -> std::result::Result<CommandSequence, SendError> {
         if !self
-            .snapshots
+            .snapshot_control
             .begin_mutation(engine::content_snapshot::ContentMutation::Clearing)
         {
             return Err(SendError::Full);
         }
         let result = self.with_mut(move |channel| channel.clear());
         if result.is_err() {
-            self.snapshots.cancel_mutation();
+            self.snapshot_control.cancel_mutation();
         }
         result
     }
@@ -5785,6 +5785,36 @@ mod tests {
             1
         );
 
+        for mutation in [
+            engine::content_snapshot::ContentMutation::Recording,
+            engine::content_snapshot::ContentMutation::PreRecording,
+            engine::content_snapshot::ContentMutation::Replacing,
+            engine::content_snapshot::ContentMutation::Loading,
+            engine::content_snapshot::ContentMutation::Clearing,
+            engine::content_snapshot::ContentMutation::RingbufferAdoption,
+        ] {
+            assert!(audio.snapshot_control.begin_mutation(mutation));
+            assert!(matches!(
+                audio.try_get_current_data_snapshot(),
+                Err(engine::content_snapshot::CurrentDataError::MutationActive(found))
+                    if found == mutation
+            ));
+            assert_eq!(
+                audio.get_latest_data_snapshot().snapshot.contiguous(),
+                vec![1.0, 2.0]
+            );
+            audio.snapshot_control.cancel_mutation();
+
+            assert!(midi.snapshot_control.begin_mutation(mutation));
+            assert!(matches!(
+                midi.try_get_current_data_snapshot(),
+                Err(engine::content_snapshot::CurrentDataError::MutationActive(found))
+                    if found == mutation
+            ));
+            assert_eq!(midi.get_latest_data_snapshot().snapshot.events().count(), 1);
+            midi.snapshot_control.cancel_mutation();
+        }
+
         loop_
             .transition(LoopMode::Recording, -1, -1)
             .expect("queue recording");
@@ -6413,6 +6443,9 @@ mod tests {
 
         let port = AudioPort::new_driver_port(&sess, &driver, "input", &PortDirection::Input, 0)
             .expect("port");
+        sess.wait_for_command(port.creation_sequence(), engine::DEFAULT_WAIT_TIMEOUT)
+            .expect("port creation");
+        sess.shared.flush_graph_changes();
         driver.wait_process();
         let initial = match port.poll_state() {
             Some(state) => state,
@@ -6428,7 +6461,7 @@ mod tests {
             .expect("first input command");
         driver.dummy_request_controlled_frames(BUFFER);
         driver.dummy_run_requested_frames();
-        let first = port.get_state().expect("first state");
+        let first = port.poll_state().expect("first state");
         assert_eq!(first.input_peak, 0.8);
         assert_eq!(first.output_peak, 0.8);
 

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -10,6 +10,7 @@
 use crate as engine;
 use crate::graph_scheduler::{GraphScheduler, DEFAULT_WINDOW};
 use anyhow::{anyhow, Result};
+use arc_swap::ArcSwap;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 pub use engine::{
     cpal_host_names, cpal_input_device_names, cpal_input_device_names_for_host,
@@ -1219,18 +1220,13 @@ struct SharedSession {
     composite_registry: Mutex<CompositeRegistry>,
     primitive_loop_controls: Mutex<Vec<PrimitiveLoopControl>>,
     primitive_sync_sources: Mutex<Vec<Option<usize>>>,
-    audio_channel_controls: Mutex<
-        Vec<(
-            Weak<ObjectControl<LoopId, engine::LoopStateMirror>>,
-            Weak<ObjectControl<AudioChannelId, engine::AudioChannelStateMirror>>,
-        )>,
-    >,
     external: Mutex<Option<Arc<Mutex<engine::DummyExternalConnections>>>>,
     jack: Mutex<Option<Arc<Mutex<JackBackend>>>>,
     cpal: Mutex<Option<Arc<Mutex<CpalBackend>>>>,
     connection_cache: Arc<Mutex<ConnectionCache>>,
     sample_rate: AtomicU32,
     buffer_size: AtomicU32,
+    snapshots: engine::content_snapshot::ContentSnapshotRuntime,
     /// Rebuilds the schedule after topology changes.
     ///
     /// A `OnceLock` rather than a `Mutex`: it is set once immediately after construction
@@ -1791,13 +1787,13 @@ impl BackendSession {
             composite_registry: Mutex::new(CompositeRegistry::default()),
             primitive_loop_controls: Mutex::new(Vec::new()),
             primitive_sync_sources: Mutex::new(Vec::new()),
-            audio_channel_controls: Mutex::new(Vec::new()),
             external: Mutex::new(None),
             jack: Mutex::new(None),
             cpal: Mutex::new(None),
             connection_cache: Arc::new(Mutex::new(ConnectionCache::default())),
             sample_rate: AtomicU32::new(48_000),
             buffer_size: AtomicU32::new(256),
+            snapshots: engine::content_snapshot::ContentSnapshotRuntime::new(),
             scheduler: OnceLock::new(),
         });
 
@@ -2221,52 +2217,12 @@ impl BackendSession {
                 data: engine::PreparedAudioChannelData::new(channel.chunk_size, channel.capacity),
             })
             .collect();
-        let mut copies: Vec<_> = shapes
-            .iter()
-            .map(|channel| Vec::with_capacity(channel.capacity))
-            .collect();
-        let controls = self
-            .shared
-            .audio_channel_controls
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .clone();
-        let mirrors: Vec<_> = shapes
-            .iter()
-            .map(|shape| {
-                controls
-                    .iter()
-                    .find_map(|(parent, channel)| {
-                        let parent = parent.upgrade()?;
-                        let channel = channel.upgrade()?;
-                        (parent.ready_id().map(ObjectIdentity::index) == Some(shape.loop_idx)
-                            && channel.auxiliary_index() == Some(shape.channel_idx))
-                        .then(|| Arc::clone(&channel.mirror))
-                    })
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "audio channel mirror is missing for loop {} channel {}",
-                            shape.loop_idx,
-                            shape.channel_idx
-                        )
-                    })
-            })
-            .collect::<Result<_>>()?;
-        let (result, returned, copies) =
-            self.shared.query_graph_scheduler_response(move |session| {
-                let result = session.adopt_audio_ringbuffers_prepared_with_copies(
-                    &requests,
-                    &mut prepared,
-                    &mut copies,
-                );
-                (result, prepared, copies)
-            })?;
+        let (result, returned) = self.shared.query_graph_scheduler_response(move |session| {
+            let result = session.adopt_audio_ringbuffers_prepared(&requests, &mut prepared);
+            (result, prepared)
+        })?;
         drop(returned);
-        result?;
-        for (mirror, data) in mirrors.into_iter().zip(copies) {
-            mirror.replace_data(data);
-        }
-        Ok(())
+        Ok(result?)
     }
 
     pub fn remove_composite_loop(
@@ -3424,11 +3380,13 @@ impl Loop {
     }
 
     pub fn add_audio_channel(&self, mode: ChannelMode) -> Result<AudioChannel> {
+        let (snapshot_writer, snapshot_control, snapshot_reader) =
+            self.shared.snapshots.create_audio_channel(1024, 256);
+        let mut snapshot_writer = Some(snapshot_writer);
         let control = Arc::new(ObjectControl::<
             AudioChannelId,
             engine::AudioChannelStateMirror,
         >::pending(self.shared.session_id));
-        control.mirror.enable_complex_data();
         let control_for_command = Arc::downgrade(&control);
         let parent = Arc::clone(&self.control);
         let sequence = self.shared.send_topology(move |s: &mut engine::Session| {
@@ -3439,11 +3397,12 @@ impl Loop {
                 control.mark_failed("parent loop was not created");
                 return;
             };
-            match s.add_audio_channel_with_state(
+            match s.add_audio_channel_with_state_and_snapshots(
                 loop_idx,
                 64,
                 mode.into(),
                 Arc::clone(&control.mirror),
+                snapshot_writer.take(),
             ) {
                 Ok(idx) => {
                     if let Some(mapping) = s.channel_mapping(idx) {
@@ -3455,25 +3414,25 @@ impl Loop {
             }
         })?;
         control.set_creation_sequence(sequence);
-        self.shared
-            .audio_channel_controls
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .push((Arc::downgrade(&self.control), Arc::downgrade(&control)));
         Ok(AudioChannel {
             shared: self.shared.clone(),
             parent: Arc::clone(&self.control),
             control,
+            snapshots: snapshot_reader,
+            snapshot_control,
+            desired_data: Arc::new(ArcSwap::from_pointee(Vec::new())),
         })
     }
 
     pub fn add_midi_channel(&self, mode: ChannelMode) -> Result<MidiChannel> {
+        let (snapshot_writer, snapshot_control, snapshot_reader) =
+            self.shared.snapshots.create_midi_channel(64, 64);
+        let mut snapshot_writer = Some(snapshot_writer);
         let control = Arc::new(
             ObjectControl::<MidiChannelId, engine::MidiChannelStateMirror>::pending(
                 self.shared.session_id,
             ),
         );
-        control.mirror.enable_complex_data();
         let control_for_command = Arc::downgrade(&control);
         let parent = Arc::clone(&self.control);
         let sequence = self.shared.send_topology(move |s: &mut engine::Session| {
@@ -3484,11 +3443,12 @@ impl Loop {
                 control.mark_failed("parent loop was not created");
                 return;
             };
-            match s.add_midi_channel_with_state(
+            match s.add_midi_channel_with_state_and_snapshots(
                 loop_idx,
                 1024,
                 mode.into(),
                 Arc::clone(&control.mirror),
+                snapshot_writer.take(),
             ) {
                 Ok(idx) => control.mark_ready(MidiChannelId(idx)),
                 Err(error) => control.mark_failed(error.to_string()),
@@ -3499,6 +3459,9 @@ impl Loop {
             shared: self.shared.clone(),
             parent: Arc::clone(&self.control),
             control,
+            snapshots: snapshot_reader,
+            snapshot_control,
+            desired_data: Arc::new(ArcSwap::from_pointee(Vec::new())),
         })
     }
 
@@ -3690,6 +3653,9 @@ pub struct AudioChannel {
     shared: Arc<SharedSession>,
     parent: Arc<ObjectControl<LoopId, engine::LoopStateMirror>>,
     control: Arc<ObjectControl<AudioChannelId, engine::AudioChannelStateMirror>>,
+    snapshots: engine::content_snapshot::AudioSnapshotReader,
+    snapshot_control: engine::content_snapshot::AudioSnapshotControl,
+    desired_data: Arc<ArcSwap<Vec<f32>>>,
 }
 pub type AudioChannelState = engine::AudioChannelState;
 impl AudioChannel {
@@ -3763,34 +3729,84 @@ impl AudioChannel {
 
     pub fn load_data(&self, data: &[f32]) -> std::result::Result<CommandSequence, SendError> {
         let owned = data.to_vec();
-        let result = self.with_mut({
-            let owned = owned.clone();
-            move |channel| channel.load_data(&owned)
+        let snapshot = self
+            .snapshot_control
+            .prepare(&owned, engine::content_snapshot::ContentMutation::Loading)
+            .ok_or(SendError::Full)?;
+        let mut prepared = engine::PreparedAudioChannelData::new(64, owned.len());
+        prepared.begin_load(owned.len());
+        prepared.write(0, &owned);
+        let mut prepared = Some(prepared);
+        let result = self.with_mut(move |channel| {
+            if let Some(mut prepared) = prepared.take() {
+                channel.commit_prepared_data_and_snapshot(&mut prepared, snapshot);
+            }
         });
         if result.is_ok() {
-            self.control.mirror.replace_data(owned);
+            self.desired_data.store(Arc::new(owned));
+        } else {
+            self.snapshot_control.cancel();
         }
         result
     }
 
     pub fn get_data(&self) -> Vec<f32> {
-        self.control.mirror.data()
+        let latest = self.snapshots.latest();
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::MutationActive(
+                    engine::content_snapshot::ContentMutation::Loading
+                ) | engine::content_snapshot::StaleReason::PublicationPending { .. }
+            )
+        ) {
+            self.desired_data.load_full().as_ref().clone()
+        } else {
+            latest.snapshot.contiguous()
+        }
+    }
+
+    pub fn get_latest_data_snapshot(
+        &self,
+    ) -> engine::content_snapshot::SnapshotRead<engine::content_snapshot::AudioContentSnapshot>
+    {
+        self.snapshots.latest()
+    }
+
+    pub fn try_get_current_data_snapshot(
+        &self,
+    ) -> std::result::Result<
+        Arc<engine::content_snapshot::AudioContentSnapshot>,
+        engine::content_snapshot::CurrentDataError,
+    > {
+        self.snapshots.try_current()
+    }
+
+    pub fn acknowledge_data_revision(&self, revision: engine::content_snapshot::ContentRevision) {
+        self.snapshots.acknowledge(revision);
     }
 
     pub fn poll_state(&self) -> Option<AudioChannelState> {
         (self.lifecycle() == ObjectLifecycle::Ready).then(|| {
-            self.control
+            let mut state = self
+                .control
                 .mirror
-                .read(self.control.acknowledged_data_sequence())
+                .read(self.control.acknowledged_data_sequence());
+            state.data_dirty = self.snapshots.is_dirty();
+            state
         })
     }
 
     pub fn get_state(&self) -> Result<AudioChannelState> {
         match self.lifecycle() {
-            ObjectLifecycle::Ready => Ok(self
-                .control
-                .mirror
-                .read(self.control.acknowledged_data_sequence())),
+            ObjectLifecycle::Ready => {
+                let mut state = self
+                    .control
+                    .mirror
+                    .read(self.control.acknowledged_data_sequence());
+                state.data_dirty = self.snapshots.is_dirty();
+                Ok(state)
+            }
             ObjectLifecycle::Pending => Err(anyhow!("audio channel is pending creation")),
             ObjectLifecycle::Failed => Err(anyhow!(
                 "audio channel creation failed: {}",
@@ -3835,12 +3851,19 @@ impl AudioChannel {
     }
 
     pub fn clear_data_dirty(&self) {
-        self.control
-            .acknowledge_data_sequence(self.control.mirror.data_sequence());
+        let revision = self.snapshots.latest().snapshot.revision;
+        self.snapshots.acknowledge(revision);
     }
 
     pub fn clear(&self, length: u32) -> std::result::Result<CommandSequence, SendError> {
-        self.with_mut(move |channel| channel.clear(length as usize))
+        let mutation_started = self
+            .snapshots
+            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing);
+        let result = self.with_mut(move |channel| channel.clear(length as usize));
+        if result.is_err() && mutation_started {
+            self.snapshots.cancel_mutation();
+        }
+        result
     }
 }
 
@@ -3849,6 +3872,9 @@ pub struct MidiChannel {
     shared: Arc<SharedSession>,
     parent: Arc<ObjectControl<LoopId, engine::LoopStateMirror>>,
     control: Arc<ObjectControl<MidiChannelId, engine::MidiChannelStateMirror>>,
+    snapshots: engine::content_snapshot::MidiSnapshotReader,
+    snapshot_control: engine::content_snapshot::MidiSnapshotControl,
+    desired_data: Arc<ArcSwap<Vec<MidiEvent>>>,
 }
 pub type MidiChannelState = engine::MidiChannelState;
 impl MidiChannel {
@@ -3879,7 +3905,38 @@ impl MidiChannel {
     }
 
     pub fn get_all_midi_data(&self) -> Vec<MidiEvent> {
-        self.control.mirror.data()
+        let latest = self.snapshots.latest();
+        if matches!(
+            latest.currentness,
+            engine::content_snapshot::SnapshotCurrentness::Stale(
+                engine::content_snapshot::StaleReason::MutationActive(
+                    engine::content_snapshot::ContentMutation::Loading
+                ) | engine::content_snapshot::StaleReason::PublicationPending { .. }
+            )
+        ) {
+            self.desired_data.load_full().as_ref().clone()
+        } else {
+            latest.snapshot.contiguous()
+        }
+    }
+
+    pub fn get_latest_data_snapshot(
+        &self,
+    ) -> engine::content_snapshot::SnapshotRead<engine::content_snapshot::MidiContentSnapshot> {
+        self.snapshots.latest()
+    }
+
+    pub fn try_get_current_data_snapshot(
+        &self,
+    ) -> std::result::Result<
+        Arc<engine::content_snapshot::MidiContentSnapshot>,
+        engine::content_snapshot::CurrentDataError,
+    > {
+        self.snapshots.try_current()
+    }
+
+    pub fn acknowledge_data_revision(&self, revision: engine::content_snapshot::ContentRevision) {
+        self.snapshots.acknowledge(revision);
     }
 
     pub fn load_all_midi_data(
@@ -3903,15 +3960,46 @@ impl MidiChannel {
             .map(|element| element.time)
             .max()
             .unwrap_or(0);
-        let result = self.with_mut(move |channel| {
-            channel.set_contents(
-                &elements,
+        let mut state_tracker = engine::MidiStateTracker::new(engine::TrackWhat::ALL);
+        for message in &state {
+            state_tracker.process(message);
+        }
+        let mut snapshot_events: Vec<MidiEvent> = if state.is_empty() {
+            Vec::new()
+        } else {
+            state_tracker
+                .state_as_messages()
+                .into_iter()
+                .map(|data| MidiEvent { time: -1, data })
+                .collect()
+        };
+        snapshot_events.extend(elements.iter().map(|event| MidiEvent {
+            time: event.time as i32,
+            data: event.data().to_vec(),
+        }));
+        let snapshot = self
+            .snapshot_control
+            .prepare(
+                &snapshot_events,
                 length,
-                (!state.is_empty()).then_some(state.as_slice()),
+                engine::content_snapshot::ContentMutation::Loading,
             )
+            .ok_or(SendError::Full)?;
+        let prepared = engine::PreparedMidiChannelData::new(
+            &elements,
+            length,
+            (!state.is_empty()).then_some(state.as_slice()),
+        );
+        let mut prepared = Some(prepared);
+        let result = self.with_mut(move |channel| {
+            if let Some(mut prepared) = prepared.take() {
+                channel.commit_prepared_data_and_snapshot(&mut prepared, snapshot);
+            }
         });
         if result.is_ok() {
-            self.control.mirror.replace_data(msgs.to_vec());
+            self.desired_data.store(Arc::new(msgs.to_vec()));
+        } else {
+            self.snapshot_control.cancel();
         }
         result
     }
@@ -3960,18 +4048,25 @@ impl MidiChannel {
 
     pub fn poll_state(&self) -> Option<MidiChannelState> {
         (self.lifecycle() == ObjectLifecycle::Ready).then(|| {
-            self.control
+            let mut state = self
+                .control
                 .mirror
-                .read(self.control.acknowledged_data_sequence())
+                .read(self.control.acknowledged_data_sequence());
+            state.data_dirty = self.snapshots.is_dirty();
+            state
         })
     }
 
     pub fn get_state(&self) -> Result<MidiChannelState> {
         match self.lifecycle() {
-            ObjectLifecycle::Ready => Ok(self
-                .control
-                .mirror
-                .read(self.control.acknowledged_data_sequence())),
+            ObjectLifecycle::Ready => {
+                let mut state = self
+                    .control
+                    .mirror
+                    .read(self.control.acknowledged_data_sequence());
+                state.data_dirty = self.snapshots.is_dirty();
+                Ok(state)
+            }
             ObjectLifecycle::Pending => Err(anyhow!("MIDI channel is pending creation")),
             ObjectLifecycle::Failed => Err(anyhow!(
                 "MIDI channel creation failed: {}",
@@ -4008,12 +4103,19 @@ impl MidiChannel {
     }
 
     pub fn clear_data_dirty(&self) {
-        self.control
-            .acknowledge_data_sequence(self.control.mirror.data_sequence());
+        let revision = self.snapshots.latest().snapshot.revision;
+        self.snapshots.acknowledge(revision);
     }
 
     pub fn clear(&self) -> std::result::Result<CommandSequence, SendError> {
-        self.with_mut(move |channel| channel.clear())
+        let mutation_started = self
+            .snapshots
+            .begin_mutation(engine::content_snapshot::ContentMutation::Clearing);
+        let result = self.with_mut(move |channel| channel.clear());
+        if result.is_err() && mutation_started {
+            self.snapshots.cancel_mutation();
+        }
+        result
     }
 
     pub fn reset_state_tracking(&self) -> std::result::Result<CommandSequence, SendError> {
@@ -5461,6 +5563,93 @@ mod tests {
     }
 
     #[test]
+    fn exact_and_stale_channel_snapshots_report_pending_and_recording_states() {
+        let sess = BackendSession::new().expect("session");
+        let mut engine = sess.shared.take_engine().expect("parked engine");
+        let loop_ = sess.create_loop().expect("loop");
+        let audio = loop_
+            .add_audio_channel(ChannelMode::Direct)
+            .expect("audio channel");
+        let midi = loop_
+            .add_midi_channel(ChannelMode::Direct)
+            .expect("MIDI channel");
+        engine.pump();
+
+        audio.load_data(&[1.0, 2.0]).expect("queue audio data");
+        midi.load_all_midi_data(&[MidiEvent {
+            time: 1,
+            data: vec![0x90, 60, 100],
+        }])
+        .expect("queue MIDI data");
+        assert!(matches!(
+            audio.try_get_current_data_snapshot(),
+            Err(engine::content_snapshot::CurrentDataError::MutationActive(
+                engine::content_snapshot::ContentMutation::Loading
+            ))
+        ));
+        assert!(matches!(
+            midi.try_get_current_data_snapshot(),
+            Err(engine::content_snapshot::CurrentDataError::MutationActive(
+                engine::content_snapshot::ContentMutation::Loading
+            ))
+        ));
+        assert!(audio
+            .get_latest_data_snapshot()
+            .snapshot
+            .contiguous()
+            .is_empty());
+        assert!(midi
+            .get_latest_data_snapshot()
+            .snapshot
+            .contiguous()
+            .is_empty());
+
+        engine.pump();
+        let start = Instant::now();
+        while audio.try_get_current_data_snapshot().is_err()
+            || midi.try_get_current_data_snapshot().is_err()
+        {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            thread::yield_now();
+        }
+        assert_eq!(
+            audio
+                .try_get_current_data_snapshot()
+                .expect("current audio")
+                .contiguous(),
+            vec![1.0, 2.0]
+        );
+        assert_eq!(
+            midi.try_get_current_data_snapshot()
+                .expect("current MIDI")
+                .events()
+                .count(),
+            1
+        );
+
+        loop_
+            .transition(LoopMode::Recording, -1, -1)
+            .expect("queue recording");
+        engine.pump();
+        engine
+            .session_mut()
+            .apply_graph_changes()
+            .expect("apply graph");
+        engine.process(4);
+        assert!(matches!(
+            audio.try_get_current_data_snapshot(),
+            Err(engine::content_snapshot::CurrentDataError::MutationActive(
+                engine::content_snapshot::ContentMutation::Recording
+            ))
+        ));
+        assert_eq!(
+            audio.get_latest_data_snapshot().snapshot.contiguous(),
+            vec![1.0, 2.0]
+        );
+        sess.shared.return_engine(engine);
+    }
+
+    #[test]
     fn channel_data_dirty_is_acknowledged_on_the_frontend() {
         let sess = BackendSession::new().expect("session");
         let loop_ = sess.create_loop().expect("loop");
@@ -5470,6 +5659,11 @@ mod tests {
         let sequence = audio.load_data(&[1.0, 2.0]).expect("queue data");
         sess.wait_for_command(sequence, engine::DEFAULT_WAIT_TIMEOUT)
             .expect("data command");
+        let start = Instant::now();
+        while audio.try_get_current_data_snapshot().is_err() {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            thread::yield_now();
+        }
 
         assert!(audio.get_state().expect("dirty state").data_dirty);
         audio.clear_data_dirty();
@@ -5477,6 +5671,11 @@ mod tests {
         let sequence = audio.clear(0).expect("queue clear");
         sess.wait_for_command(sequence, engine::DEFAULT_WAIT_TIMEOUT)
             .expect("clear command");
+        let start = Instant::now();
+        while audio.try_get_current_data_snapshot().is_err() {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            thread::yield_now();
+        }
         assert!(audio.get_state().expect("dirty again").data_dirty);
     }
 

--- a/src/rust/shoop_engine/src/audio_channel.rs
+++ b/src/rust/shoop_engine/src/audio_channel.rs
@@ -108,6 +108,11 @@ impl PreparedAudioChannelData {
         }
     }
 
+    #[cfg(feature = "app_backend")]
+    pub(crate) fn contiguous_copy(&self) -> Vec<f32> {
+        self.buffers.contiguous_copy(self.length)
+    }
+
     pub(crate) fn copy_to_preallocated(&self, destination: &mut Vec<f32>) {
         debug_assert!(destination.capacity() >= self.length);
         destination.resize(self.length, 0.0);
@@ -145,6 +150,7 @@ pub struct AudioChannel {
     queue: Vec<CopyCmd>,
     state: Arc<AudioChannelStateMirror>,
     content_snapshots: Option<AudioProcessSnapshotWriter>,
+    publish_snapshot_updates: bool,
 }
 
 impl AudioChannel {
@@ -188,6 +194,7 @@ impl AudioChannel {
             queue: Vec::new(),
             state,
             content_snapshots,
+            publish_snapshot_updates: true,
         };
         channel.publish_state();
         channel
@@ -207,6 +214,7 @@ impl AudioChannel {
 
     fn publish_all_data(&mut self) {
         if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
             snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
             let mut offset = 0;
             while offset < self.data_length {
@@ -241,6 +249,7 @@ impl AudioChannel {
     pub fn set_length(&mut self, length: usize) {
         self.data_length = length;
         if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
             snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
             snapshots.publish_range(0, &[], length, true);
             snapshots.finish_mutation(false);
@@ -307,6 +316,7 @@ impl AudioChannel {
         self.data_length = samples.len();
         self.start_offset = 0;
         if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
             snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
             snapshots.publish_range(0, samples, samples.len(), true);
             snapshots.finish_mutation(false);
@@ -378,6 +388,7 @@ impl AudioChannel {
         self.data_length = length;
         self.start_offset = 0;
         if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
             snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Clearing);
             snapshots.publish_range(0, &[], length, true);
             snapshots.finish_mutation(false);
@@ -394,6 +405,7 @@ impl AudioChannel {
         self.data_length = length;
         self.start_offset = 0;
         if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
             snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Clearing);
             snapshots.publish_silence(length);
             snapshots.finish_mutation(false);
@@ -511,16 +523,21 @@ impl AudioChannel {
                     if previous == crate::content_snapshot::ContentMutation::PreRecording {
                         snapshots.cancel_mutation();
                     } else {
-                        snapshots.finish_mutation(false);
+                        snapshots.finish_mutation(
+                            previous == crate::content_snapshot::ContentMutation::Replacing,
+                        );
                     }
                 }
             }
             if let Some(mutation) = current_mutation {
-                if let Some(snapshots) = self.content_snapshots.as_ref() {
+                if let Some(snapshots) = self.content_snapshots.as_mut() {
+                    snapshots.begin_working_generation();
                     snapshots.begin_mutation(mutation);
                 }
             }
         }
+        self.publish_snapshot_updates =
+            current_mutation != Some(crate::content_snapshot::ContentMutation::Replacing);
 
         if !flags.contains(ProcessFlags::PRE_RECORD)
             && self.prev_process_flags.contains(ProcessFlags::PRE_RECORD)
@@ -748,7 +765,12 @@ impl AudioChannel {
                     let source = &record_src[src..src + len];
                     copy_in(&mut self.buffers, dst, source);
                     if let Some(snapshots) = self.content_snapshots.as_mut() {
-                        snapshots.publish_range(dst, source, self.data_length, true);
+                        snapshots.publish_range(
+                            dst,
+                            source,
+                            self.data_length,
+                            self.publish_snapshot_updates,
+                        );
                     }
                 }
                 CopyCmd::IntoPreRecord { dst, src, len } => {

--- a/src/rust/shoop_engine/src/audio_channel.rs
+++ b/src/rust/shoop_engine/src/audio_channel.rs
@@ -10,6 +10,7 @@
 
 use crate::channel_mode::{channel_process_params, ChannelMode, ProcessFlags};
 use crate::chunked_samples::ChunkedSamples;
+use crate::content_snapshot::AudioProcessSnapshotWriter;
 use crate::loop_mode::LoopMode;
 use crate::state_mirror::AudioChannelStateMirror;
 
@@ -45,6 +46,18 @@ enum CopyCmd {
         len: usize,
         gain: f32,
     },
+}
+
+fn snapshot_mutation(flags: ProcessFlags) -> Option<crate::content_snapshot::ContentMutation> {
+    if flags.contains(ProcessFlags::REPLACE) {
+        Some(crate::content_snapshot::ContentMutation::Replacing)
+    } else if flags.contains(ProcessFlags::RECORD) {
+        Some(crate::content_snapshot::ContentMutation::Recording)
+    } else if flags.contains(ProcessFlags::PRE_RECORD) {
+        Some(crate::content_snapshot::ContentMutation::PreRecording)
+    } else {
+        None
+    }
 }
 
 /// Tracks how much of a port buffer this cycle has been consumed.
@@ -131,6 +144,7 @@ pub struct AudioChannel {
     recording: Option<CycleBuf>,
     queue: Vec<CopyCmd>,
     state: Arc<AudioChannelStateMirror>,
+    content_snapshots: Option<AudioProcessSnapshotWriter>,
 }
 
 impl AudioChannel {
@@ -146,6 +160,15 @@ impl AudioChannel {
         chunk_size: usize,
         mode: ChannelMode,
         state: Arc<AudioChannelStateMirror>,
+    ) -> Self {
+        Self::with_chunk_size_state_and_snapshots(chunk_size, mode, state, None)
+    }
+
+    pub fn with_chunk_size_state_and_snapshots(
+        chunk_size: usize,
+        mode: ChannelMode,
+        state: Arc<AudioChannelStateMirror>,
+        content_snapshots: Option<AudioProcessSnapshotWriter>,
     ) -> Self {
         let channel = Self {
             buffers: ChunkedSamples::with_chunk_size(chunk_size),
@@ -164,6 +187,7 @@ impl AudioChannel {
             recording: None,
             queue: Vec::new(),
             state,
+            content_snapshots,
         };
         channel.publish_state();
         channel
@@ -181,10 +205,28 @@ impl AudioChannel {
         );
     }
 
-    fn publish_all_data(&self) {
-        if self.state.complex_data_enabled() {
-            self.state
-                .replace_data(self.buffers.contiguous_copy(self.data_length));
+    fn publish_all_data(&mut self) {
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
+            let mut offset = 0;
+            while offset < self.data_length {
+                let source = self
+                    .buffers
+                    .chunk_slice(offset)
+                    .expect("channel data is addressable");
+                let count = source.len().min(self.data_length - offset);
+                snapshots.publish_range(
+                    offset,
+                    &source[..count],
+                    self.data_length,
+                    offset + count == self.data_length,
+                );
+                offset += count;
+            }
+            if self.data_length == 0 {
+                snapshots.publish_range(0, &[], 0, true);
+            }
+            snapshots.finish_mutation(false);
         }
     }
 
@@ -198,7 +240,11 @@ impl AudioChannel {
     }
     pub fn set_length(&mut self, length: usize) {
         self.data_length = length;
-        self.publish_all_data();
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
+            snapshots.publish_range(0, &[], length, true);
+            snapshots.finish_mutation(false);
+        }
         self.data_changed();
     }
     pub fn mode(&self) -> ChannelMode {
@@ -260,8 +306,10 @@ impl AudioChannel {
         self.buffers.set_contents(samples);
         self.data_length = samples.len();
         self.start_offset = 0;
-        if self.state.complex_data_enabled() {
-            self.state.replace_data(samples.to_vec());
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
+            snapshots.publish_range(0, samples, samples.len(), true);
+            snapshots.finish_mutation(false);
         }
         self.data_changed();
     }
@@ -303,6 +351,21 @@ impl AudioChannel {
         std::mem::swap(&mut self.buffers, &mut prepared.buffers);
         std::mem::swap(&mut self.data_length, &mut prepared.length);
         self.start_offset = 0;
+        self.publish_all_data();
+        self.data_changed();
+    }
+
+    pub(crate) fn commit_prepared_data_and_snapshot(
+        &mut self,
+        prepared: &mut PreparedAudioChannelData,
+        snapshot: crate::content_snapshot::PreparedAudioSnapshot,
+    ) {
+        std::mem::swap(&mut self.buffers, &mut prepared.buffers);
+        std::mem::swap(&mut self.data_length, &mut prepared.length);
+        self.start_offset = 0;
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.install_prepared(snapshot);
+        }
         self.data_changed();
     }
 
@@ -314,7 +377,11 @@ impl AudioChannel {
         self.buffers.ensure_available(length);
         self.data_length = length;
         self.start_offset = 0;
-        self.publish_all_data();
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Clearing);
+            snapshots.publish_range(0, &[], length, true);
+            snapshots.finish_mutation(false);
+        }
         self.data_changed();
     }
 
@@ -326,8 +393,10 @@ impl AudioChannel {
         self.buffers.fill(length, 0.0);
         self.data_length = length;
         self.start_offset = 0;
-        if self.state.complex_data_enabled() {
-            self.state.replace_data(vec![0.0; length]);
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Clearing);
+            snapshots.publish_silence(length);
+            snapshots.finish_mutation(false);
         }
         self.data_changed();
     }
@@ -434,6 +503,25 @@ impl AudioChannel {
             flags = ProcessFlags(flags.0 & !ProcessFlags::PLAYBACK.0);
         }
 
+        let previous_mutation = snapshot_mutation(self.prev_process_flags);
+        let current_mutation = snapshot_mutation(flags);
+        if previous_mutation != current_mutation {
+            if let Some(previous) = previous_mutation {
+                if let Some(snapshots) = self.content_snapshots.as_mut() {
+                    if previous == crate::content_snapshot::ContentMutation::PreRecording {
+                        snapshots.cancel_mutation();
+                    } else {
+                        snapshots.finish_mutation(false);
+                    }
+                }
+            }
+            if let Some(mutation) = current_mutation {
+                if let Some(snapshots) = self.content_snapshots.as_ref() {
+                    snapshots.begin_mutation(mutation);
+                }
+            }
+        }
+
         if !flags.contains(ProcessFlags::PRE_RECORD)
             && self.prev_process_flags.contains(ProcessFlags::PRE_RECORD)
         {
@@ -443,7 +531,11 @@ impl AudioChannel {
                 self.buffers = self.prerecord_buffers.clone();
                 self.data_length = self.prerecord_data_length;
                 self.start_offset = self.prerecord_data_length as i32;
-                self.publish_all_data();
+                if let Some(snapshots) = self.content_snapshots.as_mut() {
+                    snapshots.adopt_prerecord(self.data_length);
+                }
+            } else if let Some(snapshots) = self.content_snapshots.as_mut() {
+                snapshots.clear_prerecord();
             }
             self.prerecord_buffers.reset();
             self.prerecord_data_length = 0;
@@ -655,14 +747,16 @@ impl AudioChannel {
                 CopyCmd::IntoMain { dst, src, len } => {
                     let source = &record_src[src..src + len];
                     copy_in(&mut self.buffers, dst, source);
-                    self.state.write_data(dst, source, self.data_length);
+                    if let Some(snapshots) = self.content_snapshots.as_mut() {
+                        snapshots.publish_range(dst, source, self.data_length, true);
+                    }
                 }
                 CopyCmd::IntoPreRecord { dst, src, len } => {
-                    copy_in(
-                        &mut self.prerecord_buffers,
-                        dst,
-                        &record_src[src..src + len],
-                    );
+                    let source = &record_src[src..src + len];
+                    copy_in(&mut self.prerecord_buffers, dst, source);
+                    if let Some(snapshots) = self.content_snapshots.as_mut() {
+                        snapshots.publish_prerecord_range(dst, source, self.prerecord_data_length);
+                    }
                 }
                 CopyCmd::OutOfMain {
                     src,

--- a/src/rust/shoop_engine/src/audio_midi_loop.rs
+++ b/src/rust/shoop_engine/src/audio_midi_loop.rs
@@ -9,6 +9,7 @@
 use crate::audio_channel::{AudioChannel, ChannelError};
 use crate::basic_loop::{BasicLoop, SyncSourceState};
 use crate::channel_mode::ChannelMode;
+use crate::content_snapshot::{AudioProcessSnapshotWriter, MidiProcessSnapshotWriter};
 use crate::loop_mode::LoopMode;
 use crate::midi_channel::{MidiChannel, MidiChannelError};
 use crate::midi_storage::MidiStorageElem;
@@ -58,9 +59,19 @@ impl AudioMidiLoop {
         mode: ChannelMode,
         state: Arc<AudioChannelStateMirror>,
     ) -> usize {
+        self.add_audio_channel_with_state_and_snapshots(chunk_size, mode, state, None)
+    }
+
+    pub fn add_audio_channel_with_state_and_snapshots(
+        &mut self,
+        chunk_size: usize,
+        mode: ChannelMode,
+        state: Arc<AudioChannelStateMirror>,
+        snapshots: Option<AudioProcessSnapshotWriter>,
+    ) -> usize {
         self.audio_channels
-            .push(AudioChannel::with_chunk_size_and_state(
-                chunk_size, mode, state,
+            .push(AudioChannel::with_chunk_size_state_and_snapshots(
+                chunk_size, mode, state, snapshots,
             ));
         self.resync_poi();
         self.audio_channels.len() - 1
@@ -100,11 +111,22 @@ impl AudioMidiLoop {
         mode: ChannelMode,
         state: Arc<MidiChannelStateMirror>,
     ) -> usize {
+        self.add_midi_channel_with_state_and_snapshots(capacity_elems, mode, state, None)
+    }
+
+    pub fn add_midi_channel_with_state_and_snapshots(
+        &mut self,
+        capacity_elems: usize,
+        mode: ChannelMode,
+        state: Arc<MidiChannelStateMirror>,
+        snapshots: Option<MidiProcessSnapshotWriter>,
+    ) -> usize {
         self.midi_channels
-            .push(MidiChannel::with_capacity_elems_and_state(
+            .push(MidiChannel::with_capacity_state_and_snapshots(
                 capacity_elems,
                 mode,
                 state,
+                snapshots,
             ));
         self.resync_poi();
         self.midi_channels.len() - 1

--- a/src/rust/shoop_engine/src/content_snapshot/audio.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/audio.rs
@@ -4,7 +4,20 @@ use super::{
     AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision, ContentStatus,
     SessionContentEpoch,
 };
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy)]
+enum AudioUpdateKind {
+    Range,
+    PreRecordRange,
+    ClearPreRecord,
+    AdoptPreRecord,
+    Silence,
+    Install(ContentRevision),
+}
 
 #[derive(Debug)]
 struct AudioUpdateBlock {
@@ -15,6 +28,7 @@ struct AudioUpdateBlock {
     revision: ContentRevision,
     final_block: bool,
     publish: bool,
+    kind: AudioUpdateKind,
 }
 
 impl AudioUpdateBlock {
@@ -27,8 +41,27 @@ impl AudioUpdateBlock {
             revision: ContentRevision(0),
             final_block: false,
             publish: false,
+            kind: AudioUpdateKind::Range,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedAudioSnapshot {
+    revision: ContentRevision,
+    length: usize,
+}
+
+struct PreparedAudioManifest {
+    token: PreparedAudioSnapshot,
+    chunks: Arc<[Arc<[f32]>]>,
+}
+
+#[derive(Clone)]
+pub struct AudioSnapshotControl {
+    status: Arc<ContentStatus>,
+    prepared: Sender<PreparedAudioManifest>,
+    chunk_size: usize,
 }
 
 pub struct AudioProcessSnapshotWriter {
@@ -41,11 +74,24 @@ pub struct AudioProcessSnapshotWriter {
     block_size: usize,
 }
 
+impl fmt::Debug for AudioProcessSnapshotWriter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AudioProcessSnapshotWriter")
+            .field("latest_revision", &self.latest_revision)
+            .field("latest_length", &self.latest_length)
+            .finish_non_exhaustive()
+    }
+}
+
 pub struct AudioSnapshotPublisher {
     updates: PublisherReceiver<AudioUpdateBlock>,
     returned: ProcessSender<AudioUpdateBlock>,
+    prepared: Receiver<PreparedAudioManifest>,
+    prepared_by_revision: HashMap<ContentRevision, PreparedAudioManifest>,
     manifest: ManifestPublisher<AudioContentSnapshot>,
     chunks: Vec<Arc<[f32]>>,
+    prerecord_chunks: Vec<Arc<[f32]>>,
     chunk_size: usize,
 }
 
@@ -57,6 +103,7 @@ pub fn audio_snapshot_channel(
     transport_blocks: usize,
 ) -> (
     AudioProcessSnapshotWriter,
+    AudioSnapshotControl,
     AudioSnapshotPublisher,
     AudioSnapshotReader,
 ) {
@@ -68,6 +115,7 @@ pub fn audio_snapshot_channel(
     let status = Arc::new(ContentStatus::new(epoch));
     let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
     let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (prepared_tx, prepared_rx) = mpsc::channel();
     let initial = AudioContentSnapshot::new(
         ContentRevision(0),
         AudioSnapshotMetadata { length: 0 },
@@ -83,16 +131,24 @@ pub fn audio_snapshot_channel(
             updates: updates_tx,
             returned: returned_rx,
             free,
-            status,
+            status: Arc::clone(&status),
             latest_revision: ContentRevision(0),
             latest_length: 0,
             block_size: chunk_size,
         },
+        AudioSnapshotControl {
+            status,
+            prepared: prepared_tx,
+            chunk_size,
+        },
         AudioSnapshotPublisher {
             updates: updates_rx,
             returned: returned_tx,
+            prepared: prepared_rx,
+            prepared_by_revision: HashMap::new(),
             manifest,
             chunks: Vec::new(),
+            prerecord_chunks: Vec::new(),
             chunk_size,
         },
         reader,
@@ -117,6 +173,38 @@ impl AudioProcessSnapshotWriter {
         total_length: usize,
         publish: bool,
     ) -> Option<ContentRevision> {
+        self.publish_range_kind(
+            AudioUpdateKind::Range,
+            offset,
+            samples,
+            total_length,
+            publish,
+        )
+    }
+
+    pub fn publish_prerecord_range(
+        &mut self,
+        offset: usize,
+        samples: &[f32],
+        total_length: usize,
+    ) -> Option<ContentRevision> {
+        self.publish_range_kind(
+            AudioUpdateKind::PreRecordRange,
+            offset,
+            samples,
+            total_length,
+            false,
+        )
+    }
+
+    fn publish_range_kind(
+        &mut self,
+        kind: AudioUpdateKind,
+        offset: usize,
+        samples: &[f32],
+        total_length: usize,
+        publish: bool,
+    ) -> Option<ContentRevision> {
         self.reclaim();
         let n_blocks = samples.len().max(1).div_ceil(self.block_size);
         if self.free.len() < n_blocks || self.updates.slots() < n_blocks {
@@ -133,6 +221,7 @@ impl AudioProcessSnapshotWriter {
             block.revision = revision;
             block.final_block = true;
             block.publish = publish;
+            block.kind = kind;
             if let Err(block) = self.updates.try_send(block) {
                 self.free.push(block);
                 return None;
@@ -147,6 +236,7 @@ impl AudioProcessSnapshotWriter {
                 block.revision = revision;
                 block.final_block = index + 1 == n_blocks;
                 block.publish = publish;
+                block.kind = kind;
                 if let Err(block) = self.updates.try_send(block) {
                     self.free.push(block);
                     self.status.mark_saturated();
@@ -157,6 +247,60 @@ impl AudioProcessSnapshotWriter {
         self.latest_revision = revision;
         self.latest_length = total_length;
         Some(revision)
+    }
+
+    pub fn clear_prerecord(&mut self) -> Option<ContentRevision> {
+        self.publish_range_kind(AudioUpdateKind::ClearPreRecord, 0, &[], 0, false)
+    }
+
+    pub fn adopt_prerecord(&mut self, length: usize) -> Option<ContentRevision> {
+        self.publish_range_kind(AudioUpdateKind::AdoptPreRecord, 0, &[], length, true)
+    }
+
+    pub fn publish_silence(&mut self, length: usize) -> Option<ContentRevision> {
+        self.reclaim();
+        if self.free.is_empty() || self.updates.slots() == 0 {
+            self.status.mark_saturated();
+            return None;
+        }
+        let revision = self.status.next_revision();
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.total_length = length;
+        block.revision = revision;
+        block.final_block = true;
+        block.publish = true;
+        block.kind = AudioUpdateKind::Silence;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            return None;
+        }
+        self.latest_revision = revision;
+        self.latest_length = length;
+        Some(revision)
+    }
+
+    pub fn install_prepared(&mut self, prepared: PreparedAudioSnapshot) -> bool {
+        self.reclaim();
+        if self.free.is_empty() || self.updates.slots() == 0 {
+            self.status.mark_saturated();
+            return false;
+        }
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.total_length = prepared.length;
+        block.revision = prepared.revision;
+        block.final_block = true;
+        block.publish = true;
+        block.kind = AudioUpdateKind::Install(prepared.revision);
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            return false;
+        }
+        self.latest_revision = prepared.revision;
+        self.latest_length = prepared.length;
+        self.status.finish_mutation(prepared.revision);
+        true
     }
 
     pub fn finish_mutation(&mut self, publish_final: bool) -> ContentRevision {
@@ -176,59 +320,142 @@ impl AudioProcessSnapshotWriter {
     }
 }
 
+impl AudioSnapshotControl {
+    pub fn prepare(
+        &self,
+        samples: &[f32],
+        mutation: ContentMutation,
+    ) -> Option<PreparedAudioSnapshot> {
+        if !self.status.begin_mutation(mutation) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        let chunks: Vec<Arc<[f32]>> = samples
+            .chunks(self.chunk_size)
+            .map(|chunk| Arc::from(chunk))
+            .collect();
+        let token = PreparedAudioSnapshot {
+            revision,
+            length: samples.len(),
+        };
+        if self
+            .prepared
+            .send(PreparedAudioManifest {
+                token,
+                chunks: Arc::from(chunks),
+            })
+            .is_err()
+        {
+            self.status.cancel_mutation();
+            return None;
+        }
+        Some(token)
+    }
+
+    pub fn cancel(&self) {
+        self.status.cancel_mutation();
+    }
+}
+
 impl AudioSnapshotPublisher {
     pub fn pump(&mut self) -> usize {
+        while let Ok(prepared) = self.prepared.try_recv() {
+            self.prepared_by_revision
+                .insert(prepared.token.revision, prepared);
+        }
         let mut processed = 0;
         while let Some(block) = self.updates.try_recv() {
-            self.apply(&block);
             let final_block = block.final_block;
             let publish = block.publish;
             let revision = block.revision;
             let length = block.total_length;
+            match block.kind {
+                AudioUpdateKind::Range => {
+                    Self::apply_to(&mut self.chunks, self.chunk_size, &block);
+                    if final_block && publish {
+                        self.manifest.publish(AudioContentSnapshot::new(
+                            revision,
+                            AudioSnapshotMetadata { length },
+                            Arc::from(self.chunks.clone()),
+                        ));
+                    }
+                }
+                AudioUpdateKind::PreRecordRange => {
+                    Self::apply_to(&mut self.prerecord_chunks, self.chunk_size, &block);
+                }
+                AudioUpdateKind::ClearPreRecord => self.prerecord_chunks.clear(),
+                AudioUpdateKind::AdoptPreRecord => {
+                    self.chunks = std::mem::take(&mut self.prerecord_chunks);
+                    Self::resize_to(&mut self.chunks, self.chunk_size, length);
+                    self.manifest.publish(AudioContentSnapshot::new(
+                        revision,
+                        AudioSnapshotMetadata { length },
+                        Arc::from(self.chunks.clone()),
+                    ));
+                }
+                AudioUpdateKind::Silence => {
+                    self.chunks = (0..length.div_ceil(self.chunk_size))
+                        .map(|_| Arc::from(vec![0.0; self.chunk_size].into_boxed_slice()))
+                        .collect();
+                    self.manifest.publish(AudioContentSnapshot::new(
+                        revision,
+                        AudioSnapshotMetadata { length },
+                        Arc::from(self.chunks.clone()),
+                    ));
+                }
+                AudioUpdateKind::Install(prepared_revision) => {
+                    if let Some(prepared) = self.prepared_by_revision.remove(&prepared_revision) {
+                        self.chunks = prepared.chunks.to_vec();
+                        self.manifest.publish(AudioContentSnapshot::new(
+                            prepared.token.revision,
+                            AudioSnapshotMetadata {
+                                length: prepared.token.length,
+                            },
+                            prepared.chunks,
+                        ));
+                    }
+                }
+            }
             self.returned
                 .try_send(block)
                 .expect("return queue capacity matches the transport pool");
-            if final_block && publish {
-                self.manifest.publish(AudioContentSnapshot::new(
-                    revision,
-                    AudioSnapshotMetadata { length },
-                    Arc::from(self.chunks.clone()),
-                ));
-            }
             processed += 1;
         }
         processed
     }
 
-    fn apply(&mut self, block: &AudioUpdateBlock) {
+    fn apply_to(chunks: &mut Vec<Arc<[f32]>>, chunk_size: usize, block: &AudioUpdateBlock) {
         if block.used == 0 {
-            self.truncate(block.total_length);
+            Self::resize_to(chunks, chunk_size, block.total_length);
             return;
         }
         let end = block.offset + block.used;
-        let needed = end.div_ceil(self.chunk_size);
-        while self.chunks.len() < needed {
-            self.chunks
-                .push(Arc::from(vec![0.0; self.chunk_size].into_boxed_slice()));
+        let needed = end.div_ceil(chunk_size);
+        while chunks.len() < needed {
+            chunks.push(Arc::from(vec![0.0; chunk_size].into_boxed_slice()));
         }
         let mut source_offset = 0;
         let mut destination_offset = block.offset;
         while source_offset < block.used {
-            let chunk_index = destination_offset / self.chunk_size;
-            let chunk_offset = destination_offset % self.chunk_size;
-            let count = (self.chunk_size - chunk_offset).min(block.used - source_offset);
-            let mut updated = self.chunks[chunk_index].to_vec();
+            let chunk_index = destination_offset / chunk_size;
+            let chunk_offset = destination_offset % chunk_size;
+            let count = (chunk_size - chunk_offset).min(block.used - source_offset);
+            let mut updated = chunks[chunk_index].to_vec();
             updated[chunk_offset..chunk_offset + count]
                 .copy_from_slice(&block.samples[source_offset..source_offset + count]);
-            self.chunks[chunk_index] = Arc::from(updated.into_boxed_slice());
+            chunks[chunk_index] = Arc::from(updated.into_boxed_slice());
             source_offset += count;
             destination_offset += count;
         }
-        self.truncate(block.total_length);
+        Self::resize_to(chunks, chunk_size, block.total_length);
     }
 
-    fn truncate(&mut self, length: usize) {
-        self.chunks.truncate(length.div_ceil(self.chunk_size));
+    fn resize_to(chunks: &mut Vec<Arc<[f32]>>, chunk_size: usize, length: usize) {
+        let needed = length.div_ceil(chunk_size);
+        chunks.truncate(needed);
+        while chunks.len() < needed {
+            chunks.push(Arc::from(vec![0.0; chunk_size].into_boxed_slice()));
+        }
     }
 }
 
@@ -239,7 +466,7 @@ mod tests {
 
     #[test]
     fn recording_publishes_only_complete_process_updates() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
         assert!(writer.begin_mutation(ContentMutation::Recording));
         let first = writer
@@ -268,7 +495,7 @@ mod tests {
 
     #[test]
     fn exact_read_waits_for_final_publication_after_recording() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
         assert!(writer.begin_mutation(ContentMutation::Recording));
         let revision = writer
@@ -291,7 +518,7 @@ mod tests {
 
     #[test]
     fn hidden_working_generation_replaces_the_visible_snapshot_at_commit() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
         assert!(writer.begin_mutation(ContentMutation::Loading));
         writer.publish_range(0, &[1.0, 2.0, 3.0, 4.0], 4, true);
@@ -319,7 +546,7 @@ mod tests {
 
     #[test]
     fn saturation_keeps_the_last_complete_snapshot() {
-        let (mut writer, _publisher, reader) =
+        let (mut writer, _control, _publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 1);
         assert!(writer.begin_mutation(ContentMutation::Recording));
         assert!(writer.publish_range(0, &[1.0, 2.0], 2, true).is_some());

--- a/src/rust/shoop_engine/src/content_snapshot/audio.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/audio.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy)]
 enum AudioUpdateKind {
+    BeginWorking,
     Range,
     PreRecordRange,
     ClearPreRecord,
@@ -52,6 +53,12 @@ pub struct PreparedAudioSnapshot {
     length: usize,
 }
 
+impl PreparedAudioSnapshot {
+    pub fn revision(self) -> ContentRevision {
+        self.revision
+    }
+}
+
 struct PreparedAudioManifest {
     token: PreparedAudioSnapshot,
     chunks: Arc<[Arc<[f32]>]>,
@@ -72,6 +79,7 @@ pub struct AudioProcessSnapshotWriter {
     latest_revision: ContentRevision,
     latest_length: usize,
     block_size: usize,
+    retirement: ProcessSender<Vec<AudioUpdateBlock>>,
 }
 
 impl fmt::Debug for AudioProcessSnapshotWriter {
@@ -91,8 +99,11 @@ pub struct AudioSnapshotPublisher {
     prepared_by_revision: HashMap<ContentRevision, PreparedAudioManifest>,
     manifest: ManifestPublisher<AudioContentSnapshot>,
     chunks: Vec<Arc<[f32]>>,
+    committed_chunks: Vec<Arc<[f32]>>,
     prerecord_chunks: Vec<Arc<[f32]>>,
     chunk_size: usize,
+    retirement: PublisherReceiver<Vec<AudioUpdateBlock>>,
+    retired: bool,
 }
 
 pub type AudioSnapshotReader = ManifestReader<AudioContentSnapshot>;
@@ -115,6 +126,7 @@ pub fn audio_snapshot_channel(
     let status = Arc::new(ContentStatus::new(epoch));
     let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
     let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (retirement_tx, retirement_rx) = bounded_transport(1, Arc::clone(&status));
     let (prepared_tx, prepared_rx) = mpsc::channel();
     let initial = AudioContentSnapshot::new(
         ContentRevision(0),
@@ -135,6 +147,7 @@ pub fn audio_snapshot_channel(
             latest_revision: ContentRevision(0),
             latest_length: 0,
             block_size: chunk_size,
+            retirement: retirement_tx,
         },
         AudioSnapshotControl {
             status,
@@ -148,11 +161,25 @@ pub fn audio_snapshot_channel(
             prepared_by_revision: HashMap::new(),
             manifest,
             chunks: Vec::new(),
+            committed_chunks: Vec::new(),
             prerecord_chunks: Vec::new(),
             chunk_size,
+            retirement: retirement_rx,
+            retired: false,
         },
         reader,
     )
+}
+
+impl Drop for AudioProcessSnapshotWriter {
+    fn drop(&mut self) {
+        let resources = std::mem::take(&mut self.free);
+        if let Err(resources) = self.retirement.try_send(resources) {
+            // The single producer retires only once, so this is unreachable unless the
+            // publisher has already gone away. Leaking is preferable to realtime destruction.
+            std::mem::forget(resources);
+        }
+    }
 }
 
 impl AudioProcessSnapshotWriter {
@@ -164,6 +191,23 @@ impl AudioProcessSnapshotWriter {
         while let Some(block) = self.returned.try_recv() {
             self.free.push(block);
         }
+    }
+
+    pub fn begin_working_generation(&mut self) -> bool {
+        self.reclaim();
+        if self.free.is_empty() || self.updates.slots() == 0 {
+            self.status.mark_saturated();
+            return false;
+        }
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.kind = AudioUpdateKind::BeginWorking;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            self.status.mark_saturated();
+            return false;
+        }
+        true
     }
 
     pub fn publish_range(
@@ -332,7 +376,11 @@ impl AudioSnapshotControl {
         let revision = self.status.next_revision();
         let chunks: Vec<Arc<[f32]>> = samples
             .chunks(self.chunk_size)
-            .map(|chunk| Arc::from(chunk))
+            .map(|chunk| {
+                let mut padded = vec![0.0; self.chunk_size];
+                padded[..chunk.len()].copy_from_slice(chunk);
+                Arc::from(padded.into_boxed_slice())
+            })
             .collect();
         let token = PreparedAudioSnapshot {
             revision,
@@ -358,7 +406,12 @@ impl AudioSnapshotControl {
 }
 
 impl AudioSnapshotPublisher {
+    pub fn is_retired(&self) -> bool {
+        self.retired
+    }
+
     pub fn pump(&mut self) -> usize {
+        let retired_resources = self.retirement.try_recv();
         while let Ok(prepared) = self.prepared.try_recv() {
             self.prepared_by_revision
                 .insert(prepared.token.revision, prepared);
@@ -370,6 +423,9 @@ impl AudioSnapshotPublisher {
             let revision = block.revision;
             let length = block.total_length;
             match block.kind {
+                AudioUpdateKind::BeginWorking => {
+                    self.chunks = self.committed_chunks.clone();
+                }
                 AudioUpdateKind::Range => {
                     Self::apply_to(&mut self.chunks, self.chunk_size, &block);
                     if final_block && publish {
@@ -378,6 +434,7 @@ impl AudioSnapshotPublisher {
                             AudioSnapshotMetadata { length },
                             Arc::from(self.chunks.clone()),
                         ));
+                        self.committed_chunks = self.chunks.clone();
                     }
                 }
                 AudioUpdateKind::PreRecordRange => {
@@ -392,6 +449,7 @@ impl AudioSnapshotPublisher {
                         AudioSnapshotMetadata { length },
                         Arc::from(self.chunks.clone()),
                     ));
+                    self.committed_chunks = self.chunks.clone();
                 }
                 AudioUpdateKind::Silence => {
                     self.chunks = (0..length.div_ceil(self.chunk_size))
@@ -402,6 +460,7 @@ impl AudioSnapshotPublisher {
                         AudioSnapshotMetadata { length },
                         Arc::from(self.chunks.clone()),
                     ));
+                    self.committed_chunks = self.chunks.clone();
                 }
                 AudioUpdateKind::Install(prepared_revision) => {
                     if let Some(prepared) = self.prepared_by_revision.remove(&prepared_revision) {
@@ -413,6 +472,7 @@ impl AudioSnapshotPublisher {
                             },
                             prepared.chunks,
                         ));
+                        self.committed_chunks = self.chunks.clone();
                     }
                 }
             }
@@ -420,6 +480,10 @@ impl AudioSnapshotPublisher {
                 .try_send(block)
                 .expect("return queue capacity matches the transport pool");
             processed += 1;
+        }
+        if let Some(resources) = retired_resources {
+            drop(resources);
+            self.retired = true;
         }
         processed
     }
@@ -541,6 +605,55 @@ mod tests {
         assert_eq!(
             reader.latest().snapshot.contiguous(),
             vec![1.0, 9.0, 8.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn cancelled_private_work_is_reset_from_the_committed_generation() {
+        let (mut writer, _control, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 6);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        writer.publish_range(0, &[1.0, 2.0, 3.0, 4.0], 4, true);
+        writer.finish_mutation(false);
+        publisher.pump();
+
+        assert!(writer.begin_mutation(ContentMutation::Replacing));
+        assert!(writer.begin_working_generation());
+        writer.publish_range(0, &[9.0], 4, false);
+        publisher.pump();
+        writer.cancel_mutation();
+
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        assert!(writer.begin_working_generation());
+        writer.publish_range(3, &[5.0], 4, true);
+        writer.finish_mutation(false);
+        publisher.pump();
+        assert_eq!(
+            reader.latest().snapshot.contiguous(),
+            vec![1.0, 2.0, 3.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn prepared_generation_installs_without_process_side_content_copying() {
+        let (mut writer, control, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
+        let prepared = control
+            .prepare(&[1.0, 2.0, 3.0], ContentMutation::Loading)
+            .expect("prepare generation");
+        assert!(matches!(
+            reader.try_current(),
+            Err(CurrentDataError::MutationActive(ContentMutation::Loading))
+        ));
+        assert!(writer.install_prepared(prepared));
+        assert!(matches!(
+            reader.try_current(),
+            Err(CurrentDataError::PublicationPending { .. })
+        ));
+        publisher.pump();
+        assert_eq!(
+            reader.try_current().expect("installed").contiguous(),
+            vec![1.0, 2.0, 3.0]
         );
     }
 

--- a/src/rust/shoop_engine/src/content_snapshot/audio.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/audio.rs
@@ -358,13 +358,17 @@ impl AudioProcessSnapshotWriter {
     pub fn cancel_mutation(&self) {
         self.status.cancel_mutation();
     }
-
-    pub fn status(&self) -> &Arc<ContentStatus> {
-        &self.status
-    }
 }
 
 impl AudioSnapshotControl {
+    pub fn begin_mutation(&self, mutation: ContentMutation) -> bool {
+        self.status.begin_mutation(mutation)
+    }
+
+    pub fn cancel_mutation(&self) {
+        self.status.cancel_mutation();
+    }
+
     pub fn prepare(
         &self,
         samples: &[f32],
@@ -412,10 +416,23 @@ impl AudioSnapshotPublisher {
 
     pub fn pump(&mut self) -> usize {
         let retired_resources = self.retirement.try_recv();
+        self.drain_prepared();
+        let processed = self.pump_updates();
+        if let Some(resources) = retired_resources {
+            drop(resources);
+            self.retired = true;
+        }
+        processed
+    }
+
+    fn drain_prepared(&mut self) {
         while let Ok(prepared) = self.prepared.try_recv() {
             self.prepared_by_revision
                 .insert(prepared.token.revision, prepared);
         }
+    }
+
+    fn pump_updates(&mut self) -> usize {
         let mut processed = 0;
         while let Some(block) = self.updates.try_recv() {
             let final_block = block.final_block;
@@ -461,8 +478,12 @@ impl AudioSnapshotPublisher {
                         Arc::from(self.chunks.clone()),
                     ));
                     self.committed_chunks = self.chunks.clone();
+                    self.manifest.recover_saturation();
                 }
                 AudioUpdateKind::Install(prepared_revision) => {
+                    // Preparation and process commands use different transports. The command can
+                    // arrive after this pump's initial prepared drain, so close that race here.
+                    self.drain_prepared();
                     if let Some(prepared) = self.prepared_by_revision.remove(&prepared_revision) {
                         self.chunks = prepared.chunks.to_vec();
                         self.manifest.publish(AudioContentSnapshot::new(
@@ -473,6 +494,7 @@ impl AudioSnapshotPublisher {
                             prepared.chunks,
                         ));
                         self.committed_chunks = self.chunks.clone();
+                        self.manifest.recover_saturation();
                     }
                 }
             }
@@ -480,10 +502,6 @@ impl AudioSnapshotPublisher {
                 .try_send(block)
                 .expect("return queue capacity matches the transport pool");
             processed += 1;
-        }
-        if let Some(resources) = retired_resources {
-            drop(resources);
-            self.retired = true;
         }
         processed
     }
@@ -609,6 +627,22 @@ mod tests {
     }
 
     #[test]
+    fn install_closes_the_cross_transport_preparation_race() {
+        let (mut writer, control, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
+        publisher.drain_prepared();
+        let token = control
+            .prepare(&[7.0, 8.0], ContentMutation::Loading)
+            .expect("prepare after the initial drain");
+        assert!(writer.install_prepared(token));
+        assert_eq!(publisher.pump_updates(), 1);
+        assert_eq!(
+            reader.try_current().expect("installed").contiguous(),
+            vec![7.0, 8.0]
+        );
+    }
+
+    #[test]
     fn cancelled_private_work_is_reset_from_the_committed_generation() {
         let (mut writer, _control, mut publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 6);
@@ -658,16 +692,98 @@ mod tests {
     }
 
     #[test]
+    fn clear_keeps_retained_readers_and_publishes_a_newer_complete_revision() {
+        let (mut writer, _control, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 6);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        let loaded = writer
+            .publish_range(0, &[1.0, 2.0, 3.0], 3, true)
+            .expect("load across chunk boundary");
+        writer.finish_mutation(false);
+        publisher.pump();
+        let retained = reader.latest().snapshot;
+
+        assert!(writer.begin_mutation(ContentMutation::Clearing));
+        assert!(writer.begin_working_generation());
+        let cleared = writer.publish_silence(3).expect("clear generation");
+        writer.finish_mutation(false);
+        publisher.pump();
+
+        assert!(cleared > loaded);
+        assert_eq!(retained.contiguous(), vec![1.0, 2.0, 3.0]);
+        assert_eq!(
+            reader.try_current().expect("cleared current").contiguous(),
+            vec![0.0, 0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn rapid_load_clear_replace_and_slow_readers_converge() {
+        use std::collections::VecDeque;
+
+        let (mut writer, control, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 8);
+        let mut retained = VecDeque::new();
+        for generation in 0..1_000_u32 {
+            let prepared = control
+                .prepare(&[generation as f32; 9], ContentMutation::Loading)
+                .expect("prepare load");
+            assert!(writer.install_prepared(prepared));
+            publisher.pump();
+
+            assert!(writer.begin_mutation(ContentMutation::Replacing));
+            assert!(writer.begin_working_generation());
+            writer
+                .publish_range(4, &[generation as f32 + 0.5], 9, false)
+                .expect("private replacement");
+            if generation % 2 == 0 {
+                writer.finish_mutation(true);
+            } else {
+                writer.cancel_mutation();
+            }
+            publisher.pump();
+
+            if generation % 5 == 0 {
+                assert!(writer.begin_mutation(ContentMutation::Clearing));
+                assert!(writer.begin_working_generation());
+                writer.publish_silence(9).expect("clear");
+                writer.finish_mutation(false);
+                publisher.pump();
+            }
+
+            retained.push_back(reader.latest().snapshot);
+            if retained.len() > 64 {
+                retained.pop_front();
+            }
+        }
+        let current = reader.try_current().expect("stress converged");
+        assert_eq!(current.metadata.length, 9);
+        assert_eq!(retained.len(), 64);
+    }
+
+    #[test]
     fn saturation_keeps_the_last_complete_snapshot() {
-        let (mut writer, _control, _publisher, reader) =
+        let (mut writer, control, mut publisher, reader) =
             audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 1);
         assert!(writer.begin_mutation(ContentMutation::Recording));
         assert!(writer.publish_range(0, &[1.0, 2.0], 2, true).is_some());
         assert!(writer.publish_range(2, &[3.0], 3, true).is_none());
+        publisher.pump();
+        writer.finish_mutation(false);
         assert!(matches!(
             reader.latest().currentness,
             SnapshotCurrentness::Stale(StaleReason::PublicationSaturated)
         ));
-        assert!(reader.latest().snapshot.contiguous().is_empty());
+        assert_eq!(reader.latest().snapshot.contiguous(), vec![1.0, 2.0]);
+
+        let prepared = control
+            .prepare(&[1.0, 2.0, 3.0], ContentMutation::Loading)
+            .expect("explicit full-generation recovery");
+        assert!(writer.install_prepared(prepared));
+        publisher.pump();
+        assert_eq!(
+            reader.try_current().expect("recovered").contiguous(),
+            vec![1.0, 2.0, 3.0]
+        );
     }
 }

--- a/src/rust/shoop_engine/src/content_snapshot/audio.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/audio.rs
@@ -1,0 +1,333 @@
+use super::manifest::{manifest_pair, ManifestPublisher, ManifestReader};
+use super::transport::{bounded_transport, ProcessSender, PublisherReceiver};
+use super::{
+    AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision, ContentStatus,
+    SessionContentEpoch,
+};
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct AudioUpdateBlock {
+    samples: Box<[f32]>,
+    offset: usize,
+    used: usize,
+    total_length: usize,
+    revision: ContentRevision,
+    final_block: bool,
+    publish: bool,
+}
+
+impl AudioUpdateBlock {
+    fn new(chunk_size: usize) -> Self {
+        Self {
+            samples: vec![0.0; chunk_size].into_boxed_slice(),
+            offset: 0,
+            used: 0,
+            total_length: 0,
+            revision: ContentRevision(0),
+            final_block: false,
+            publish: false,
+        }
+    }
+}
+
+pub struct AudioProcessSnapshotWriter {
+    updates: ProcessSender<AudioUpdateBlock>,
+    returned: PublisherReceiver<AudioUpdateBlock>,
+    free: Vec<AudioUpdateBlock>,
+    status: Arc<ContentStatus>,
+    latest_revision: ContentRevision,
+    latest_length: usize,
+    block_size: usize,
+}
+
+pub struct AudioSnapshotPublisher {
+    updates: PublisherReceiver<AudioUpdateBlock>,
+    returned: ProcessSender<AudioUpdateBlock>,
+    manifest: ManifestPublisher<AudioContentSnapshot>,
+    chunks: Vec<Arc<[f32]>>,
+    chunk_size: usize,
+}
+
+pub type AudioSnapshotReader = ManifestReader<AudioContentSnapshot>;
+
+pub fn audio_snapshot_channel(
+    epoch: Arc<SessionContentEpoch>,
+    chunk_size: usize,
+    transport_blocks: usize,
+) -> (
+    AudioProcessSnapshotWriter,
+    AudioSnapshotPublisher,
+    AudioSnapshotReader,
+) {
+    assert!(chunk_size > 0, "audio snapshot chunk size must be non-zero");
+    assert!(
+        transport_blocks > 0,
+        "audio snapshot transport must have blocks"
+    );
+    let status = Arc::new(ContentStatus::new(epoch));
+    let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let initial = AudioContentSnapshot::new(
+        ContentRevision(0),
+        AudioSnapshotMetadata { length: 0 },
+        Arc::from([]),
+    );
+    let (manifest, reader) = manifest_pair(initial, Arc::clone(&status));
+    let mut free = Vec::with_capacity(transport_blocks);
+    for _ in 0..transport_blocks {
+        free.push(AudioUpdateBlock::new(chunk_size));
+    }
+    (
+        AudioProcessSnapshotWriter {
+            updates: updates_tx,
+            returned: returned_rx,
+            free,
+            status,
+            latest_revision: ContentRevision(0),
+            latest_length: 0,
+            block_size: chunk_size,
+        },
+        AudioSnapshotPublisher {
+            updates: updates_rx,
+            returned: returned_tx,
+            manifest,
+            chunks: Vec::new(),
+            chunk_size,
+        },
+        reader,
+    )
+}
+
+impl AudioProcessSnapshotWriter {
+    pub fn begin_mutation(&self, mutation: ContentMutation) -> bool {
+        self.status.begin_mutation(mutation)
+    }
+
+    fn reclaim(&mut self) {
+        while let Some(block) = self.returned.try_recv() {
+            self.free.push(block);
+        }
+    }
+
+    pub fn publish_range(
+        &mut self,
+        offset: usize,
+        samples: &[f32],
+        total_length: usize,
+        publish: bool,
+    ) -> Option<ContentRevision> {
+        self.reclaim();
+        let n_blocks = samples.len().max(1).div_ceil(self.block_size);
+        if self.free.len() < n_blocks || self.updates.slots() < n_blocks {
+            self.status.mark_saturated();
+            return None;
+        }
+        let revision = self.status.next_revision();
+        let block_size = self.block_size;
+        if samples.is_empty() {
+            let mut block = self.free.pop().expect("capacity checked");
+            block.offset = offset;
+            block.used = 0;
+            block.total_length = total_length;
+            block.revision = revision;
+            block.final_block = true;
+            block.publish = publish;
+            if let Err(block) = self.updates.try_send(block) {
+                self.free.push(block);
+                return None;
+            }
+        } else {
+            for (index, source) in samples.chunks(block_size).enumerate() {
+                let mut block = self.free.pop().expect("capacity checked");
+                block.samples[..source.len()].copy_from_slice(source);
+                block.offset = offset + index * block_size;
+                block.used = source.len();
+                block.total_length = total_length;
+                block.revision = revision;
+                block.final_block = index + 1 == n_blocks;
+                block.publish = publish;
+                if let Err(block) = self.updates.try_send(block) {
+                    self.free.push(block);
+                    self.status.mark_saturated();
+                    return None;
+                }
+            }
+        }
+        self.latest_revision = revision;
+        self.latest_length = total_length;
+        Some(revision)
+    }
+
+    pub fn finish_mutation(&mut self, publish_final: bool) -> ContentRevision {
+        if publish_final {
+            let _ = self.publish_range(self.latest_length, &[], self.latest_length, true);
+        }
+        self.status.finish_mutation(self.latest_revision);
+        self.latest_revision
+    }
+
+    pub fn cancel_mutation(&self) {
+        self.status.cancel_mutation();
+    }
+
+    pub fn status(&self) -> &Arc<ContentStatus> {
+        &self.status
+    }
+}
+
+impl AudioSnapshotPublisher {
+    pub fn pump(&mut self) -> usize {
+        let mut processed = 0;
+        while let Some(block) = self.updates.try_recv() {
+            self.apply(&block);
+            let final_block = block.final_block;
+            let publish = block.publish;
+            let revision = block.revision;
+            let length = block.total_length;
+            self.returned
+                .try_send(block)
+                .expect("return queue capacity matches the transport pool");
+            if final_block && publish {
+                self.manifest.publish(AudioContentSnapshot::new(
+                    revision,
+                    AudioSnapshotMetadata { length },
+                    Arc::from(self.chunks.clone()),
+                ));
+            }
+            processed += 1;
+        }
+        processed
+    }
+
+    fn apply(&mut self, block: &AudioUpdateBlock) {
+        if block.used == 0 {
+            self.truncate(block.total_length);
+            return;
+        }
+        let end = block.offset + block.used;
+        let needed = end.div_ceil(self.chunk_size);
+        while self.chunks.len() < needed {
+            self.chunks
+                .push(Arc::from(vec![0.0; self.chunk_size].into_boxed_slice()));
+        }
+        let mut source_offset = 0;
+        let mut destination_offset = block.offset;
+        while source_offset < block.used {
+            let chunk_index = destination_offset / self.chunk_size;
+            let chunk_offset = destination_offset % self.chunk_size;
+            let count = (self.chunk_size - chunk_offset).min(block.used - source_offset);
+            let mut updated = self.chunks[chunk_index].to_vec();
+            updated[chunk_offset..chunk_offset + count]
+                .copy_from_slice(&block.samples[source_offset..source_offset + count]);
+            self.chunks[chunk_index] = Arc::from(updated.into_boxed_slice());
+            source_offset += count;
+            destination_offset += count;
+        }
+        self.truncate(block.total_length);
+    }
+
+    fn truncate(&mut self, length: usize) {
+        self.chunks.truncate(length.div_ceil(self.chunk_size));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content_snapshot::{CurrentDataError, SnapshotCurrentness, StaleReason};
+
+    #[test]
+    fn recording_publishes_only_complete_process_updates() {
+        let (mut writer, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        let first = writer
+            .publish_range(0, &[1.0, 2.0, 3.0], 3, true)
+            .expect("first update");
+        assert_eq!(reader.latest().snapshot.revision, ContentRevision(0));
+        assert_eq!(publisher.pump(), 1);
+        let read = reader.latest();
+        assert_eq!(read.snapshot.revision, first);
+        assert_eq!(read.snapshot.contiguous(), vec![1.0, 2.0, 3.0]);
+        assert_eq!(
+            read.currentness,
+            SnapshotCurrentness::Stale(StaleReason::MutationActive(ContentMutation::Recording))
+        );
+
+        let second = writer
+            .publish_range(3, &[4.0, 5.0], 5, true)
+            .expect("second update");
+        assert_eq!(publisher.pump(), 1);
+        assert_eq!(reader.latest().snapshot.revision, second);
+        assert_eq!(
+            reader.latest().snapshot.contiguous(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn exact_read_waits_for_final_publication_after_recording() {
+        let (mut writer, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        let revision = writer
+            .publish_range(0, &[1.0, 2.0], 2, true)
+            .expect("record update");
+        writer.finish_mutation(false);
+        assert_eq!(
+            reader.try_current().unwrap_err(),
+            CurrentDataError::PublicationPending {
+                settled: revision,
+                published: ContentRevision(0),
+            }
+        );
+        publisher.pump();
+        assert_eq!(
+            reader.try_current().expect("settled").contiguous(),
+            vec![1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn hidden_working_generation_replaces_the_visible_snapshot_at_commit() {
+        let (mut writer, mut publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        writer.publish_range(0, &[1.0, 2.0, 3.0, 4.0], 4, true);
+        writer.finish_mutation(false);
+        publisher.pump();
+        assert_eq!(
+            reader.latest().snapshot.contiguous(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+
+        assert!(writer.begin_mutation(ContentMutation::Replacing));
+        writer.publish_range(1, &[9.0, 8.0], 4, false);
+        publisher.pump();
+        assert_eq!(
+            reader.latest().snapshot.contiguous(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        writer.finish_mutation(true);
+        publisher.pump();
+        assert_eq!(
+            reader.latest().snapshot.contiguous(),
+            vec![1.0, 9.0, 8.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn saturation_keeps_the_last_complete_snapshot() {
+        let (mut writer, _publisher, reader) =
+            audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 1);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        assert!(writer.publish_range(0, &[1.0, 2.0], 2, true).is_some());
+        assert!(writer.publish_range(2, &[3.0], 3, true).is_none());
+        assert!(matches!(
+            reader.latest().currentness,
+            SnapshotCurrentness::Stale(StaleReason::PublicationSaturated)
+        ));
+        assert!(reader.latest().snapshot.contiguous().is_empty());
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/contracts.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/contracts.rs
@@ -2,7 +2,7 @@ use crate::midi_event::MidiEvent;
 use std::sync::Arc;
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ContentRevision(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/rust/shoop_engine/src/content_snapshot/contracts.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/contracts.rs
@@ -1,0 +1,193 @@
+use crate::midi_event::MidiEvent;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct ContentRevision(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ContentMutation {
+    Recording = 1,
+    PreRecording = 2,
+    Replacing = 3,
+    Loading = 4,
+    Clearing = 5,
+    RingbufferAdoption = 6,
+}
+
+impl ContentMutation {
+    pub(super) fn from_raw(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Recording),
+            2 => Some(Self::PreRecording),
+            3 => Some(Self::Replacing),
+            4 => Some(Self::Loading),
+            5 => Some(Self::Clearing),
+            6 => Some(Self::RingbufferAdoption),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaleReason {
+    MutationActive(ContentMutation),
+    PublicationPending {
+        settled: ContentRevision,
+        published: ContentRevision,
+    },
+    PublicationSaturated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotCurrentness {
+    Current,
+    Stale(StaleReason),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CurrentDataError {
+    #[error("channel content is changing: {0:?}")]
+    MutationActive(ContentMutation),
+    #[error(
+        "settled content revision {settled:?} has not been published; latest is {published:?}"
+    )]
+    PublicationPending {
+        settled: ContentRevision,
+        published: ContentRevision,
+    },
+    #[error("channel content publication saturated")]
+    PublicationSaturated,
+}
+
+impl From<StaleReason> for CurrentDataError {
+    fn from(value: StaleReason) -> Self {
+        match value {
+            StaleReason::MutationActive(mutation) => Self::MutationActive(mutation),
+            StaleReason::PublicationPending { settled, published } => {
+                Self::PublicationPending { settled, published }
+            }
+            StaleReason::PublicationSaturated => Self::PublicationSaturated,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AudioSnapshotMetadata {
+    pub length: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioContentSnapshot {
+    pub revision: ContentRevision,
+    pub metadata: AudioSnapshotMetadata,
+    chunks: Arc<[Arc<[f32]>]>,
+}
+
+impl AudioContentSnapshot {
+    pub fn new(
+        revision: ContentRevision,
+        metadata: AudioSnapshotMetadata,
+        chunks: Arc<[Arc<[f32]>]>,
+    ) -> Self {
+        Self {
+            revision,
+            metadata,
+            chunks,
+        }
+    }
+
+    pub fn chunks(&self) -> &[Arc<[f32]>] {
+        &self.chunks
+    }
+
+    pub fn samples(&self) -> impl Iterator<Item = f32> + '_ {
+        self.chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter().copied())
+            .take(self.metadata.length)
+    }
+
+    pub fn contiguous(&self) -> Vec<f32> {
+        self.samples().collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MidiSnapshotMetadata {
+    pub length: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct MidiContentSnapshot {
+    pub revision: ContentRevision,
+    pub metadata: MidiSnapshotMetadata,
+    chunks: Arc<[Arc<[MidiEvent]>]>,
+}
+
+impl MidiContentSnapshot {
+    pub fn new(
+        revision: ContentRevision,
+        metadata: MidiSnapshotMetadata,
+        chunks: Arc<[Arc<[MidiEvent]>]>,
+    ) -> Self {
+        Self {
+            revision,
+            metadata,
+            chunks,
+        }
+    }
+
+    pub fn chunks(&self) -> &[Arc<[MidiEvent]>] {
+        &self.chunks
+    }
+
+    pub fn events(&self) -> impl Iterator<Item = &MidiEvent> {
+        self.chunks.iter().flat_map(|chunk| chunk.iter())
+    }
+
+    pub fn contiguous(&self) -> Vec<MidiEvent> {
+        self.events().cloned().collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SnapshotRead<T> {
+    pub snapshot: Arc<T>,
+    pub currentness: SnapshotCurrentness,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_snapshot_trims_the_last_chunk_to_metadata_length() {
+        let chunks = Arc::from([
+            Arc::<[f32]>::from([1.0, 2.0]),
+            Arc::<[f32]>::from([3.0, 99.0]),
+        ]);
+        let snapshot = AudioContentSnapshot::new(
+            ContentRevision(4),
+            AudioSnapshotMetadata { length: 3 },
+            chunks,
+        );
+        assert_eq!(snapshot.contiguous(), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn midi_duration_is_independent_of_the_last_event() {
+        let chunks = Arc::from([Arc::<[MidiEvent]>::from([MidiEvent {
+            time: 2,
+            data: vec![0x90, 60, 100],
+        }])]);
+        let snapshot = MidiContentSnapshot::new(
+            ContentRevision(2),
+            MidiSnapshotMetadata { length: 100 },
+            chunks,
+        );
+        assert_eq!(snapshot.metadata.length, 100);
+        assert_eq!(snapshot.events().next().map(|event| event.time), Some(2));
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/manifest.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/manifest.rs
@@ -61,17 +61,13 @@ impl<T: ContentSnapshot> ManifestPublisher<T> {
         self.shared.current.store(Arc::new(snapshot));
         self.shared.status.mark_published(revision);
     }
+
+    pub(crate) fn recover_saturation(&self) {
+        self.shared.status.recover_saturation();
+    }
 }
 
 impl<T: ContentSnapshot> ManifestReader<T> {
-    pub fn begin_mutation(&self, mutation: super::ContentMutation) -> bool {
-        self.shared.status.begin_mutation(mutation)
-    }
-
-    pub fn cancel_mutation(&self) {
-        self.shared.status.cancel_mutation();
-    }
-
     pub fn latest(&self) -> SnapshotRead<T> {
         SnapshotRead {
             snapshot: self.shared.current.load_full(),

--- a/src/rust/shoop_engine/src/content_snapshot/manifest.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/manifest.rs
@@ -64,6 +64,14 @@ impl<T: ContentSnapshot> ManifestPublisher<T> {
 }
 
 impl<T: ContentSnapshot> ManifestReader<T> {
+    pub fn begin_mutation(&self, mutation: super::ContentMutation) -> bool {
+        self.shared.status.begin_mutation(mutation)
+    }
+
+    pub fn cancel_mutation(&self) {
+        self.shared.status.cancel_mutation();
+    }
+
     pub fn latest(&self) -> SnapshotRead<T> {
         SnapshotRead {
             snapshot: self.shared.current.load_full(),

--- a/src/rust/shoop_engine/src/content_snapshot/manifest.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/manifest.rs
@@ -1,0 +1,175 @@
+use super::{
+    AudioContentSnapshot, ContentRevision, ContentStatus, CurrentDataError, MidiContentSnapshot,
+    SnapshotCurrentness, SnapshotRead,
+};
+use arc_swap::ArcSwap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+pub trait ContentSnapshot: Send + Sync + 'static {
+    fn revision(&self) -> ContentRevision;
+}
+
+impl ContentSnapshot for AudioContentSnapshot {
+    fn revision(&self) -> ContentRevision {
+        self.revision
+    }
+}
+
+impl ContentSnapshot for MidiContentSnapshot {
+    fn revision(&self) -> ContentRevision {
+        self.revision
+    }
+}
+
+struct SharedManifest<T> {
+    current: ArcSwap<T>,
+    status: Arc<ContentStatus>,
+    acknowledged_revision: AtomicU64,
+}
+
+pub struct ManifestPublisher<T> {
+    shared: Arc<SharedManifest<T>>,
+}
+
+#[derive(Clone)]
+pub struct ManifestReader<T> {
+    shared: Arc<SharedManifest<T>>,
+}
+
+pub fn manifest_pair<T: ContentSnapshot>(
+    initial: T,
+    status: Arc<ContentStatus>,
+) -> (ManifestPublisher<T>, ManifestReader<T>) {
+    status.mark_published(initial.revision());
+    let shared = Arc::new(SharedManifest {
+        current: ArcSwap::from_pointee(initial),
+        status,
+        acknowledged_revision: AtomicU64::new(0),
+    });
+    (
+        ManifestPublisher {
+            shared: Arc::clone(&shared),
+        },
+        ManifestReader { shared },
+    )
+}
+
+impl<T: ContentSnapshot> ManifestPublisher<T> {
+    pub fn publish(&self, snapshot: T) {
+        let revision = snapshot.revision();
+        self.shared.current.store(Arc::new(snapshot));
+        self.shared.status.mark_published(revision);
+    }
+}
+
+impl<T: ContentSnapshot> ManifestReader<T> {
+    pub fn latest(&self) -> SnapshotRead<T> {
+        SnapshotRead {
+            snapshot: self.shared.current.load_full(),
+            currentness: self.shared.status.currentness(),
+        }
+    }
+
+    pub fn try_current(&self) -> Result<Arc<T>, CurrentDataError> {
+        let required = self.shared.status.require_current()?;
+        let snapshot = self.shared.current.load_full();
+        if snapshot.revision() < required {
+            return Err(CurrentDataError::PublicationPending {
+                settled: required,
+                published: snapshot.revision(),
+            });
+        }
+        Ok(snapshot)
+    }
+
+    pub fn acknowledge(&self, revision: ContentRevision) {
+        self.shared
+            .acknowledged_revision
+            .fetch_max(revision.0, Ordering::Release);
+    }
+
+    pub fn acknowledged_revision(&self) -> ContentRevision {
+        ContentRevision(self.shared.acknowledged_revision.load(Ordering::Acquire))
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.shared.current.load().revision().0 > self.acknowledged_revision().0
+    }
+
+    pub fn currentness(&self) -> SnapshotCurrentness {
+        self.shared.status.currentness()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content_snapshot::{
+        AudioSnapshotMetadata, ContentMutation, SessionContentEpoch, StaleReason,
+    };
+
+    fn audio(revision: u64, samples: &[f32]) -> AudioContentSnapshot {
+        AudioContentSnapshot::new(
+            ContentRevision(revision),
+            AudioSnapshotMetadata {
+                length: samples.len(),
+            },
+            Arc::from([Arc::<[f32]>::from(samples)]),
+        )
+    }
+
+    #[test]
+    fn latest_retains_a_complete_older_manifest_during_mutation() {
+        let status = Arc::new(ContentStatus::new(Arc::new(SessionContentEpoch::default())));
+        let (publisher, reader) = manifest_pair(audio(0, &[]), Arc::clone(&status));
+        publisher.publish(audio(1, &[1.0, 2.0]));
+        status.mark_published(ContentRevision(1));
+        assert!(status.begin_mutation(ContentMutation::Recording));
+
+        let read = reader.latest();
+        assert_eq!(read.snapshot.contiguous(), vec![1.0, 2.0]);
+        assert_eq!(
+            read.currentness,
+            SnapshotCurrentness::Stale(StaleReason::MutationActive(ContentMutation::Recording))
+        );
+    }
+
+    #[test]
+    fn acknowledging_a_delivered_revision_does_not_hide_a_newer_one() {
+        let status = Arc::new(ContentStatus::new(Arc::new(SessionContentEpoch::default())));
+        let (publisher, reader) = manifest_pair(audio(0, &[]), Arc::clone(&status));
+        publisher.publish(audio(1, &[1.0]));
+        let delivered = reader.latest();
+        publisher.publish(audio(2, &[2.0]));
+
+        reader.acknowledge(delivered.snapshot.revision);
+        assert_eq!(reader.acknowledged_revision(), ContentRevision(1));
+        assert!(reader.is_dirty());
+    }
+
+    #[test]
+    fn exact_read_requires_the_settled_revision_to_be_published() {
+        let status = Arc::new(ContentStatus::new(Arc::new(SessionContentEpoch::default())));
+        let (publisher, reader) = manifest_pair(audio(0, &[]), Arc::clone(&status));
+        assert!(status.begin_mutation(ContentMutation::Loading));
+        let revision = status.next_revision();
+        status.finish_mutation(revision);
+        assert_eq!(
+            reader.try_current().unwrap_err(),
+            CurrentDataError::PublicationPending {
+                settled: revision,
+                published: ContentRevision(0),
+            }
+        );
+
+        publisher.publish(audio(revision.0, &[4.0]));
+        assert_eq!(
+            reader
+                .try_current()
+                .expect("published current")
+                .contiguous(),
+            vec![4.0]
+        );
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/midi.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/midi.rs
@@ -419,6 +419,14 @@ impl MidiProcessSnapshotWriter {
 }
 
 impl MidiSnapshotControl {
+    pub fn begin_mutation(&self, mutation: ContentMutation) -> bool {
+        self.status.begin_mutation(mutation)
+    }
+
+    pub fn cancel_mutation(&self) {
+        self.status.cancel_mutation();
+    }
+
     pub fn prepare(
         &self,
         events: &[MidiEvent],
@@ -460,13 +468,30 @@ impl MidiSnapshotPublisher {
 
     pub fn pump(&mut self) -> usize {
         let retired_resources = self.retirement.try_recv();
+        self.drain_prepared();
+        let processed = self.pump_updates();
+        if let Some(resources) = retired_resources {
+            drop(resources);
+            self.retired = true;
+        }
+        processed
+    }
+
+    fn drain_prepared(&mut self) {
         while let Ok(prepared) = self.prepared.try_recv() {
             self.prepared_by_revision
                 .insert(prepared.token.revision, prepared);
         }
+    }
+
+    fn pump_updates(&mut self) -> usize {
         let mut processed = 0;
         while let Some(block) = self.updates.try_recv() {
             let mut installed = false;
+            let recovers_saturation = matches!(
+                block.kind,
+                MidiUpdateKind::Clear | MidiUpdateKind::Install(_)
+            );
             match block.kind {
                 MidiUpdateKind::BeginWorking => {
                     self.events.clone_from(&self.committed_events);
@@ -482,6 +507,9 @@ impl MidiSnapshotPublisher {
                 }
                 MidiUpdateKind::Publish => {}
                 MidiUpdateKind::Install(prepared_revision) => {
+                    // Preparation and process commands use different transports. The command can
+                    // arrive after this pump's initial prepared drain, so close that race here.
+                    self.drain_prepared();
                     if let Some(prepared) = self.prepared_by_revision.remove(&prepared_revision) {
                         self.events = prepared
                             .chunks
@@ -496,6 +524,7 @@ impl MidiSnapshotPublisher {
                             },
                             prepared.chunks,
                         ));
+                        self.manifest.recover_saturation();
                         installed = true;
                     }
                 }
@@ -519,12 +548,11 @@ impl MidiSnapshotPublisher {
                     Arc::from(chunks),
                 ));
                 self.committed_events.clone_from(&self.events);
+                if recovers_saturation {
+                    self.manifest.recover_saturation();
+                }
             }
             processed += 1;
-        }
-        if let Some(resources) = retired_resources {
-            drop(resources);
-            self.retired = true;
         }
         processed
     }
@@ -617,6 +645,23 @@ mod tests {
     }
 
     #[test]
+    fn midi_install_closes_the_cross_transport_preparation_race() {
+        let (mut writer, control, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
+        publisher.drain_prepared();
+        let token = control
+            .prepare(
+                &[MidiEvent::new(1, vec![0x90, 60, 100])],
+                8,
+                ContentMutation::Loading,
+            )
+            .expect("prepare after the initial drain");
+        assert!(writer.install_prepared(token));
+        assert_eq!(publisher.pump_updates(), 1);
+        assert_eq!(reader.try_current().expect("installed").events().count(), 1);
+    }
+
+    #[test]
     fn cancelled_midi_work_is_reset_before_the_next_generation() {
         let (mut writer, _control, mut publisher, reader) =
             midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 6);
@@ -645,6 +690,76 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![1, 3]
         );
+    }
+
+    #[test]
+    fn payload_boundaries_partial_publication_and_clear_are_deterministic() {
+        let (mut writer, _control, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 6);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        writer
+            .append_raw_event(1, &[0xf0, 1, 2, 3], 8, false)
+            .expect("maximum payload");
+        publisher.pump();
+        assert!(reader.latest().snapshot.events().next().is_none());
+        assert!(writer
+            .append_raw_event(2, &[0xf0, 1, 2, 3, 4], 8, true)
+            .is_none());
+        let published = writer
+            .append_raw_event(3, &[0x90, 60, 100], 8, true)
+            .expect("valid payload after rejection");
+        writer.finish_mutation(false);
+        publisher.pump();
+        let retained = reader.latest().snapshot;
+        assert_eq!(retained.revision, published);
+        assert_eq!(
+            retained
+                .events()
+                .map(|event| event.time)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+
+        assert!(writer.begin_mutation(ContentMutation::Clearing));
+        assert!(writer.begin_working_generation());
+        let cleared = writer.clear(true).expect("clear");
+        writer.finish_mutation(false);
+        publisher.pump();
+        assert!(cleared > published);
+        assert_eq!(retained.events().count(), 2);
+        let current = reader.try_current().expect("clear settled");
+        assert_eq!(current.metadata.length, 0);
+        assert_eq!(current.events().count(), 0);
+    }
+
+    #[test]
+    fn midi_saturation_is_sticky_until_a_full_clear_recovers() {
+        let (mut writer, _control, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 1, 1);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        writer
+            .append_storage_events(&[event(1, &[0x90, 60, 100])], 4, true)
+            .expect("first block");
+        assert!(writer
+            .append_storage_events(&[event(2, &[0x80, 60, 0])], 4, true)
+            .is_none());
+        publisher.pump();
+        writer.finish_mutation(false);
+        assert!(matches!(
+            reader.latest().currentness,
+            SnapshotCurrentness::Stale(StaleReason::PublicationSaturated)
+        ));
+
+        assert!(writer.begin_mutation(ContentMutation::Clearing));
+        writer.clear(true).expect("full clear recovery");
+        writer.finish_mutation(false);
+        publisher.pump();
+        assert!(reader
+            .try_current()
+            .expect("recovered")
+            .events()
+            .next()
+            .is_none());
     }
 
     #[test]

--- a/src/rust/shoop_engine/src/content_snapshot/midi.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/midi.rs
@@ -1,0 +1,428 @@
+use super::manifest::{manifest_pair, ManifestPublisher, ManifestReader};
+use super::transport::{bounded_transport, ProcessSender, PublisherReceiver};
+use super::{
+    ContentMutation, ContentRevision, ContentStatus, MidiContentSnapshot, MidiSnapshotMetadata,
+    SessionContentEpoch,
+};
+use crate::midi_event::MidiEvent;
+use crate::midi_storage::{MidiStorageElem, MAX_MSG_BYTES};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, Default)]
+struct WireMidiEvent {
+    time: i32,
+    size: u8,
+    data: [u8; MAX_MSG_BYTES],
+}
+
+impl WireMidiEvent {
+    fn set(&mut self, time: i32, data: &[u8]) -> bool {
+        if data.is_empty() || data.len() > MAX_MSG_BYTES {
+            return false;
+        }
+        self.time = time;
+        self.size = data.len() as u8;
+        self.data[..data.len()].copy_from_slice(data);
+        true
+    }
+
+    fn event(&self) -> MidiEvent {
+        MidiEvent {
+            time: self.time,
+            data: self.data[..self.size as usize].to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MidiUpdateKind {
+    Append,
+    Clear,
+    TruncateAfter(i32),
+    Publish,
+}
+
+#[derive(Debug)]
+struct MidiUpdateBlock {
+    events: Box<[WireMidiEvent]>,
+    used: usize,
+    kind: MidiUpdateKind,
+    total_length: u32,
+    revision: ContentRevision,
+    final_block: bool,
+    publish: bool,
+}
+
+impl MidiUpdateBlock {
+    fn new(block_events: usize) -> Self {
+        Self {
+            events: vec![WireMidiEvent::default(); block_events].into_boxed_slice(),
+            used: 0,
+            kind: MidiUpdateKind::Publish,
+            total_length: 0,
+            revision: ContentRevision(0),
+            final_block: false,
+            publish: false,
+        }
+    }
+}
+
+pub struct MidiProcessSnapshotWriter {
+    updates: ProcessSender<MidiUpdateBlock>,
+    returned: PublisherReceiver<MidiUpdateBlock>,
+    free: Vec<MidiUpdateBlock>,
+    status: Arc<ContentStatus>,
+    latest_revision: ContentRevision,
+    latest_length: u32,
+    block_events: usize,
+}
+
+pub struct MidiSnapshotPublisher {
+    updates: PublisherReceiver<MidiUpdateBlock>,
+    returned: ProcessSender<MidiUpdateBlock>,
+    manifest: ManifestPublisher<MidiContentSnapshot>,
+    events: Vec<MidiEvent>,
+    snapshot_chunk_events: usize,
+}
+
+pub type MidiSnapshotReader = ManifestReader<MidiContentSnapshot>;
+
+pub fn midi_snapshot_channel(
+    epoch: Arc<SessionContentEpoch>,
+    block_events: usize,
+    transport_blocks: usize,
+) -> (
+    MidiProcessSnapshotWriter,
+    MidiSnapshotPublisher,
+    MidiSnapshotReader,
+) {
+    assert!(block_events > 0, "MIDI snapshot block must hold events");
+    assert!(
+        transport_blocks > 0,
+        "MIDI snapshot transport must have blocks"
+    );
+    let status = Arc::new(ContentStatus::new(epoch));
+    let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let initial = MidiContentSnapshot::new(
+        ContentRevision(0),
+        MidiSnapshotMetadata { length: 0 },
+        Arc::from([]),
+    );
+    let (manifest, reader) = manifest_pair(initial, Arc::clone(&status));
+    let mut free = Vec::with_capacity(transport_blocks);
+    for _ in 0..transport_blocks {
+        free.push(MidiUpdateBlock::new(block_events));
+    }
+    (
+        MidiProcessSnapshotWriter {
+            updates: updates_tx,
+            returned: returned_rx,
+            free,
+            status,
+            latest_revision: ContentRevision(0),
+            latest_length: 0,
+            block_events,
+        },
+        MidiSnapshotPublisher {
+            updates: updates_rx,
+            returned: returned_tx,
+            manifest,
+            events: Vec::new(),
+            snapshot_chunk_events: block_events,
+        },
+        reader,
+    )
+}
+
+impl MidiProcessSnapshotWriter {
+    pub fn begin_mutation(&self, mutation: ContentMutation) -> bool {
+        self.status.begin_mutation(mutation)
+    }
+
+    fn reclaim(&mut self) {
+        while let Some(block) = self.returned.try_recv() {
+            self.free.push(block);
+        }
+    }
+
+    fn reserve_blocks(&mut self, count: usize) -> bool {
+        self.reclaim();
+        if self.free.len() < count || self.updates.slots() < count {
+            self.status.mark_saturated();
+            return false;
+        }
+        true
+    }
+
+    pub fn append_storage_events(
+        &mut self,
+        events: &[MidiStorageElem],
+        total_length: u32,
+        publish: bool,
+    ) -> Option<ContentRevision> {
+        let count = events.len().max(1).div_ceil(self.block_events);
+        if !self.reserve_blocks(count) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        if events.is_empty() {
+            self.send_control(MidiUpdateKind::Append, total_length, revision, publish)?;
+        } else {
+            for (index, source) in events.chunks(self.block_events).enumerate() {
+                let mut block = self.free.pop().expect("capacity checked");
+                for (destination, event) in block.events.iter_mut().zip(source) {
+                    destination.set(event.time as i32, event.data());
+                }
+                block.used = source.len();
+                block.kind = MidiUpdateKind::Append;
+                block.total_length = total_length;
+                block.revision = revision;
+                block.final_block = index + 1 == count;
+                block.publish = publish;
+                if let Err(block) = self.updates.try_send(block) {
+                    self.free.push(block);
+                    self.status.mark_saturated();
+                    return None;
+                }
+            }
+        }
+        self.latest_revision = revision;
+        self.latest_length = total_length;
+        Some(revision)
+    }
+
+    pub fn append_raw_event(
+        &mut self,
+        time: i32,
+        data: &[u8],
+        total_length: u32,
+        publish: bool,
+    ) -> Option<ContentRevision> {
+        if !self.reserve_blocks(1) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        let mut block = self.free.pop().expect("capacity checked");
+        if !block.events[0].set(time, data) {
+            self.free.push(block);
+            return None;
+        }
+        block.used = 1;
+        block.kind = MidiUpdateKind::Append;
+        block.total_length = total_length;
+        block.revision = revision;
+        block.final_block = true;
+        block.publish = publish;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            return None;
+        }
+        self.latest_revision = revision;
+        self.latest_length = total_length;
+        Some(revision)
+    }
+
+    pub fn clear(&mut self, publish: bool) -> Option<ContentRevision> {
+        if !self.reserve_blocks(1) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        self.send_control(MidiUpdateKind::Clear, 0, revision, publish)?;
+        self.latest_revision = revision;
+        self.latest_length = 0;
+        Some(revision)
+    }
+
+    pub fn truncate_after(
+        &mut self,
+        time: i32,
+        total_length: u32,
+        publish: bool,
+    ) -> Option<ContentRevision> {
+        if !self.reserve_blocks(1) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        self.send_control(
+            MidiUpdateKind::TruncateAfter(time),
+            total_length,
+            revision,
+            publish,
+        )?;
+        self.latest_revision = revision;
+        self.latest_length = total_length;
+        Some(revision)
+    }
+
+    fn send_control(
+        &mut self,
+        kind: MidiUpdateKind,
+        total_length: u32,
+        revision: ContentRevision,
+        publish: bool,
+    ) -> Option<()> {
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.kind = kind;
+        block.total_length = total_length;
+        block.revision = revision;
+        block.final_block = true;
+        block.publish = publish;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            return None;
+        }
+        Some(())
+    }
+
+    pub fn finish_mutation(&mut self, publish_final: bool) -> ContentRevision {
+        if publish_final && self.reserve_blocks(1) {
+            let revision = self.latest_revision;
+            let _ = self.send_control(MidiUpdateKind::Publish, self.latest_length, revision, true);
+        }
+        self.status.finish_mutation(self.latest_revision);
+        self.latest_revision
+    }
+
+    pub fn cancel_mutation(&self) {
+        self.status.cancel_mutation();
+    }
+}
+
+impl MidiSnapshotPublisher {
+    pub fn pump(&mut self) -> usize {
+        let mut processed = 0;
+        while let Some(block) = self.updates.try_recv() {
+            match block.kind {
+                MidiUpdateKind::Append => {
+                    self.events
+                        .extend(block.events[..block.used].iter().map(WireMidiEvent::event));
+                }
+                MidiUpdateKind::Clear => self.events.clear(),
+                MidiUpdateKind::TruncateAfter(time) => {
+                    self.events
+                        .retain(|event| event.time < 0 || event.time <= time);
+                }
+                MidiUpdateKind::Publish => {}
+            }
+            let final_block = block.final_block;
+            let publish = block.publish;
+            let revision = block.revision;
+            let length = block.total_length;
+            self.returned
+                .try_send(block)
+                .expect("return queue capacity matches the transport pool");
+            if final_block && publish {
+                let chunks: Vec<Arc<[MidiEvent]>> = self
+                    .events
+                    .chunks(self.snapshot_chunk_events)
+                    .map(|events| Arc::from(events))
+                    .collect();
+                self.manifest.publish(MidiContentSnapshot::new(
+                    revision,
+                    MidiSnapshotMetadata { length },
+                    Arc::from(chunks),
+                ));
+            }
+            processed += 1;
+        }
+        processed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content_snapshot::{CurrentDataError, SnapshotCurrentness, StaleReason};
+
+    fn event(time: u32, data: &[u8]) -> MidiStorageElem {
+        MidiStorageElem::new(time, data).expect("valid event")
+    }
+
+    #[test]
+    fn recording_publishes_ordered_complete_event_blocks() {
+        let (mut writer, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 3);
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        let revision = writer
+            .append_storage_events(
+                &[
+                    event(1, &[0x90, 60, 100]),
+                    event(1, &[0x80, 60, 0]),
+                    event(4, &[0x90, 64, 100]),
+                ],
+                8,
+                true,
+            )
+            .expect("event update");
+        assert_eq!(publisher.pump(), 2);
+        let read = reader.latest();
+        assert_eq!(read.snapshot.revision, revision);
+        assert_eq!(
+            read.snapshot
+                .events()
+                .map(|event| event.time)
+                .collect::<Vec<_>>(),
+            vec![1, 1, 4]
+        );
+        assert_eq!(read.snapshot.metadata.length, 8);
+        assert_eq!(
+            read.currentness,
+            SnapshotCurrentness::Stale(StaleReason::MutationActive(ContentMutation::Recording))
+        );
+    }
+
+    #[test]
+    fn exact_midi_requires_final_publication() {
+        let (mut writer, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        let revision = writer
+            .append_raw_event(-1, &[0xb0, 64, 0], 20, true)
+            .expect("state event");
+        writer.finish_mutation(false);
+        assert_eq!(
+            reader.try_current().unwrap_err(),
+            CurrentDataError::PublicationPending {
+                settled: revision,
+                published: ContentRevision(0),
+            }
+        );
+        publisher.pump();
+        let snapshot = reader.try_current().expect("current snapshot");
+        assert_eq!(snapshot.metadata.length, 20);
+        assert_eq!(snapshot.events().next().map(|event| event.time), Some(-1));
+    }
+
+    #[test]
+    fn hidden_replace_is_published_only_when_committed() {
+        let (mut writer, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 3);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        writer.append_storage_events(
+            &[event(1, &[0x90, 60, 100]), event(8, &[0x80, 60, 0])],
+            10,
+            true,
+        );
+        writer.finish_mutation(false);
+        publisher.pump();
+
+        assert!(writer.begin_mutation(ContentMutation::Replacing));
+        writer.truncate_after(2, 10, false);
+        writer.append_storage_events(&[event(3, &[0x90, 64, 100])], 10, false);
+        publisher.pump();
+        assert_eq!(reader.latest().snapshot.events().count(), 2);
+        writer.finish_mutation(true);
+        publisher.pump();
+        assert_eq!(
+            reader
+                .latest()
+                .snapshot
+                .events()
+                .map(|event| event.time)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/midi.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/midi.rs
@@ -6,6 +6,9 @@ use super::{
 };
 use crate::midi_event::MidiEvent;
 use crate::midi_storage::{MidiStorageElem, MAX_MSG_BYTES};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -40,6 +43,7 @@ enum MidiUpdateKind {
     Clear,
     TruncateAfter(i32),
     Publish,
+    Install(ContentRevision),
 }
 
 #[derive(Debug)]
@@ -67,6 +71,24 @@ impl MidiUpdateBlock {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedMidiSnapshot {
+    revision: ContentRevision,
+    length: u32,
+}
+
+struct PreparedMidiManifest {
+    token: PreparedMidiSnapshot,
+    chunks: Arc<[Arc<[MidiEvent]>]>,
+}
+
+#[derive(Clone)]
+pub struct MidiSnapshotControl {
+    status: Arc<ContentStatus>,
+    prepared: Sender<PreparedMidiManifest>,
+    chunk_events: usize,
+}
+
 pub struct MidiProcessSnapshotWriter {
     updates: ProcessSender<MidiUpdateBlock>,
     returned: PublisherReceiver<MidiUpdateBlock>,
@@ -77,9 +99,21 @@ pub struct MidiProcessSnapshotWriter {
     block_events: usize,
 }
 
+impl fmt::Debug for MidiProcessSnapshotWriter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MidiProcessSnapshotWriter")
+            .field("latest_revision", &self.latest_revision)
+            .field("latest_length", &self.latest_length)
+            .finish_non_exhaustive()
+    }
+}
+
 pub struct MidiSnapshotPublisher {
     updates: PublisherReceiver<MidiUpdateBlock>,
     returned: ProcessSender<MidiUpdateBlock>,
+    prepared: Receiver<PreparedMidiManifest>,
+    prepared_by_revision: HashMap<ContentRevision, PreparedMidiManifest>,
     manifest: ManifestPublisher<MidiContentSnapshot>,
     events: Vec<MidiEvent>,
     snapshot_chunk_events: usize,
@@ -93,6 +127,7 @@ pub fn midi_snapshot_channel(
     transport_blocks: usize,
 ) -> (
     MidiProcessSnapshotWriter,
+    MidiSnapshotControl,
     MidiSnapshotPublisher,
     MidiSnapshotReader,
 ) {
@@ -104,6 +139,7 @@ pub fn midi_snapshot_channel(
     let status = Arc::new(ContentStatus::new(epoch));
     let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
     let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (prepared_tx, prepared_rx) = mpsc::channel();
     let initial = MidiContentSnapshot::new(
         ContentRevision(0),
         MidiSnapshotMetadata { length: 0 },
@@ -119,14 +155,21 @@ pub fn midi_snapshot_channel(
             updates: updates_tx,
             returned: returned_rx,
             free,
-            status,
+            status: Arc::clone(&status),
             latest_revision: ContentRevision(0),
             latest_length: 0,
             block_events,
         },
+        MidiSnapshotControl {
+            status,
+            prepared: prepared_tx,
+            chunk_events: block_events,
+        },
         MidiSnapshotPublisher {
             updates: updates_rx,
             returned: returned_tx,
+            prepared: prepared_rx,
+            prepared_by_revision: HashMap::new(),
             manifest,
             events: Vec::new(),
             snapshot_chunk_events: block_events,
@@ -276,6 +319,27 @@ impl MidiProcessSnapshotWriter {
         Some(())
     }
 
+    pub fn install_prepared(&mut self, prepared: PreparedMidiSnapshot) -> bool {
+        if !self.reserve_blocks(1) {
+            return false;
+        }
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.kind = MidiUpdateKind::Install(prepared.revision);
+        block.total_length = prepared.length;
+        block.revision = prepared.revision;
+        block.final_block = true;
+        block.publish = true;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            return false;
+        }
+        self.latest_revision = prepared.revision;
+        self.latest_length = prepared.length;
+        self.status.finish_mutation(prepared.revision);
+        true
+    }
+
     pub fn finish_mutation(&mut self, publish_final: bool) -> ContentRevision {
         if publish_final && self.reserve_blocks(1) {
             let revision = self.latest_revision;
@@ -290,10 +354,50 @@ impl MidiProcessSnapshotWriter {
     }
 }
 
+impl MidiSnapshotControl {
+    pub fn prepare(
+        &self,
+        events: &[MidiEvent],
+        length: u32,
+        mutation: ContentMutation,
+    ) -> Option<PreparedMidiSnapshot> {
+        if !self.status.begin_mutation(mutation) {
+            return None;
+        }
+        let revision = self.status.next_revision();
+        let chunks: Vec<Arc<[MidiEvent]>> = events
+            .chunks(self.chunk_events)
+            .map(|events| Arc::from(events))
+            .collect();
+        let token = PreparedMidiSnapshot { revision, length };
+        if self
+            .prepared
+            .send(PreparedMidiManifest {
+                token,
+                chunks: Arc::from(chunks),
+            })
+            .is_err()
+        {
+            self.status.cancel_mutation();
+            return None;
+        }
+        Some(token)
+    }
+
+    pub fn cancel(&self) {
+        self.status.cancel_mutation();
+    }
+}
+
 impl MidiSnapshotPublisher {
     pub fn pump(&mut self) -> usize {
+        while let Ok(prepared) = self.prepared.try_recv() {
+            self.prepared_by_revision
+                .insert(prepared.token.revision, prepared);
+        }
         let mut processed = 0;
         while let Some(block) = self.updates.try_recv() {
+            let mut installed = false;
             match block.kind {
                 MidiUpdateKind::Append => {
                     self.events
@@ -305,6 +409,23 @@ impl MidiSnapshotPublisher {
                         .retain(|event| event.time < 0 || event.time <= time);
                 }
                 MidiUpdateKind::Publish => {}
+                MidiUpdateKind::Install(prepared_revision) => {
+                    if let Some(prepared) = self.prepared_by_revision.remove(&prepared_revision) {
+                        self.events = prepared
+                            .chunks
+                            .iter()
+                            .flat_map(|chunk| chunk.iter().cloned())
+                            .collect();
+                        self.manifest.publish(MidiContentSnapshot::new(
+                            prepared.token.revision,
+                            MidiSnapshotMetadata {
+                                length: prepared.token.length,
+                            },
+                            prepared.chunks,
+                        ));
+                        installed = true;
+                    }
+                }
             }
             let final_block = block.final_block;
             let publish = block.publish;
@@ -313,7 +434,7 @@ impl MidiSnapshotPublisher {
             self.returned
                 .try_send(block)
                 .expect("return queue capacity matches the transport pool");
-            if final_block && publish {
+            if final_block && publish && !installed {
                 let chunks: Vec<Arc<[MidiEvent]>> = self
                     .events
                     .chunks(self.snapshot_chunk_events)
@@ -342,7 +463,7 @@ mod tests {
 
     #[test]
     fn recording_publishes_ordered_complete_event_blocks() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 3);
         assert!(writer.begin_mutation(ContentMutation::Recording));
         let revision = writer
@@ -375,7 +496,7 @@ mod tests {
 
     #[test]
     fn exact_midi_requires_final_publication() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
         assert!(writer.begin_mutation(ContentMutation::Loading));
         let revision = writer
@@ -397,7 +518,7 @@ mod tests {
 
     #[test]
     fn hidden_replace_is_published_only_when_committed() {
-        let (mut writer, mut publisher, reader) =
+        let (mut writer, _control, mut publisher, reader) =
             midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 3);
         assert!(writer.begin_mutation(ContentMutation::Loading));
         writer.append_storage_events(

--- a/src/rust/shoop_engine/src/content_snapshot/midi.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/midi.rs
@@ -39,6 +39,7 @@ impl WireMidiEvent {
 
 #[derive(Debug, Clone, Copy)]
 enum MidiUpdateKind {
+    BeginWorking,
     Append,
     Clear,
     TruncateAfter(i32),
@@ -77,6 +78,12 @@ pub struct PreparedMidiSnapshot {
     length: u32,
 }
 
+impl PreparedMidiSnapshot {
+    pub fn revision(self) -> ContentRevision {
+        self.revision
+    }
+}
+
 struct PreparedMidiManifest {
     token: PreparedMidiSnapshot,
     chunks: Arc<[Arc<[MidiEvent]>]>,
@@ -97,6 +104,7 @@ pub struct MidiProcessSnapshotWriter {
     latest_revision: ContentRevision,
     latest_length: u32,
     block_events: usize,
+    retirement: ProcessSender<Vec<MidiUpdateBlock>>,
 }
 
 impl fmt::Debug for MidiProcessSnapshotWriter {
@@ -116,7 +124,10 @@ pub struct MidiSnapshotPublisher {
     prepared_by_revision: HashMap<ContentRevision, PreparedMidiManifest>,
     manifest: ManifestPublisher<MidiContentSnapshot>,
     events: Vec<MidiEvent>,
+    committed_events: Vec<MidiEvent>,
     snapshot_chunk_events: usize,
+    retirement: PublisherReceiver<Vec<MidiUpdateBlock>>,
+    retired: bool,
 }
 
 pub type MidiSnapshotReader = ManifestReader<MidiContentSnapshot>;
@@ -139,6 +150,7 @@ pub fn midi_snapshot_channel(
     let status = Arc::new(ContentStatus::new(epoch));
     let (updates_tx, updates_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
     let (returned_tx, returned_rx) = bounded_transport(transport_blocks, Arc::clone(&status));
+    let (retirement_tx, retirement_rx) = bounded_transport(1, Arc::clone(&status));
     let (prepared_tx, prepared_rx) = mpsc::channel();
     let initial = MidiContentSnapshot::new(
         ContentRevision(0),
@@ -159,6 +171,7 @@ pub fn midi_snapshot_channel(
             latest_revision: ContentRevision(0),
             latest_length: 0,
             block_events,
+            retirement: retirement_tx,
         },
         MidiSnapshotControl {
             status,
@@ -172,10 +185,23 @@ pub fn midi_snapshot_channel(
             prepared_by_revision: HashMap::new(),
             manifest,
             events: Vec::new(),
+            committed_events: Vec::new(),
             snapshot_chunk_events: block_events,
+            retirement: retirement_rx,
+            retired: false,
         },
         reader,
     )
+}
+
+impl Drop for MidiProcessSnapshotWriter {
+    fn drop(&mut self) {
+        let resources = std::mem::take(&mut self.free);
+        if let Err(resources) = self.retirement.try_send(resources) {
+            // The single producer retires only once. Never destroy pooled payloads here.
+            std::mem::forget(resources);
+        }
+    }
 }
 
 impl MidiProcessSnapshotWriter {
@@ -187,6 +213,23 @@ impl MidiProcessSnapshotWriter {
         while let Some(block) = self.returned.try_recv() {
             self.free.push(block);
         }
+    }
+
+    pub fn begin_working_generation(&mut self) -> bool {
+        self.reclaim();
+        if self.free.is_empty() || self.updates.slots() == 0 {
+            self.status.mark_saturated();
+            return false;
+        }
+        let mut block = self.free.pop().expect("capacity checked");
+        block.used = 0;
+        block.kind = MidiUpdateKind::BeginWorking;
+        if let Err(block) = self.updates.try_send(block) {
+            self.free.push(block);
+            self.status.mark_saturated();
+            return false;
+        }
+        true
     }
 
     fn reserve_blocks(&mut self, count: usize) -> bool {
@@ -204,6 +247,24 @@ impl MidiProcessSnapshotWriter {
         total_length: u32,
         publish: bool,
     ) -> Option<ContentRevision> {
+        self.append_storage_events_with_time(events, total_length, publish, false)
+    }
+
+    pub fn append_state_events(
+        &mut self,
+        events: &[MidiStorageElem],
+        total_length: u32,
+    ) -> Option<ContentRevision> {
+        self.append_storage_events_with_time(events, total_length, false, true)
+    }
+
+    fn append_storage_events_with_time(
+        &mut self,
+        events: &[MidiStorageElem],
+        total_length: u32,
+        publish: bool,
+        state_events: bool,
+    ) -> Option<ContentRevision> {
         let count = events.len().max(1).div_ceil(self.block_events);
         if !self.reserve_blocks(count) {
             return None;
@@ -215,7 +276,10 @@ impl MidiProcessSnapshotWriter {
             for (index, source) in events.chunks(self.block_events).enumerate() {
                 let mut block = self.free.pop().expect("capacity checked");
                 for (destination, event) in block.events.iter_mut().zip(source) {
-                    destination.set(event.time as i32, event.data());
+                    destination.set(
+                        if state_events { -1 } else { event.time as i32 },
+                        event.data(),
+                    );
                 }
                 block.used = source.len();
                 block.kind = MidiUpdateKind::Append;
@@ -390,7 +454,12 @@ impl MidiSnapshotControl {
 }
 
 impl MidiSnapshotPublisher {
+    pub fn is_retired(&self) -> bool {
+        self.retired
+    }
+
     pub fn pump(&mut self) -> usize {
+        let retired_resources = self.retirement.try_recv();
         while let Ok(prepared) = self.prepared.try_recv() {
             self.prepared_by_revision
                 .insert(prepared.token.revision, prepared);
@@ -399,6 +468,9 @@ impl MidiSnapshotPublisher {
         while let Some(block) = self.updates.try_recv() {
             let mut installed = false;
             match block.kind {
+                MidiUpdateKind::BeginWorking => {
+                    self.events.clone_from(&self.committed_events);
+                }
                 MidiUpdateKind::Append => {
                     self.events
                         .extend(block.events[..block.used].iter().map(WireMidiEvent::event));
@@ -416,6 +488,7 @@ impl MidiSnapshotPublisher {
                             .iter()
                             .flat_map(|chunk| chunk.iter().cloned())
                             .collect();
+                        self.committed_events.clone_from(&self.events);
                         self.manifest.publish(MidiContentSnapshot::new(
                             prepared.token.revision,
                             MidiSnapshotMetadata {
@@ -445,8 +518,13 @@ impl MidiSnapshotPublisher {
                     MidiSnapshotMetadata { length },
                     Arc::from(chunks),
                 ));
+                self.committed_events.clone_from(&self.events);
             }
             processed += 1;
+        }
+        if let Some(resources) = retired_resources {
+            drop(resources);
+            self.retired = true;
         }
         processed
     }
@@ -514,6 +592,59 @@ mod tests {
         let snapshot = reader.try_current().expect("current snapshot");
         assert_eq!(snapshot.metadata.length, 20);
         assert_eq!(snapshot.events().next().map(|event| event.time), Some(-1));
+    }
+
+    #[test]
+    fn prepared_generation_installs_with_explicit_duration() {
+        let (mut writer, control, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 2);
+        let events = [MidiEvent {
+            time: 3,
+            data: vec![0x90, 60, 100],
+        }];
+        let prepared = control
+            .prepare(&events, 100, ContentMutation::Loading)
+            .expect("prepare generation");
+        assert!(writer.install_prepared(prepared));
+        assert!(matches!(
+            reader.try_current(),
+            Err(CurrentDataError::PublicationPending { .. })
+        ));
+        publisher.pump();
+        let snapshot = reader.try_current().expect("installed");
+        assert_eq!(snapshot.metadata.length, 100);
+        assert_eq!(snapshot.events().next().map(|event| event.time), Some(3));
+    }
+
+    #[test]
+    fn cancelled_midi_work_is_reset_before_the_next_generation() {
+        let (mut writer, _control, mut publisher, reader) =
+            midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 2, 6);
+        assert!(writer.begin_mutation(ContentMutation::Loading));
+        writer.append_storage_events(&[event(1, &[0x90, 60, 100])], 8, true);
+        writer.finish_mutation(false);
+        publisher.pump();
+
+        assert!(writer.begin_mutation(ContentMutation::Replacing));
+        assert!(writer.begin_working_generation());
+        writer.append_storage_events(&[event(2, &[0x90, 61, 100])], 8, false);
+        publisher.pump();
+        writer.cancel_mutation();
+
+        assert!(writer.begin_mutation(ContentMutation::Recording));
+        assert!(writer.begin_working_generation());
+        writer.append_storage_events(&[event(3, &[0x90, 62, 100])], 8, true);
+        writer.finish_mutation(false);
+        publisher.pump();
+        assert_eq!(
+            reader
+                .latest()
+                .snapshot
+                .events()
+                .map(|event| event.time)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
     }
 
     #[test]

--- a/src/rust/shoop_engine/src/content_snapshot/mod.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/mod.rs
@@ -46,19 +46,18 @@ mod runtime;
 mod status;
 mod transport;
 
+pub(crate) use audio::{audio_snapshot_channel, AudioSnapshotPublisher};
 pub use audio::{
-    audio_snapshot_channel, AudioProcessSnapshotWriter, AudioSnapshotControl,
-    AudioSnapshotPublisher, AudioSnapshotReader, PreparedAudioSnapshot,
+    AudioProcessSnapshotWriter, AudioSnapshotControl, AudioSnapshotReader, PreparedAudioSnapshot,
 };
 pub use contracts::{
     AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision,
     CurrentDataError, MidiContentSnapshot, MidiSnapshotMetadata, SnapshotCurrentness, SnapshotRead,
     StaleReason,
 };
-pub use manifest::{manifest_pair, ContentSnapshot, ManifestPublisher, ManifestReader};
+pub(crate) use midi::{midi_snapshot_channel, MidiSnapshotPublisher};
 pub use midi::{
-    midi_snapshot_channel, MidiProcessSnapshotWriter, MidiSnapshotControl, MidiSnapshotPublisher,
-    MidiSnapshotReader, PreparedMidiSnapshot,
+    MidiProcessSnapshotWriter, MidiSnapshotControl, MidiSnapshotReader, PreparedMidiSnapshot,
 };
 pub use runtime::ContentSnapshotRuntime;
-pub use status::{ContentStatus, SessionContentEpoch};
+pub(crate) use status::{ContentStatus, SessionContentEpoch};

--- a/src/rust/shoop_engine/src/content_snapshot/mod.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/mod.rs
@@ -1,0 +1,28 @@
+//! Revisioned channel-content snapshots for realtime writers and non-realtime readers.
+//!
+//! Channel implementations use opaque content stores and mutation operations. Pool ownership,
+//! publication transport, immutable manifests, revision state, and deferred reclamation remain
+//! inside this module tree.
+
+mod audio;
+mod contracts;
+mod manifest;
+mod midi;
+mod runtime;
+mod status;
+mod transport;
+
+pub use audio::{
+    audio_snapshot_channel, AudioProcessSnapshotWriter, AudioSnapshotPublisher, AudioSnapshotReader,
+};
+pub use contracts::{
+    AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision,
+    CurrentDataError, MidiContentSnapshot, MidiSnapshotMetadata, SnapshotCurrentness, SnapshotRead,
+    StaleReason,
+};
+pub use manifest::{manifest_pair, ContentSnapshot, ManifestPublisher, ManifestReader};
+pub use midi::{
+    midi_snapshot_channel, MidiProcessSnapshotWriter, MidiSnapshotPublisher, MidiSnapshotReader,
+};
+pub use runtime::ContentSnapshotRuntime;
+pub use status::{ContentStatus, SessionContentEpoch};

--- a/src/rust/shoop_engine/src/content_snapshot/mod.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/mod.rs
@@ -1,5 +1,39 @@
 //! Revisioned channel-content snapshots for realtime writers and non-realtime readers.
 //!
+//! # Ownership and thread model
+//!
+//! ```text
+//! frontend/control thread                   realtime process thread
+//! ┌────────────────────────┐                ┌──────────────────────────┐
+//! │ SnapshotControl        │ prepare ─────▶ │ ProcessSnapshotWriter    │
+//! │ ManifestReader         │                │ preallocated block pool  │
+//! └──────────┬─────────────┘                └────────────┬─────────────┘
+//!            │ immutable Arc snapshots                    │ bounded SPSC
+//!            ▼                                            ▼
+//!       stale/exact reads                    session snapshot publisher thread
+//!                                             ┌─────────────────────────┐
+//!                                             │ mutable private builder │
+//!                                             │ immutable manifests     │
+//!                                             │ returned block reclaim  │
+//!                                             └─────────────────────────┘
+//! ```
+//!
+//! One [`ContentSnapshotRuntime`] worker services all channels in a session. The process endpoint
+//! owns only fixed-capacity update blocks and atomics; it never constructs or destroys manifests.
+//! Prepared loads are allocated on the control thread and installed by a bounded process command.
+//! The publisher performs chunk cloning, manifest allocation, `Arc` replacement, and reclamation.
+//!
+//! # Publication invariants
+//!
+//! * A manifest is immutable and contains content plus its length/duration and revision.
+//! * Readers either retain the previous complete manifest or observe a complete newer manifest;
+//!   private recording/replacement builders are never visible.
+//! * `latest()` is nonblocking and may be stale. `try_current()` is nonblocking and returns a
+//!   typed reason while a mutation, publication, or saturation is unsettled.
+//! * Dirty acknowledgement names the revision actually consumed and cannot acknowledge a newer
+//!   generation accidentally.
+//! * The session epoch brackets every mutation so persistence can reject cross-channel mixtures.
+//!
 //! Channel implementations use opaque content stores and mutation operations. Pool ownership,
 //! publication transport, immutable manifests, revision state, and deferred reclamation remain
 //! inside this module tree.

--- a/src/rust/shoop_engine/src/content_snapshot/mod.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/mod.rs
@@ -13,7 +13,8 @@ mod status;
 mod transport;
 
 pub use audio::{
-    audio_snapshot_channel, AudioProcessSnapshotWriter, AudioSnapshotPublisher, AudioSnapshotReader,
+    audio_snapshot_channel, AudioProcessSnapshotWriter, AudioSnapshotControl,
+    AudioSnapshotPublisher, AudioSnapshotReader, PreparedAudioSnapshot,
 };
 pub use contracts::{
     AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision,
@@ -22,7 +23,8 @@ pub use contracts::{
 };
 pub use manifest::{manifest_pair, ContentSnapshot, ManifestPublisher, ManifestReader};
 pub use midi::{
-    midi_snapshot_channel, MidiProcessSnapshotWriter, MidiSnapshotPublisher, MidiSnapshotReader,
+    midi_snapshot_channel, MidiProcessSnapshotWriter, MidiSnapshotControl, MidiSnapshotPublisher,
+    MidiSnapshotReader, PreparedMidiSnapshot,
 };
 pub use runtime::ContentSnapshotRuntime;
 pub use status::{ContentStatus, SessionContentEpoch};

--- a/src/rust/shoop_engine/src/content_snapshot/runtime.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/runtime.rs
@@ -128,12 +128,14 @@ fn publisher_worker(commands: Receiver<RuntimeCommand>) {
                 RuntimeCommand::Stop => return,
             }
         }
-        for publisher in &mut audio_publishers {
+        audio_publishers.retain_mut(|publisher| {
             publisher.pump();
-        }
-        for publisher in &mut midi_publishers {
+            !publisher.is_retired()
+        });
+        midi_publishers.retain_mut(|publisher| {
             publisher.pump();
-        }
+            !publisher.is_retired()
+        });
     }
 }
 
@@ -141,13 +143,14 @@ fn publisher_worker(commands: Receiver<RuntimeCommand>) {
 mod tests {
     use super::*;
     use crate::content_snapshot::{ContentMutation, ContentRevision};
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Instant;
 
     fn wait_until(mut predicate: impl FnMut() -> bool) {
         let start = Instant::now();
         while !predicate() {
             assert!(
-                start.elapsed() < Duration::from_secs(1),
+                start.elapsed() < Duration::from_secs(10),
                 "snapshot publisher did not converge"
             );
             thread::yield_now();
@@ -201,5 +204,69 @@ mod tests {
         assert!(second.begin_mutation(ContentMutation::Clearing));
         second.cancel_mutation();
         assert!(!runtime.validate_epoch(stable));
+    }
+
+    #[test]
+    fn concurrent_readers_observe_only_complete_generations_under_stress() {
+        let runtime = ContentSnapshotRuntime::new();
+        let (mut writer, _control, reader) = runtime.create_audio_channel(4, 8);
+        let stop = Arc::new(AtomicBool::new(false));
+        let failed = Arc::new(AtomicBool::new(false));
+        let reader_thread = {
+            let reader = reader.clone();
+            let stop = Arc::clone(&stop);
+            let failed = Arc::clone(&failed);
+            thread::spawn(move || {
+                while !stop.load(Ordering::Acquire) {
+                    let data = reader.latest().snapshot.contiguous();
+                    if data.len() != 4 && !data.is_empty() {
+                        failed.store(true, Ordering::Release);
+                        return;
+                    }
+                    if let Some(first) = data.first() {
+                        if data.iter().any(|sample| sample != first) {
+                            failed.store(true, Ordering::Release);
+                            return;
+                        }
+                    }
+                }
+            })
+        };
+
+        for value in 1..=10_000_u32 {
+            assert!(writer.begin_mutation(ContentMutation::Loading));
+            let samples = [value as f32; 4];
+            while writer
+                .publish_range(0, &samples, samples.len(), true)
+                .is_none()
+            {
+                thread::yield_now();
+            }
+            writer.finish_mutation(false);
+        }
+        wait_until(|| {
+            reader
+                .try_current()
+                .is_ok_and(|snapshot| snapshot.contiguous() == vec![10_000.0; 4])
+        });
+        stop.store(true, Ordering::Release);
+        reader_thread.join().expect("reader thread");
+        assert!(!failed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn a_reader_keeps_its_last_manifest_after_runtime_shutdown() {
+        let reader = {
+            let runtime = ContentSnapshotRuntime::new();
+            let (mut writer, _control, reader) = runtime.create_audio_channel(4, 4);
+            assert!(writer.begin_mutation(ContentMutation::Loading));
+            writer
+                .publish_range(0, &[3.0, 4.0], 2, true)
+                .expect("publish");
+            writer.finish_mutation(false);
+            wait_until(|| reader.try_current().is_ok());
+            reader
+        };
+        assert_eq!(reader.latest().snapshot.contiguous(), vec![3.0, 4.0]);
     }
 }

--- a/src/rust/shoop_engine/src/content_snapshot/runtime.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/runtime.rs
@@ -1,7 +1,7 @@
 use super::{
     audio_snapshot_channel, midi_snapshot_channel, AudioProcessSnapshotWriter,
-    AudioSnapshotPublisher, AudioSnapshotReader, MidiProcessSnapshotWriter, MidiSnapshotPublisher,
-    MidiSnapshotReader, SessionContentEpoch,
+    AudioSnapshotControl, AudioSnapshotPublisher, AudioSnapshotReader, MidiProcessSnapshotWriter,
+    MidiSnapshotControl, MidiSnapshotPublisher, MidiSnapshotReader, SessionContentEpoch,
 };
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
@@ -53,22 +53,30 @@ impl ContentSnapshotRuntime {
         &self,
         chunk_size: usize,
         transport_blocks: usize,
-    ) -> (AudioProcessSnapshotWriter, AudioSnapshotReader) {
-        let (writer, publisher, reader) =
+    ) -> (
+        AudioProcessSnapshotWriter,
+        AudioSnapshotControl,
+        AudioSnapshotReader,
+    ) {
+        let (writer, control, publisher, reader) =
             audio_snapshot_channel(Arc::clone(&self.inner.epoch), chunk_size, transport_blocks);
         self.inner
             .commands
             .send(RuntimeCommand::AddAudio(publisher))
             .expect("content snapshot worker is alive");
-        (writer, reader)
+        (writer, control, reader)
     }
 
     pub fn create_midi_channel(
         &self,
         block_events: usize,
         transport_blocks: usize,
-    ) -> (MidiProcessSnapshotWriter, MidiSnapshotReader) {
-        let (writer, publisher, reader) = midi_snapshot_channel(
+    ) -> (
+        MidiProcessSnapshotWriter,
+        MidiSnapshotControl,
+        MidiSnapshotReader,
+    ) {
+        let (writer, control, publisher, reader) = midi_snapshot_channel(
             Arc::clone(&self.inner.epoch),
             block_events,
             transport_blocks,
@@ -77,7 +85,7 @@ impl ContentSnapshotRuntime {
             .commands
             .send(RuntimeCommand::AddMidi(publisher))
             .expect("content snapshot worker is alive");
-        (writer, reader)
+        (writer, control, reader)
     }
 
     pub fn capture_epoch(&self) -> Option<u64> {
@@ -149,8 +157,9 @@ mod tests {
     #[test]
     fn one_worker_publishes_multiple_channel_streams() {
         let runtime = ContentSnapshotRuntime::new();
-        let (mut first_writer, first_reader) = runtime.create_audio_channel(4, 4);
-        let (mut second_writer, second_reader) = runtime.create_audio_channel(4, 4);
+        let (mut first_writer, _first_control, first_reader) = runtime.create_audio_channel(4, 4);
+        let (mut second_writer, _second_control, second_reader) =
+            runtime.create_audio_channel(4, 4);
 
         assert!(first_writer.begin_mutation(ContentMutation::Loading));
         let first_revision = first_writer
@@ -181,8 +190,8 @@ mod tests {
     #[test]
     fn session_epoch_spans_all_registered_channels() {
         let runtime = ContentSnapshotRuntime::new();
-        let (first, _) = runtime.create_audio_channel(4, 2);
-        let (second, _) = runtime.create_audio_channel(4, 2);
+        let (first, _first_control, _) = runtime.create_audio_channel(4, 2);
+        let (second, _second_control, _) = runtime.create_audio_channel(4, 2);
         let stable = runtime.capture_epoch().expect("stable");
         assert!(first.begin_mutation(ContentMutation::Recording));
         assert!(runtime.capture_epoch().is_none());

--- a/src/rust/shoop_engine/src/content_snapshot/runtime.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/runtime.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn concurrent_readers_observe_only_complete_generations_under_stress() {
         let runtime = ContentSnapshotRuntime::new();
-        let (mut writer, _control, reader) = runtime.create_audio_channel(4, 8);
+        let (mut writer, control, reader) = runtime.create_audio_channel(4, 8);
         let stop = Arc::new(AtomicBool::new(false));
         let failed = Arc::new(AtomicBool::new(false));
         let reader_thread = {
@@ -243,6 +243,12 @@ mod tests {
                 thread::yield_now();
             }
             writer.finish_mutation(false);
+        }
+        let recovery = control
+            .prepare(&[10_000.0; 4], ContentMutation::Loading)
+            .expect("prepare explicit recovery");
+        while !writer.install_prepared(recovery) {
+            thread::yield_now();
         }
         wait_until(|| {
             reader

--- a/src/rust/shoop_engine/src/content_snapshot/runtime.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/runtime.rs
@@ -1,0 +1,196 @@
+use super::{
+    audio_snapshot_channel, midi_snapshot_channel, AudioProcessSnapshotWriter,
+    AudioSnapshotPublisher, AudioSnapshotReader, MidiProcessSnapshotWriter, MidiSnapshotPublisher,
+    MidiSnapshotReader, SessionContentEpoch,
+};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const PUBLISHER_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+enum RuntimeCommand {
+    AddAudio(AudioSnapshotPublisher),
+    AddMidi(MidiSnapshotPublisher),
+    Stop,
+}
+
+struct RuntimeInner {
+    commands: Sender<RuntimeCommand>,
+    epoch: Arc<SessionContentEpoch>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+#[derive(Clone)]
+pub struct ContentSnapshotRuntime {
+    inner: Arc<RuntimeInner>,
+}
+
+impl Default for ContentSnapshotRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContentSnapshotRuntime {
+    pub fn new() -> Self {
+        let (commands, receiver) = mpsc::channel();
+        let worker = thread::Builder::new()
+            .name("shoop-content-snapshots".to_string())
+            .spawn(move || publisher_worker(receiver))
+            .expect("content snapshot publisher worker must start");
+        Self {
+            inner: Arc::new(RuntimeInner {
+                commands,
+                epoch: Arc::new(SessionContentEpoch::default()),
+                worker: Mutex::new(Some(worker)),
+            }),
+        }
+    }
+
+    pub fn create_audio_channel(
+        &self,
+        chunk_size: usize,
+        transport_blocks: usize,
+    ) -> (AudioProcessSnapshotWriter, AudioSnapshotReader) {
+        let (writer, publisher, reader) =
+            audio_snapshot_channel(Arc::clone(&self.inner.epoch), chunk_size, transport_blocks);
+        self.inner
+            .commands
+            .send(RuntimeCommand::AddAudio(publisher))
+            .expect("content snapshot worker is alive");
+        (writer, reader)
+    }
+
+    pub fn create_midi_channel(
+        &self,
+        block_events: usize,
+        transport_blocks: usize,
+    ) -> (MidiProcessSnapshotWriter, MidiSnapshotReader) {
+        let (writer, publisher, reader) = midi_snapshot_channel(
+            Arc::clone(&self.inner.epoch),
+            block_events,
+            transport_blocks,
+        );
+        self.inner
+            .commands
+            .send(RuntimeCommand::AddMidi(publisher))
+            .expect("content snapshot worker is alive");
+        (writer, reader)
+    }
+
+    pub fn capture_epoch(&self) -> Option<u64> {
+        self.inner.epoch.capture()
+    }
+
+    pub fn validate_epoch(&self, captured: u64) -> bool {
+        self.inner.epoch.validate(captured)
+    }
+}
+
+impl Drop for RuntimeInner {
+    fn drop(&mut self) {
+        let _ = self.commands.send(RuntimeCommand::Stop);
+        if let Some(worker) = self
+            .worker
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take()
+        {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn publisher_worker(commands: Receiver<RuntimeCommand>) {
+    let mut audio_publishers = Vec::<AudioSnapshotPublisher>::new();
+    let mut midi_publishers = Vec::<MidiSnapshotPublisher>::new();
+    loop {
+        match commands.recv_timeout(PUBLISHER_POLL_INTERVAL) {
+            Ok(RuntimeCommand::AddAudio(publisher)) => audio_publishers.push(publisher),
+            Ok(RuntimeCommand::AddMidi(publisher)) => midi_publishers.push(publisher),
+            Ok(RuntimeCommand::Stop) | Err(RecvTimeoutError::Disconnected) => break,
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+        while let Ok(command) = commands.try_recv() {
+            match command {
+                RuntimeCommand::AddAudio(publisher) => audio_publishers.push(publisher),
+                RuntimeCommand::AddMidi(publisher) => midi_publishers.push(publisher),
+                RuntimeCommand::Stop => return,
+            }
+        }
+        for publisher in &mut audio_publishers {
+            publisher.pump();
+        }
+        for publisher in &mut midi_publishers {
+            publisher.pump();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content_snapshot::{ContentMutation, ContentRevision};
+    use std::time::Instant;
+
+    fn wait_until(mut predicate: impl FnMut() -> bool) {
+        let start = Instant::now();
+        while !predicate() {
+            assert!(
+                start.elapsed() < Duration::from_secs(1),
+                "snapshot publisher did not converge"
+            );
+            thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn one_worker_publishes_multiple_channel_streams() {
+        let runtime = ContentSnapshotRuntime::new();
+        let (mut first_writer, first_reader) = runtime.create_audio_channel(4, 4);
+        let (mut second_writer, second_reader) = runtime.create_audio_channel(4, 4);
+
+        assert!(first_writer.begin_mutation(ContentMutation::Loading));
+        let first_revision = first_writer
+            .publish_range(0, &[1.0, 2.0], 2, true)
+            .expect("first publish");
+        first_writer.finish_mutation(false);
+
+        assert!(second_writer.begin_mutation(ContentMutation::Loading));
+        let second_revision = second_writer
+            .publish_range(0, &[8.0], 1, true)
+            .expect("second publish");
+        second_writer.finish_mutation(false);
+
+        wait_until(|| {
+            first_reader
+                .try_current()
+                .is_ok_and(|snapshot| snapshot.revision == first_revision)
+                && second_reader
+                    .try_current()
+                    .is_ok_and(|snapshot| snapshot.revision == second_revision)
+        });
+        assert_eq!(first_reader.latest().snapshot.contiguous(), vec![1.0, 2.0]);
+        assert_eq!(second_reader.latest().snapshot.contiguous(), vec![8.0]);
+        assert_eq!(first_revision, ContentRevision(1));
+        assert_eq!(second_revision, ContentRevision(1));
+    }
+
+    #[test]
+    fn session_epoch_spans_all_registered_channels() {
+        let runtime = ContentSnapshotRuntime::new();
+        let (first, _) = runtime.create_audio_channel(4, 2);
+        let (second, _) = runtime.create_audio_channel(4, 2);
+        let stable = runtime.capture_epoch().expect("stable");
+        assert!(first.begin_mutation(ContentMutation::Recording));
+        assert!(runtime.capture_epoch().is_none());
+        first.cancel_mutation();
+        assert!(!runtime.validate_epoch(stable));
+        let stable = runtime.capture_epoch().expect("stable again");
+        assert!(second.begin_mutation(ContentMutation::Clearing));
+        second.cancel_mutation();
+        assert!(!runtime.validate_epoch(stable));
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/status.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/status.rs
@@ -93,14 +93,12 @@ impl ContentStatus {
     pub fn mark_published(&self, revision: ContentRevision) {
         self.published_revision
             .fetch_max(revision.0, Ordering::Release);
+        // A newer complete manifest proves the bounded transport and publisher recovered.
+        self.saturated.store(false, Ordering::Release);
     }
 
     pub fn mark_saturated(&self) {
         self.saturated.store(true, Ordering::Release);
-    }
-
-    pub fn clear_saturated(&self) {
-        self.saturated.store(false, Ordering::Release);
     }
 
     pub fn settled_revision(&self) -> ContentRevision {
@@ -167,6 +165,26 @@ mod tests {
     }
 
     #[test]
+    fn every_unsettled_mutation_has_a_typed_exact_read_error() {
+        for mutation in [
+            ContentMutation::Recording,
+            ContentMutation::PreRecording,
+            ContentMutation::Replacing,
+            ContentMutation::Loading,
+            ContentMutation::Clearing,
+            ContentMutation::RingbufferAdoption,
+        ] {
+            let status = ContentStatus::new(Arc::new(SessionContentEpoch::default()));
+            assert!(status.begin_mutation(mutation));
+            assert_eq!(
+                status.require_current(),
+                Err(CurrentDataError::MutationActive(mutation))
+            );
+            status.cancel_mutation();
+        }
+    }
+
+    #[test]
     fn saturation_retains_revisions_but_blocks_exact_reads_until_recovered() {
         let status = ContentStatus::new(Arc::new(SessionContentEpoch::default()));
         let revision = status.next_revision();
@@ -179,7 +197,7 @@ mod tests {
             Err(CurrentDataError::PublicationSaturated)
         );
         assert_eq!(status.published_revision(), revision);
-        status.clear_saturated();
+        status.mark_published(revision);
         assert_eq!(status.require_current(), Ok(revision));
     }
 

--- a/src/rust/shoop_engine/src/content_snapshot/status.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/status.rs
@@ -1,0 +1,206 @@
+use super::{ContentMutation, ContentRevision, CurrentDataError, SnapshotCurrentness, StaleReason};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct SessionContentEpoch {
+    epoch: AtomicU64,
+    active_mutations: AtomicU32,
+}
+
+impl SessionContentEpoch {
+    pub fn capture(&self) -> Option<u64> {
+        (self.active_mutations.load(Ordering::Acquire) == 0)
+            .then(|| self.epoch.load(Ordering::Acquire))
+    }
+
+    pub fn validate(&self, captured: u64) -> bool {
+        self.active_mutations.load(Ordering::Acquire) == 0
+            && self.epoch.load(Ordering::Acquire) == captured
+    }
+
+    fn mutation_started(&self) {
+        self.active_mutations.fetch_add(1, Ordering::AcqRel);
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn mutation_finished(&self) {
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.active_mutations.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+const NO_MUTATION: u8 = 0;
+
+#[derive(Debug)]
+pub struct ContentStatus {
+    epoch: Arc<SessionContentEpoch>,
+    mutation: AtomicU8,
+    next_revision: AtomicU64,
+    settled_revision: AtomicU64,
+    published_revision: AtomicU64,
+    saturated: AtomicBool,
+}
+
+impl ContentStatus {
+    pub fn new(epoch: Arc<SessionContentEpoch>) -> Self {
+        Self {
+            epoch,
+            mutation: AtomicU8::new(NO_MUTATION),
+            next_revision: AtomicU64::new(1),
+            settled_revision: AtomicU64::new(0),
+            published_revision: AtomicU64::new(0),
+            saturated: AtomicBool::new(false),
+        }
+    }
+
+    pub fn begin_mutation(&self, mutation: ContentMutation) -> bool {
+        if self
+            .mutation
+            .compare_exchange(
+                NO_MUTATION,
+                mutation as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        self.epoch.mutation_started();
+        true
+    }
+
+    pub fn next_revision(&self) -> ContentRevision {
+        ContentRevision(self.next_revision.fetch_add(1, Ordering::Relaxed))
+    }
+
+    pub fn finish_mutation(&self, settled: ContentRevision) {
+        self.settled_revision.store(settled.0, Ordering::Release);
+        let previous = self.mutation.swap(NO_MUTATION, Ordering::AcqRel);
+        if previous != NO_MUTATION {
+            self.epoch.mutation_finished();
+        }
+    }
+
+    pub fn cancel_mutation(&self) {
+        let previous = self.mutation.swap(NO_MUTATION, Ordering::AcqRel);
+        if previous != NO_MUTATION {
+            self.epoch.mutation_finished();
+        }
+    }
+
+    pub fn mark_published(&self, revision: ContentRevision) {
+        self.published_revision
+            .fetch_max(revision.0, Ordering::Release);
+    }
+
+    pub fn mark_saturated(&self) {
+        self.saturated.store(true, Ordering::Release);
+    }
+
+    pub fn clear_saturated(&self) {
+        self.saturated.store(false, Ordering::Release);
+    }
+
+    pub fn settled_revision(&self) -> ContentRevision {
+        ContentRevision(self.settled_revision.load(Ordering::Acquire))
+    }
+
+    pub fn published_revision(&self) -> ContentRevision {
+        ContentRevision(self.published_revision.load(Ordering::Acquire))
+    }
+
+    pub fn currentness(&self) -> SnapshotCurrentness {
+        if self.saturated.load(Ordering::Acquire) {
+            return SnapshotCurrentness::Stale(StaleReason::PublicationSaturated);
+        }
+        if let Some(mutation) = ContentMutation::from_raw(self.mutation.load(Ordering::Acquire)) {
+            return SnapshotCurrentness::Stale(StaleReason::MutationActive(mutation));
+        }
+        let settled = self.settled_revision();
+        let published = self.published_revision();
+        if published < settled {
+            SnapshotCurrentness::Stale(StaleReason::PublicationPending { settled, published })
+        } else {
+            SnapshotCurrentness::Current
+        }
+    }
+
+    pub fn require_current(&self) -> Result<ContentRevision, CurrentDataError> {
+        match self.currentness() {
+            SnapshotCurrentness::Current => Ok(self.settled_revision()),
+            SnapshotCurrentness::Stale(reason) => Err(reason.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutation_and_publication_state_control_exact_reads() {
+        let epoch = Arc::new(SessionContentEpoch::default());
+        let status = ContentStatus::new(epoch);
+        assert_eq!(status.require_current(), Ok(ContentRevision(0)));
+
+        assert!(status.begin_mutation(ContentMutation::Recording));
+        assert!(!status.begin_mutation(ContentMutation::Clearing));
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::MutationActive(ContentMutation::Recording))
+        );
+
+        let revision = status.next_revision();
+        status.finish_mutation(revision);
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationPending {
+                settled: revision,
+                published: ContentRevision(0),
+            })
+        );
+
+        status.mark_published(revision);
+        assert_eq!(status.require_current(), Ok(revision));
+    }
+
+    #[test]
+    fn saturation_retains_revisions_but_blocks_exact_reads_until_recovered() {
+        let status = ContentStatus::new(Arc::new(SessionContentEpoch::default()));
+        let revision = status.next_revision();
+        assert!(status.begin_mutation(ContentMutation::Loading));
+        status.finish_mutation(revision);
+        status.mark_published(revision);
+        status.mark_saturated();
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationSaturated)
+        );
+        assert_eq!(status.published_revision(), revision);
+        status.clear_saturated();
+        assert_eq!(status.require_current(), Ok(revision));
+    }
+
+    #[test]
+    fn session_epoch_rejects_overlap_and_changes_completed_between_reads() {
+        let epoch = Arc::new(SessionContentEpoch::default());
+        let a = ContentStatus::new(Arc::clone(&epoch));
+        let b = ContentStatus::new(Arc::clone(&epoch));
+
+        let before = epoch.capture().expect("initially stable");
+        assert!(a.begin_mutation(ContentMutation::Recording));
+        assert!(epoch.capture().is_none());
+        a.cancel_mutation();
+        assert!(!epoch.validate(before));
+
+        let stable = epoch.capture().expect("stable after cancellation");
+        assert!(b.begin_mutation(ContentMutation::Clearing));
+        let revision = b.next_revision();
+        b.finish_mutation(revision);
+        assert!(!epoch.validate(stable));
+        let after = epoch.capture().expect("stable after clear");
+        assert!(epoch.validate(after));
+    }
+}

--- a/src/rust/shoop_engine/src/content_snapshot/status.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/status.rs
@@ -6,26 +6,41 @@ use std::sync::Arc;
 pub struct SessionContentEpoch {
     epoch: AtomicU64,
     active_mutations: AtomicU32,
+    exhausted: AtomicBool,
 }
 
 impl SessionContentEpoch {
     pub fn capture(&self) -> Option<u64> {
-        (self.active_mutations.load(Ordering::Acquire) == 0)
+        (!self.exhausted.load(Ordering::Acquire)
+            && self.active_mutations.load(Ordering::Acquire) == 0)
             .then(|| self.epoch.load(Ordering::Acquire))
     }
 
     pub fn validate(&self, captured: u64) -> bool {
-        self.active_mutations.load(Ordering::Acquire) == 0
+        !self.exhausted.load(Ordering::Acquire)
+            && self.active_mutations.load(Ordering::Acquire) == 0
             && self.epoch.load(Ordering::Acquire) == captured
+    }
+
+    fn bump_epoch(&self) {
+        let previous = self
+            .epoch
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                Some(current.saturating_add(1))
+            })
+            .expect("epoch update closure always succeeds");
+        if previous == u64::MAX {
+            self.exhausted.store(true, Ordering::Release);
+        }
     }
 
     fn mutation_started(&self) {
         self.active_mutations.fetch_add(1, Ordering::AcqRel);
-        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.bump_epoch();
     }
 
     fn mutation_finished(&self) {
-        self.epoch.fetch_add(1, Ordering::AcqRel);
+        self.bump_epoch();
         self.active_mutations.fetch_sub(1, Ordering::AcqRel);
     }
 }
@@ -40,6 +55,7 @@ pub struct ContentStatus {
     settled_revision: AtomicU64,
     published_revision: AtomicU64,
     saturated: AtomicBool,
+    revision_exhausted: AtomicBool,
 }
 
 impl ContentStatus {
@@ -51,6 +67,7 @@ impl ContentStatus {
             settled_revision: AtomicU64::new(0),
             published_revision: AtomicU64::new(0),
             saturated: AtomicBool::new(false),
+            revision_exhausted: AtomicBool::new(false),
         }
     }
 
@@ -72,7 +89,16 @@ impl ContentStatus {
     }
 
     pub fn next_revision(&self) -> ContentRevision {
-        ContentRevision(self.next_revision.fetch_add(1, Ordering::Relaxed))
+        let revision = self
+            .next_revision
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_add(1))
+            })
+            .expect("revision update closure always succeeds");
+        if revision == u64::MAX {
+            self.revision_exhausted.store(true, Ordering::Release);
+        }
+        ContentRevision(revision)
     }
 
     pub fn finish_mutation(&self, settled: ContentRevision) {
@@ -93,7 +119,9 @@ impl ContentStatus {
     pub fn mark_published(&self, revision: ContentRevision) {
         self.published_revision
             .fetch_max(revision.0, Ordering::Release);
-        // A newer complete manifest proves the bounded transport and publisher recovered.
+    }
+
+    pub fn recover_saturation(&self) {
         self.saturated.store(false, Ordering::Release);
     }
 
@@ -110,7 +138,8 @@ impl ContentStatus {
     }
 
     pub fn currentness(&self) -> SnapshotCurrentness {
-        if self.saturated.load(Ordering::Acquire) {
+        if self.saturated.load(Ordering::Acquire) || self.revision_exhausted.load(Ordering::Acquire)
+        {
             return SnapshotCurrentness::Stale(StaleReason::PublicationSaturated);
         }
         if let Some(mutation) = ContentMutation::from_raw(self.mutation.load(Ordering::Acquire)) {
@@ -198,7 +227,40 @@ mod tests {
         );
         assert_eq!(status.published_revision(), revision);
         status.mark_published(revision);
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationSaturated)
+        );
+        status.recover_saturation();
         assert_eq!(status.require_current(), Ok(revision));
+    }
+
+    #[test]
+    fn revision_counter_saturates_instead_of_wrapping() {
+        let status = ContentStatus::new(Arc::new(SessionContentEpoch::default()));
+        status.next_revision.store(u64::MAX - 1, Ordering::Relaxed);
+        assert_eq!(status.next_revision(), ContentRevision(u64::MAX - 1));
+        assert_eq!(status.next_revision(), ContentRevision(u64::MAX));
+        assert_eq!(status.next_revision(), ContentRevision(u64::MAX));
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationSaturated)
+        );
+        status.recover_saturation();
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationSaturated)
+        );
+    }
+
+    #[test]
+    fn session_epoch_exhaustion_fails_closed() {
+        let epoch = SessionContentEpoch::default();
+        epoch.epoch.store(u64::MAX, Ordering::Relaxed);
+        epoch.mutation_started();
+        epoch.mutation_finished();
+        assert!(epoch.capture().is_none());
+        assert!(!epoch.validate(u64::MAX));
     }
 
     #[test]

--- a/src/rust/shoop_engine/src/content_snapshot/transport.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/transport.rs
@@ -1,0 +1,87 @@
+use super::ContentStatus;
+use rtrb::{Consumer, PopError, Producer, PushError, RingBuffer};
+use std::sync::Arc;
+
+pub struct ProcessSender<T> {
+    producer: Producer<T>,
+    status: Arc<ContentStatus>,
+}
+
+pub struct PublisherReceiver<T> {
+    consumer: Consumer<T>,
+}
+
+pub fn bounded_transport<T>(
+    capacity: usize,
+    status: Arc<ContentStatus>,
+) -> (ProcessSender<T>, PublisherReceiver<T>) {
+    let (producer, consumer) = RingBuffer::new(capacity.max(1));
+    (
+        ProcessSender { producer, status },
+        PublisherReceiver { consumer },
+    )
+}
+
+impl<T> ProcessSender<T> {
+    pub fn try_send(&mut self, item: T) -> Result<(), T> {
+        match self.producer.push(item) {
+            Ok(()) => Ok(()),
+            Err(PushError::Full(item)) => {
+                self.status.mark_saturated();
+                Err(item)
+            }
+        }
+    }
+
+    pub fn slots(&self) -> usize {
+        self.producer.slots()
+    }
+}
+
+impl<T> PublisherReceiver<T> {
+    pub fn try_recv(&mut self) -> Option<T> {
+        match self.consumer.pop() {
+            Ok(item) => Some(item),
+            Err(PopError::Empty) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content_snapshot::{
+        CurrentDataError, SessionContentEpoch, SnapshotCurrentness, StaleReason,
+    };
+
+    #[test]
+    fn fifo_transport_is_bounded_and_marks_saturation() {
+        let status = Arc::new(ContentStatus::new(Arc::new(SessionContentEpoch::default())));
+        let (mut sender, mut receiver) = bounded_transport(2, Arc::clone(&status));
+        assert_eq!(sender.try_send(1), Ok(()));
+        assert_eq!(sender.try_send(2), Ok(()));
+        assert_eq!(sender.try_send(3), Err(3));
+        assert_eq!(
+            status.currentness(),
+            SnapshotCurrentness::Stale(StaleReason::PublicationSaturated)
+        );
+        assert_eq!(
+            status.require_current(),
+            Err(CurrentDataError::PublicationSaturated)
+        );
+        assert_eq!(receiver.try_recv(), Some(1));
+        assert_eq!(receiver.try_recv(), Some(2));
+        assert_eq!(receiver.try_recv(), None);
+    }
+
+    #[test]
+    fn a_failed_push_returns_ownership_to_the_process_side() {
+        let status = Arc::new(ContentStatus::new(Arc::new(SessionContentEpoch::default())));
+        let (mut sender, _receiver) = bounded_transport(1, status);
+        let first = Box::new(1);
+        let second = Box::new(2);
+        assert!(sender.try_send(first).is_ok());
+        let returned = sender.try_send(second).expect_err("queue is full");
+        assert_eq!(*returned, 2);
+    }
+}

--- a/src/rust/shoop_engine/src/engine.rs
+++ b/src/rust/shoop_engine/src/engine.rs
@@ -457,6 +457,7 @@ impl EngineHandle {
         self.alive.load(Ordering::Acquire)
     }
 
+    #[cfg(feature = "app_backend")]
     pub(crate) fn connected_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.alive)
     }

--- a/src/rust/shoop_engine/src/lib.rs
+++ b/src/rust/shoop_engine/src/lib.rs
@@ -118,7 +118,9 @@ pub use graph_build::{ChannelDesc, GraphDesc, LoopDesc, PortDesc};
 pub use internal_audio_port::InternalAudioPort;
 pub use loop_mode::LoopMode;
 pub use midi_buffering_input_port::MidiBufferingInputPort;
-pub use midi_channel::{MidiChannel, MidiChannelError, PreparedMidiChannelData};
+#[cfg(feature = "app_backend")]
+pub use midi_channel::PreparedMidiChannelData;
+pub use midi_channel::{MidiChannel, MidiChannelError};
 pub use midi_event::MidiEvent;
 pub use midi_port::MidiPort;
 pub use midi_ringbuffer::MidiRingbuffer;

--- a/src/rust/shoop_engine/src/lib.rs
+++ b/src/rust/shoop_engine/src/lib.rs
@@ -16,6 +16,7 @@ pub mod composite_plan;
 pub mod composite_runtime;
 pub mod composite_semantics;
 pub mod composite_timeline;
+pub mod content_snapshot;
 #[cfg(feature = "cpal")]
 pub mod cpal_mock;
 pub mod decoupled_midi_port;
@@ -90,6 +91,11 @@ pub use composite_timeline::{
     CompositeTimelineControlError, CompositeTimelineCounters, CompositeTimelineFault,
     CompositeTimelineFaultRecord, CompositeTimelineLimits, CompositeTimelineNode,
     CompositeTimelineNodeState, MAX_COMPOSITE_CONTROLS,
+};
+pub use content_snapshot::{
+    AudioContentSnapshot, AudioSnapshotMetadata, ContentMutation, ContentRevision,
+    CurrentDataError, MidiContentSnapshot, MidiSnapshotMetadata, SnapshotCurrentness, SnapshotRead,
+    StaleReason,
 };
 pub use decoupled_midi_port::DecoupledMidiPort;
 pub use driver::{

--- a/src/rust/shoop_engine/src/lib.rs
+++ b/src/rust/shoop_engine/src/lib.rs
@@ -118,7 +118,7 @@ pub use graph_build::{ChannelDesc, GraphDesc, LoopDesc, PortDesc};
 pub use internal_audio_port::InternalAudioPort;
 pub use loop_mode::LoopMode;
 pub use midi_buffering_input_port::MidiBufferingInputPort;
-pub use midi_channel::{MidiChannel, MidiChannelError};
+pub use midi_channel::{MidiChannel, MidiChannelError, PreparedMidiChannelData};
 pub use midi_event::MidiEvent;
 pub use midi_port::MidiPort;
 pub use midi_ringbuffer::MidiRingbuffer;

--- a/src/rust/shoop_engine/src/midi_channel.rs
+++ b/src/rust/shoop_engine/src/midi_channel.rs
@@ -16,6 +16,7 @@
 //! interest.
 
 use crate::channel_mode::{channel_process_params, ChannelMode, ProcessFlags};
+use crate::content_snapshot::MidiProcessSnapshotWriter;
 use crate::loop_mode::LoopMode;
 use crate::midi;
 use crate::midi_event::MidiEvent;
@@ -64,6 +65,48 @@ impl OutBuf {
     }
 }
 
+fn snapshot_mutation(flags: ProcessFlags) -> Option<crate::content_snapshot::ContentMutation> {
+    if flags.contains(ProcessFlags::REPLACE) {
+        Some(crate::content_snapshot::ContentMutation::Replacing)
+    } else if flags.contains(ProcessFlags::RECORD) {
+        Some(crate::content_snapshot::ContentMutation::Recording)
+    } else if flags.contains(ProcessFlags::PRE_RECORD) {
+        Some(crate::content_snapshot::ContentMutation::PreRecording)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct PreparedMidiChannelData {
+    storage: MidiStorage,
+    prerecord_storage: MidiStorage,
+    length: u32,
+    start_state: MidiStateTracker,
+    start_state_valid: bool,
+}
+
+impl PreparedMidiChannelData {
+    pub fn new(messages: &[MidiStorageElem], length: u32, start_state: Option<&[Vec<u8>]>) -> Self {
+        let capacity = messages.len().max(1);
+        let mut storage = MidiStorage::with_capacity_elems(capacity);
+        for message in messages {
+            storage.append(message.time, message.data(), false, None);
+        }
+        let mut state = MidiStateTracker::new(TrackWhat::ALL);
+        for message in start_state.unwrap_or(&[]) {
+            state.process(message);
+        }
+        Self {
+            storage,
+            prerecord_storage: MidiStorage::with_capacity_elems(capacity),
+            length,
+            start_state: state,
+            start_state_valid: start_state.is_some(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct MidiChannel {
     storage: MidiStorage,
@@ -106,6 +149,7 @@ pub struct MidiChannel {
     /// never grows it.
     restore_scratch: Vec<MidiStorageElem>,
     state: Arc<MidiChannelStateMirror>,
+    content_snapshots: Option<MidiProcessSnapshotWriter>,
 }
 
 impl MidiChannel {
@@ -121,6 +165,15 @@ impl MidiChannel {
         capacity: usize,
         mode: ChannelMode,
         state: Arc<MidiChannelStateMirror>,
+    ) -> Self {
+        Self::with_capacity_state_and_snapshots(capacity, mode, state, None)
+    }
+
+    pub fn with_capacity_state_and_snapshots(
+        capacity: usize,
+        mode: ChannelMode,
+        state: Arc<MidiChannelStateMirror>,
+        content_snapshots: Option<MidiProcessSnapshotWriter>,
     ) -> Self {
         let storage = MidiStorage::with_capacity_elems(capacity);
         let playback_cursor = storage.create_cursor();
@@ -151,6 +204,7 @@ impl MidiChannel {
             play: None,
             restore_scratch: Vec::with_capacity(MAX_DIFF_MESSAGES),
             state,
+            content_snapshots,
         };
         channel.publish_state();
         channel
@@ -168,10 +222,7 @@ impl MidiChannel {
         );
     }
 
-    fn publish_data(&self) {
-        if !self.state.complex_data_enabled() {
-            return;
-        }
+    fn publish_snapshot_contents(&mut self, mutation: crate::content_snapshot::ContentMutation) {
         let mut data: Vec<MidiEvent> = self
             .recording_start_state_messages()
             .into_iter()
@@ -181,7 +232,20 @@ impl MidiChannel {
             time: event.time as i32,
             data: event.data().to_vec(),
         }));
-        self.state.replace_data(data);
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_mutation(mutation);
+            snapshots.clear(data.is_empty());
+            let last = data.len().saturating_sub(1);
+            for (index, event) in data.iter().enumerate() {
+                snapshots.append_raw_event(
+                    event.time,
+                    &event.data,
+                    self.data_length,
+                    index == last,
+                );
+            }
+            snapshots.finish_mutation(false);
+        }
     }
 
     // --- accessors ---
@@ -264,7 +328,7 @@ impl MidiChannel {
         self.pending_playback_valid = false;
         self.loaded_contents = false;
         self.start_offset = 0;
-        self.publish_data();
+        self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Clearing);
         self.data_changed();
     }
 
@@ -300,7 +364,25 @@ impl MidiChannel {
         for m in start_state.unwrap_or(&[]) {
             self.recording_start_state.process(m);
         }
-        self.publish_data();
+        self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Loading);
+        self.data_changed();
+    }
+
+    pub(crate) fn commit_prepared_data_and_snapshot(
+        &mut self,
+        prepared: &mut PreparedMidiChannelData,
+        snapshot: crate::content_snapshot::PreparedMidiSnapshot,
+    ) {
+        std::mem::swap(&mut self.storage, &mut prepared.storage);
+        std::mem::swap(&mut self.prerecord_storage, &mut prepared.prerecord_storage);
+        std::mem::swap(&mut self.data_length, &mut prepared.length);
+        std::mem::swap(&mut self.recording_start_state, &mut prepared.start_state);
+        self.recording_start_valid = prepared.start_state_valid;
+        self.playback_cursor = self.storage.create_cursor();
+        self.loaded_contents = true;
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.install_prepared(snapshot);
+        }
         self.data_changed();
     }
 
@@ -310,7 +392,7 @@ impl MidiChannel {
         let changed = len != self.data_length;
         self.data_length = len;
         if changed {
-            self.publish_data();
+            self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Loading);
             self.data_changed();
         }
     }
@@ -428,6 +510,25 @@ impl MidiChannel {
             flags = ProcessFlags(flags.0 & !ProcessFlags::PLAYBACK.0);
         }
 
+        let previous_mutation = snapshot_mutation(self.prev_process_flags);
+        let current_mutation = snapshot_mutation(flags);
+        if previous_mutation != current_mutation {
+            if let Some(previous) = previous_mutation {
+                if let Some(snapshots) = self.content_snapshots.as_mut() {
+                    if previous == crate::content_snapshot::ContentMutation::PreRecording {
+                        snapshots.cancel_mutation();
+                    } else {
+                        snapshots.finish_mutation(false);
+                    }
+                }
+            }
+            if let Some(mutation) = current_mutation {
+                if let Some(snapshots) = self.content_snapshots.as_ref() {
+                    snapshots.begin_mutation(mutation);
+                }
+            }
+        }
+
         // Anything other than plain forward playback leaves notes hanging.
         let interrupted = self.prev_process_flags.contains(ProcessFlags::PLAYBACK)
             && (!flags.contains(ProcessFlags::PLAYBACK)
@@ -507,7 +608,10 @@ impl MidiChannel {
         self.prev_process_flags = flags;
 
         if adopted_prerecording {
-            self.publish_data();
+            self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Recording);
+            if let Some(snapshots) = self.content_snapshots.as_ref() {
+                snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Recording);
+            }
             self.data_changed();
         }
         if !processed_input {
@@ -575,6 +679,11 @@ impl MidiChannel {
             };
             Self::set_length_impl(storage, len, record_from);
         }
+        if !into_prerecord {
+            if let Some(snapshots) = self.content_snapshots.as_mut() {
+                snapshots.truncate_after(record_from as i32, record_from, false);
+            }
+        }
 
         let record_end = rec.n_frames_processed + n_samples;
         let mut changed = false;
@@ -616,6 +725,13 @@ impl MidiChannel {
                 } else {
                     self.storage.append(at, e.data(), false, None)
                 };
+                if stored && !into_prerecord {
+                    if let Some(snapshots) = self.content_snapshots.as_mut() {
+                        if let Some(event) = MidiStorageElem::new(at, e.data()) {
+                            snapshots.append_storage_events(&[event], at, false);
+                        }
+                    }
+                }
                 changed |= stored;
             }
             self.input_state.process(e.data());
@@ -633,8 +749,12 @@ impl MidiChannel {
             let target = *len + n_samples;
             Self::set_length_impl(storage, len, target);
         }
+        if !into_prerecord {
+            if let Some(snapshots) = self.content_snapshots.as_mut() {
+                snapshots.append_storage_events(&[], self.data_length, true);
+            }
+        }
         if changed {
-            self.publish_data();
             self.data_changed();
         }
         Ok(())

--- a/src/rust/shoop_engine/src/midi_channel.rs
+++ b/src/rust/shoop_engine/src/midi_channel.rs
@@ -19,7 +19,6 @@ use crate::channel_mode::{channel_process_params, ChannelMode, ProcessFlags};
 use crate::content_snapshot::MidiProcessSnapshotWriter;
 use crate::loop_mode::LoopMode;
 use crate::midi;
-use crate::midi_event::MidiEvent;
 use crate::midi_state::{MidiStateTracker, TrackWhat, MAX_DIFF_MESSAGES};
 use crate::midi_storage::{Cursor, MidiStorage, MidiStorageElem, TruncateSide};
 use crate::state_mirror::MidiChannelStateMirror;
@@ -77,6 +76,7 @@ fn snapshot_mutation(flags: ProcessFlags) -> Option<crate::content_snapshot::Con
     }
 }
 
+#[cfg(feature = "app_backend")]
 #[derive(Debug)]
 pub struct PreparedMidiChannelData {
     storage: MidiStorage,
@@ -86,6 +86,7 @@ pub struct PreparedMidiChannelData {
     start_state_valid: bool,
 }
 
+#[cfg(feature = "app_backend")]
 impl PreparedMidiChannelData {
     pub fn new(messages: &[MidiStorageElem], length: u32, start_state: Option<&[Vec<u8>]>) -> Self {
         let capacity = messages.len().max(1);
@@ -222,30 +223,30 @@ impl MidiChannel {
         );
     }
 
+    /// Compatibility publication for legacy control-side setters. Realtime recording and
+    /// prepared application loads use bounded incremental/prepared operations instead.
     fn publish_snapshot_contents(&mut self, mutation: crate::content_snapshot::ContentMutation) {
-        let mut data: Vec<MidiEvent> = self
-            .recording_start_state_messages()
-            .into_iter()
-            .map(|data| MidiEvent { time: -1, data })
-            .collect();
-        data.extend(self.storage.iter().map(|event| MidiEvent {
-            time: event.time as i32,
-            data: event.data().to_vec(),
-        }));
-        if let Some(snapshots) = self.content_snapshots.as_mut() {
-            snapshots.begin_mutation(mutation);
-            snapshots.clear(data.is_empty());
-            let last = data.len().saturating_sub(1);
-            for (index, event) in data.iter().enumerate() {
-                snapshots.append_raw_event(
-                    event.time,
-                    &event.data,
-                    self.data_length,
-                    index == last,
-                );
-            }
-            snapshots.finish_mutation(false);
+        let MidiChannel {
+            storage,
+            data_length,
+            recording_start_state,
+            restore_scratch,
+            content_snapshots,
+            ..
+        } = self;
+        let Some(snapshots) = content_snapshots.as_mut() else {
+            return;
+        };
+        snapshots.begin_working_generation();
+        snapshots.begin_mutation(mutation);
+        snapshots.clear(false);
+        recording_start_state.state_as_messages_into(restore_scratch);
+        snapshots.append_state_events(restore_scratch, *data_length);
+        for event in storage.iter() {
+            snapshots.append_storage_events(&[*event], *data_length, false);
         }
+        snapshots.append_storage_events(&[], *data_length, true);
+        snapshots.finish_mutation(false);
     }
 
     // --- accessors ---
@@ -328,7 +329,12 @@ impl MidiChannel {
         self.pending_playback_valid = false;
         self.loaded_contents = false;
         self.start_offset = 0;
-        self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Clearing);
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.begin_working_generation();
+            snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Clearing);
+            snapshots.clear(true);
+            snapshots.finish_mutation(false);
+        }
         self.data_changed();
     }
 
@@ -368,6 +374,7 @@ impl MidiChannel {
         self.data_changed();
     }
 
+    #[cfg(feature = "app_backend")]
     pub(crate) fn commit_prepared_data_and_snapshot(
         &mut self,
         prepared: &mut PreparedMidiChannelData,
@@ -387,12 +394,22 @@ impl MidiChannel {
     }
 
     pub fn set_length(&mut self, length: u32) {
+        let old_length = self.data_length;
         let mut len = self.data_length;
         Self::set_length_impl(&mut self.storage, &mut len, length);
         let changed = len != self.data_length;
         self.data_length = len;
         if changed {
-            self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Loading);
+            if let Some(snapshots) = self.content_snapshots.as_mut() {
+                snapshots.begin_working_generation();
+                snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Loading);
+                if length < old_length {
+                    snapshots.truncate_after(length as i32, length, true);
+                } else {
+                    snapshots.append_storage_events(&[], length, true);
+                }
+                snapshots.finish_mutation(false);
+            }
             self.data_changed();
         }
     }
@@ -515,15 +532,26 @@ impl MidiChannel {
         if previous_mutation != current_mutation {
             if let Some(previous) = previous_mutation {
                 if let Some(snapshots) = self.content_snapshots.as_mut() {
-                    if previous == crate::content_snapshot::ContentMutation::PreRecording {
+                    if previous == crate::content_snapshot::ContentMutation::PreRecording
+                        && current_mutation
+                            != Some(crate::content_snapshot::ContentMutation::Recording)
+                    {
                         snapshots.cancel_mutation();
                     } else {
-                        snapshots.finish_mutation(false);
+                        snapshots.finish_mutation(
+                            previous == crate::content_snapshot::ContentMutation::Replacing,
+                        );
                     }
                 }
             }
             if let Some(mutation) = current_mutation {
-                if let Some(snapshots) = self.content_snapshots.as_ref() {
+                if let Some(snapshots) = self.content_snapshots.as_mut() {
+                    let carries_prerecord = previous_mutation
+                        == Some(crate::content_snapshot::ContentMutation::PreRecording)
+                        && mutation == crate::content_snapshot::ContentMutation::Recording;
+                    if !carries_prerecord {
+                        snapshots.begin_working_generation();
+                    }
                     snapshots.begin_mutation(mutation);
                 }
             }
@@ -608,10 +636,6 @@ impl MidiChannel {
         self.prev_process_flags = flags;
 
         if adopted_prerecording {
-            self.publish_snapshot_contents(crate::content_snapshot::ContentMutation::Recording);
-            if let Some(snapshots) = self.content_snapshots.as_ref() {
-                snapshots.begin_mutation(crate::content_snapshot::ContentMutation::Recording);
-            }
             self.data_changed();
         }
         if !processed_input {
@@ -715,8 +739,26 @@ impl MidiChannel {
                     }
                     if into_prerecord {
                         self.temp_prerecording_valid = true;
+                        let MidiChannel {
+                            temp_prerecording_start_state,
+                            restore_scratch,
+                            ..
+                        } = self;
+                        temp_prerecording_start_state.state_as_messages_into(restore_scratch);
+                        if let Some(snapshots) = self.content_snapshots.as_mut() {
+                            snapshots.append_state_events(restore_scratch, record_from);
+                        }
                     } else {
                         self.recording_start_valid = true;
+                        let MidiChannel {
+                            recording_start_state,
+                            restore_scratch,
+                            ..
+                        } = self;
+                        recording_start_state.state_as_messages_into(restore_scratch);
+                        if let Some(snapshots) = self.content_snapshots.as_mut() {
+                            snapshots.append_state_events(restore_scratch, record_from);
+                        }
                     }
                 }
                 let at = record_from + e.time - rec.n_frames_processed;
@@ -725,7 +767,7 @@ impl MidiChannel {
                 } else {
                     self.storage.append(at, e.data(), false, None)
                 };
-                if stored && !into_prerecord {
+                if stored {
                     if let Some(snapshots) = self.content_snapshots.as_mut() {
                         if let Some(event) = MidiStorageElem::new(at, e.data()) {
                             snapshots.append_storage_events(&[event], at, false);
@@ -749,10 +791,16 @@ impl MidiChannel {
             let target = *len + n_samples;
             Self::set_length_impl(storage, len, target);
         }
-        if !into_prerecord {
-            if let Some(snapshots) = self.content_snapshots.as_mut() {
-                snapshots.append_storage_events(&[], self.data_length, true);
-            }
+        if let Some(snapshots) = self.content_snapshots.as_mut() {
+            snapshots.append_storage_events(
+                &[],
+                if into_prerecord {
+                    self.prerecord_data_length
+                } else {
+                    self.data_length
+                },
+                !into_prerecord,
+            );
         }
         if changed {
             self.data_changed();

--- a/src/rust/shoop_engine/src/midi_state.rs
+++ b/src/rust/shoop_engine/src/midi_state.rs
@@ -249,35 +249,49 @@ impl MidiStateTracker {
     /// Controllers come before notes so a note sounds with the intended
     /// controller values already applied.
     pub fn state_as_messages(&self) -> Vec<Vec<u8>> {
-        let mut out = Vec::new();
+        let mut storage = Vec::with_capacity(MAX_DIFF_MESSAGES);
+        self.state_as_messages_into(&mut storage);
+        storage
+            .iter()
+            .map(|message| message.data().to_vec())
+            .collect()
+    }
+
+    /// Allocation-free variant for process-side publication.
+    pub fn state_as_messages_into(&self, out: &mut Vec<MidiStorageElem>) {
+        out.clear();
+        let mut push = |data: &[u8]| {
+            if let Some(message) = MidiStorageElem::new(0, data) {
+                out.push(message);
+            }
+        };
         for ch in 0..N_CHANNELS as u8 {
             if let Some(c) = self.controls.get(ch as usize) {
-                for (controller, v) in c.cc.iter().enumerate() {
-                    if let Some(v) = v {
-                        out.push(midi::cc(ch, controller as u8, *v).to_vec());
+                for (controller, value) in c.cc.iter().enumerate() {
+                    if let Some(value) = value {
+                        push(&midi::cc(ch, controller as u8, *value));
                     }
                 }
-                if let Some(v) = c.pitch_wheel {
-                    out.push(midi::pitch_wheel(ch, v).to_vec());
+                if let Some(value) = c.pitch_wheel {
+                    push(&midi::pitch_wheel(ch, value));
                 }
-                if let Some(v) = c.channel_pressure {
-                    out.push(midi::channel_pressure(ch, v).to_vec());
+                if let Some(value) = c.channel_pressure {
+                    push(&midi::channel_pressure(ch, value));
                 }
             }
-            if let Some(p) = self.program(ch) {
-                out.push(midi::program_change(ch, p).to_vec());
+            if let Some(program) = self.program(ch) {
+                push(&midi::program_change(ch, program));
             }
         }
         for ch in 0..N_CHANNELS as u8 {
             if let Some(slots) = self.notes.get(ch as usize) {
-                for (note, v) in slots.iter().enumerate() {
-                    if let Some(v) = v {
-                        out.push(midi::note_on(ch, note as u8, *v).to_vec());
+                for (note, velocity) in slots.iter().enumerate() {
+                    if let Some(velocity) = velocity {
+                        push(&midi::note_on(ch, note as u8, *velocity));
                     }
                 }
             }
         }
-        out
     }
 
     /// [`Self::diff_to`] without allocating, appending into `out`.

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1021,11 +1021,23 @@ impl Session {
         mode: ChannelMode,
         state: Arc<AudioChannelStateMirror>,
     ) -> Result<usize, SessionError> {
+        self.add_audio_channel_with_state_and_snapshots(loop_idx, chunk_size, mode, state, None)
+    }
+
+    pub fn add_audio_channel_with_state_and_snapshots(
+        &mut self,
+        loop_idx: usize,
+        chunk_size: usize,
+        mode: ChannelMode,
+        state: Arc<AudioChannelStateMirror>,
+        snapshots: Option<crate::content_snapshot::AudioProcessSnapshotWriter>,
+    ) -> Result<usize, SessionError> {
         let l = self
             .loops
             .get_mut(loop_idx)
             .ok_or(SessionError::NoSuchLoop(loop_idx))?;
-        let channel_idx = l.add_audio_channel_with_state(chunk_size, mode, state);
+        let channel_idx =
+            l.add_audio_channel_with_state_and_snapshots(chunk_size, mode, state, snapshots);
         self.channels.push(ChannelMapping {
             loop_idx,
             kind: ChannelKind::Audio,
@@ -1059,11 +1071,23 @@ impl Session {
         mode: ChannelMode,
         state: Arc<MidiChannelStateMirror>,
     ) -> Result<usize, SessionError> {
+        self.add_midi_channel_with_state_and_snapshots(loop_idx, capacity_elems, mode, state, None)
+    }
+
+    pub fn add_midi_channel_with_state_and_snapshots(
+        &mut self,
+        loop_idx: usize,
+        capacity_elems: usize,
+        mode: ChannelMode,
+        state: Arc<MidiChannelStateMirror>,
+        snapshots: Option<crate::content_snapshot::MidiProcessSnapshotWriter>,
+    ) -> Result<usize, SessionError> {
         let l = self
             .loops
             .get_mut(loop_idx)
             .ok_or(SessionError::NoSuchLoop(loop_idx))?;
-        let channel_idx = l.add_midi_channel_with_state(capacity_elems, mode, state);
+        let channel_idx =
+            l.add_midi_channel_with_state_and_snapshots(capacity_elems, mode, state, snapshots);
         self.channels.push(ChannelMapping {
             loop_idx,
             kind: ChannelKind::Midi,

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1397,46 +1397,19 @@ impl Session {
         Ok(shape)
     }
 
-    pub fn adopt_audio_ringbuffers_prepared(
+    pub fn prepare_audio_ringbuffers_prepared(
         &mut self,
         requests: &[AudioRingbufferAdoption],
         prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
-    ) -> Result<(), SessionError> {
-        self.adopt_audio_ringbuffers_prepared_inner(requests, prepared, None)
-    }
-
-    /// The application backend variant also returns preallocated copies for control-thread
-    /// state-mirror publication. Filling the copies is bounded and allocation-free.
-    pub fn adopt_audio_ringbuffers_prepared_with_copies(
-        &mut self,
-        requests: &[AudioRingbufferAdoption],
-        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
-        copies: &mut [Vec<f32>],
-    ) -> Result<(), SessionError> {
-        self.adopt_audio_ringbuffers_prepared_inner(requests, prepared, Some(copies))
-    }
-
-    fn adopt_audio_ringbuffers_prepared_inner(
-        &mut self,
-        requests: &[AudioRingbufferAdoption],
-        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
-        mut copies: Option<&mut [Vec<f32>]>,
     ) -> Result<(), SessionError> {
         let shape = self.describe_audio_ringbuffer_adoption(requests)?;
-        if prepared.len() != shape.n_channels
-            || copies
-                .as_ref()
-                .is_some_and(|copies| copies.len() != shape.n_channels)
-        {
+        if prepared.len() != shape.n_channels {
             return Err(SessionError::AudioRingbufferAdoptionCapacity);
         }
-        for (index, (slot, expected)) in prepared.iter_mut().zip(shape.channels()).enumerate() {
+        for (slot, expected) in prepared.iter_mut().zip(shape.channels()) {
             if slot.loop_idx != expected.loop_idx
                 || slot.channel_idx != expected.channel_idx
                 || slot.data.capacity() < expected.capacity
-                || copies
-                    .as_ref()
-                    .is_some_and(|copies| copies[index].capacity() < expected.capacity)
             {
                 return Err(SessionError::AudioRingbufferAdoptionCapacity);
             }
@@ -1470,8 +1443,68 @@ impl Session {
                     offset += samples.len();
                 });
             }
-            if let Some(copies) = copies.as_deref_mut() {
-                slot.data.copy_to_preallocated(&mut copies[index]);
+        }
+        Ok(())
+    }
+
+    pub fn commit_audio_ringbuffers_prepared_with_snapshots(
+        &mut self,
+        requests: &[AudioRingbufferAdoption],
+        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
+        snapshots: &[crate::content_snapshot::PreparedAudioSnapshot],
+    ) -> Result<(), SessionError> {
+        if prepared.len() != snapshots.len() {
+            return Err(SessionError::AudioRingbufferAdoptionCapacity);
+        }
+        for (slot, snapshot) in prepared.iter_mut().zip(snapshots.iter().copied()) {
+            self.loops[slot.loop_idx]
+                .audio_channel_mut(slot.channel_idx)
+                .ok_or(SessionError::NoSuchChannel(slot.channel_idx))?
+                .commit_prepared_data_and_snapshot(&mut slot.data, snapshot);
+        }
+        self.apply_audio_ringbuffer_adoption_states(requests);
+        Ok(())
+    }
+
+    pub fn adopt_audio_ringbuffers_prepared(
+        &mut self,
+        requests: &[AudioRingbufferAdoption],
+        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
+    ) -> Result<(), SessionError> {
+        self.adopt_audio_ringbuffers_prepared_inner(requests, prepared, None)
+    }
+
+    /// The application backend variant also returns preallocated copies for control-thread
+    /// state-mirror publication. Filling the copies is bounded and allocation-free.
+    pub fn adopt_audio_ringbuffers_prepared_with_copies(
+        &mut self,
+        requests: &[AudioRingbufferAdoption],
+        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
+        copies: &mut [Vec<f32>],
+    ) -> Result<(), SessionError> {
+        self.adopt_audio_ringbuffers_prepared_inner(requests, prepared, Some(copies))
+    }
+
+    fn adopt_audio_ringbuffers_prepared_inner(
+        &mut self,
+        requests: &[AudioRingbufferAdoption],
+        prepared: &mut [PreparedAudioRingbufferAdoptionChannel],
+        mut copies: Option<&mut [Vec<f32>]>,
+    ) -> Result<(), SessionError> {
+        if let Some(copies) = copies.as_ref() {
+            if copies.len() != prepared.len()
+                || copies
+                    .iter()
+                    .zip(prepared.iter())
+                    .any(|(copy, slot)| copy.capacity() < slot.data.capacity())
+            {
+                return Err(SessionError::AudioRingbufferAdoptionCapacity);
+            }
+        }
+        self.prepare_audio_ringbuffers_prepared(requests, prepared)?;
+        if let Some(copies) = copies.as_deref_mut() {
+            for (slot, copy) in prepared.iter().zip(copies.iter_mut()) {
+                slot.data.copy_to_preallocated(copy);
             }
         }
 

--- a/src/rust/shoop_engine/src/state_mirror.rs
+++ b/src/rust/shoop_engine/src/state_mirror.rs
@@ -4,11 +4,9 @@ use crate::composite_runtime::{
     ActiveCompositeChild, CompositeRuntimeCounters, CompositeRuntimeFault,
 };
 use crate::loop_mode::LoopMode;
-use crate::midi_event::MidiEvent;
 use crate::state::{AudioChannelState, AudioPortState, LoopState, MidiChannelState, MidiPortState};
 use std::array;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::Mutex;
 
 const NO_MODE: i32 = -1;
 const NO_DELAY: u64 = u64::MAX;
@@ -419,7 +417,6 @@ impl Default for CompositeStateMirror {
 
 #[derive(Debug)]
 pub struct AudioChannelStateMirror {
-    complex_data_enabled: AtomicBool,
     mode: AtomicI32,
     gain: AtomicU32,
     output_peak: AtomicU32,
@@ -428,13 +425,11 @@ pub struct AudioChannelStateMirror {
     played_back_sample: AtomicI32,
     n_preplay_samples: AtomicU32,
     data_sequence: AtomicU64,
-    data: Mutex<Vec<f32>>,
 }
 
 impl Default for AudioChannelStateMirror {
     fn default() -> Self {
         Self {
-            complex_data_enabled: AtomicBool::new(false),
             mode: AtomicI32::new(ChannelMode::Disabled as i32),
             gain: AtomicU32::new(0.0f32.to_bits()),
             output_peak: AtomicU32::new(0.0f32.to_bits()),
@@ -443,20 +438,11 @@ impl Default for AudioChannelStateMirror {
             played_back_sample: AtomicI32::new(NO_SAMPLE),
             n_preplay_samples: AtomicU32::new(0),
             data_sequence: AtomicU64::new(0),
-            data: Mutex::new(Vec::new()),
         }
     }
 }
 
 impl AudioChannelStateMirror {
-    pub fn enable_complex_data(&self) {
-        self.complex_data_enabled.store(true, Ordering::Relaxed);
-    }
-
-    pub fn complex_data_enabled(&self) -> bool {
-        self.complex_data_enabled.load(Ordering::Relaxed)
-    }
-
     pub fn publish(
         &self,
         mode: ChannelMode,
@@ -516,37 +502,10 @@ impl AudioChannelStateMirror {
     pub fn data_sequence(&self) -> u64 {
         self.data_sequence.load(Ordering::Relaxed)
     }
-
-    pub fn replace_data(&self, data: Vec<f32>) {
-        if self.complex_data_enabled() {
-            *self.data.lock().unwrap_or_else(|e| e.into_inner()) = data;
-        }
-    }
-
-    pub fn write_data(&self, offset: usize, source: &[f32], length: usize) {
-        if !self.complex_data_enabled() {
-            return;
-        }
-        let mut data = self.data.lock().unwrap_or_else(|e| e.into_inner());
-        if data.len() < length {
-            data.resize(length, 0.0);
-        } else {
-            data.truncate(length);
-        }
-        let end = offset.saturating_add(source.len()).min(data.len());
-        if offset < end {
-            data[offset..end].copy_from_slice(&source[..end - offset]);
-        }
-    }
-
-    pub fn data(&self) -> Vec<f32> {
-        self.data.lock().unwrap_or_else(|e| e.into_inner()).clone()
-    }
 }
 
 #[derive(Debug)]
 pub struct MidiChannelStateMirror {
-    complex_data_enabled: AtomicBool,
     mode: AtomicI32,
     n_events_triggered: AtomicU32,
     n_notes_active: AtomicU32,
@@ -555,13 +514,11 @@ pub struct MidiChannelStateMirror {
     played_back_sample: AtomicI32,
     n_preplay_samples: AtomicU32,
     data_sequence: AtomicU64,
-    data: Mutex<Vec<MidiEvent>>,
 }
 
 impl Default for MidiChannelStateMirror {
     fn default() -> Self {
         Self {
-            complex_data_enabled: AtomicBool::new(false),
             mode: AtomicI32::new(ChannelMode::Disabled as i32),
             n_events_triggered: AtomicU32::new(0),
             n_notes_active: AtomicU32::new(0),
@@ -570,20 +527,11 @@ impl Default for MidiChannelStateMirror {
             played_back_sample: AtomicI32::new(NO_SAMPLE),
             n_preplay_samples: AtomicU32::new(0),
             data_sequence: AtomicU64::new(0),
-            data: Mutex::new(Vec::new()),
         }
     }
 }
 
 impl MidiChannelStateMirror {
-    pub fn enable_complex_data(&self) {
-        self.complex_data_enabled.store(true, Ordering::Relaxed);
-    }
-
-    pub fn complex_data_enabled(&self) -> bool {
-        self.complex_data_enabled.load(Ordering::Relaxed)
-    }
-
     pub fn publish(
         &self,
         mode: ChannelMode,
@@ -638,16 +586,6 @@ impl MidiChannelStateMirror {
 
     pub fn data_sequence(&self) -> u64 {
         self.data_sequence.load(Ordering::Relaxed)
-    }
-
-    pub fn replace_data(&self, data: Vec<MidiEvent>) {
-        if self.complex_data_enabled() {
-            *self.data.lock().unwrap_or_else(|e| e.into_inner()) = data;
-        }
-    }
-
-    pub fn data(&self) -> Vec<MidiEvent> {
-        self.data.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -11,7 +11,7 @@
 use assert_no_alloc::*;
 use shoop_engine::channel_mode::ChannelMode;
 use shoop_engine::content_snapshot::{
-    audio_snapshot_channel, midi_snapshot_channel, SessionContentEpoch,
+    audio_snapshot_channel, midi_snapshot_channel, ContentSnapshotRuntime, SessionContentEpoch,
 };
 use shoop_engine::dummy_midi_port::DummyMidiPort;
 use shoop_engine::dummy_port::{DummyAudioPort, PortId};
@@ -50,11 +50,25 @@ fn snapshot_process_publication_is_allocation_free() {
     let (mut audio, _audio_control, _audio_publisher, _audio_reader) =
         audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 8, 4);
     let (mut midi, _midi_control, _midi_publisher, _midi_reader) =
-        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
-    let midi_events = [
-        MidiStorageElem::new(1, &[0x90, 60, 100]).expect("valid MIDI"),
-        MidiStorageElem::new(3, &[0x80, 60, 0]).expect("valid MIDI"),
-    ];
+        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 20);
+    let mut midi_events = [MidiStorageElem::default(); 32];
+    for (index, event) in midi_events.iter_mut().enumerate() {
+        *event = MidiStorageElem::new(index as u32, &[0x90, index as u8, 100]).expect("valid MIDI");
+    }
+    let (mut audio_install, audio_control, _publisher, _reader) =
+        audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 8, 2);
+    let audio_prepared = audio_control
+        .prepare(&[1.0, 2.0], ContentMutation::Loading)
+        .expect("prepare audio");
+    let (mut midi_install, midi_control, _publisher, _reader) =
+        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 2);
+    let midi_prepared = midi_control
+        .prepare(
+            &[shoop_engine::MidiEvent::new(1, vec![0x90, 60, 100])],
+            4,
+            ContentMutation::Loading,
+        )
+        .expect("prepare MIDI");
 
     assert_no_alloc(|| {
         assert!(audio.begin_mutation(ContentMutation::Recording));
@@ -64,8 +78,24 @@ fn snapshot_process_publication_is_allocation_free() {
         audio.finish_mutation(false);
 
         assert!(midi.begin_mutation(ContentMutation::Recording));
-        assert!(midi.append_storage_events(&midi_events, 4, true).is_some());
+        assert!(midi.append_state_events(&midi_events[..16], 32).is_some());
+        assert!(midi.append_storage_events(&midi_events, 32, true).is_some());
         midi.finish_mutation(false);
+
+        assert!(audio_install.install_prepared(audio_prepared));
+        assert!(midi_install.install_prepared(midi_prepared));
+    });
+}
+
+#[test]
+fn snapshot_process_endpoint_retirement_defers_pooled_destruction() {
+    let runtime = ContentSnapshotRuntime::new();
+    let (audio, _audio_control, _audio_reader) = runtime.create_audio_channel(8, 4);
+    let (midi, _midi_control, _midi_reader) = runtime.create_midi_channel(4, 4);
+
+    assert_no_alloc(|| {
+        drop(audio);
+        drop(midi);
     });
 }
 

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -10,6 +10,9 @@
 
 use assert_no_alloc::*;
 use shoop_engine::channel_mode::ChannelMode;
+use shoop_engine::content_snapshot::{
+    audio_snapshot_channel, midi_snapshot_channel, SessionContentEpoch,
+};
 use shoop_engine::dummy_midi_port::DummyMidiPort;
 use shoop_engine::dummy_port::{DummyAudioPort, PortId};
 use shoop_engine::internal_audio_port::InternalAudioPort;
@@ -21,10 +24,11 @@ use shoop_engine::session::{AudioRingbufferAdoption, Port, Session};
 use shoop_engine::{
     compile_composite_plan, BoundaryTargetAction, CompositeBoundaryTimeline, CompositeEntry,
     CompositePlanDescriptor, CompositePlanLimits, CompositeRuntime, CompositeSection,
-    CompositeTimeline, CompositeTimelineLimits, CompositeTimelineNode, LoopIdentity,
-    LoopTargetCatalog, LoopTargetKind, LoopTargetMetadata, PreparedAudioChannelData,
-    PreparedAudioRingbufferAdoptionChannel,
+    CompositeTimeline, CompositeTimelineLimits, CompositeTimelineNode, ContentMutation,
+    LoopIdentity, LoopTargetCatalog, LoopTargetKind, LoopTargetMetadata, MidiStorageElem,
+    PreparedAudioChannelData, PreparedAudioRingbufferAdoptionChannel,
 };
+use std::sync::Arc;
 
 #[cfg(debug_assertions)]
 #[global_allocator]
@@ -39,6 +43,30 @@ fn realtime_guard_reverse_guard_allows_exceptional_allocations() {
         });
     });
     realtime_alloc_guard::set_enabled(false);
+}
+
+#[test]
+fn snapshot_process_publication_is_allocation_free() {
+    let (mut audio, _audio_control, _audio_publisher, _audio_reader) =
+        audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 8, 4);
+    let (mut midi, _midi_control, _midi_publisher, _midi_reader) =
+        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 4);
+    let midi_events = [
+        MidiStorageElem::new(1, &[0x90, 60, 100]).expect("valid MIDI"),
+        MidiStorageElem::new(3, &[0x80, 60, 0]).expect("valid MIDI"),
+    ];
+
+    assert_no_alloc(|| {
+        assert!(audio.begin_mutation(ContentMutation::Recording));
+        assert!(audio
+            .publish_range(0, &[1.0, 2.0, 3.0, 4.0], 4, true)
+            .is_some());
+        audio.finish_mutation(false);
+
+        assert!(midi.begin_mutation(ContentMutation::Recording));
+        assert!(midi.append_storage_events(&midi_events, 4, true).is_some());
+        midi.finish_mutation(false);
+    });
 }
 
 fn audio_port(id: u64, name: &str, dir: PortDirection) -> Port {

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -10,9 +10,7 @@
 
 use assert_no_alloc::*;
 use shoop_engine::channel_mode::ChannelMode;
-use shoop_engine::content_snapshot::{
-    audio_snapshot_channel, midi_snapshot_channel, ContentSnapshotRuntime, SessionContentEpoch,
-};
+use shoop_engine::content_snapshot::ContentSnapshotRuntime;
 use shoop_engine::dummy_midi_port::DummyMidiPort;
 use shoop_engine::dummy_port::{DummyAudioPort, PortId};
 use shoop_engine::internal_audio_port::InternalAudioPort;
@@ -28,7 +26,6 @@ use shoop_engine::{
     LoopIdentity, LoopTargetCatalog, LoopTargetKind, LoopTargetMetadata, MidiStorageElem,
     PreparedAudioChannelData, PreparedAudioRingbufferAdoptionChannel,
 };
-use std::sync::Arc;
 
 #[cfg(debug_assertions)]
 #[global_allocator]
@@ -47,21 +44,18 @@ fn realtime_guard_reverse_guard_allows_exceptional_allocations() {
 
 #[test]
 fn snapshot_process_publication_is_allocation_free() {
-    let (mut audio, _audio_control, _audio_publisher, _audio_reader) =
-        audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 8, 4);
-    let (mut midi, _midi_control, _midi_publisher, _midi_reader) =
-        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 20);
+    let runtime = ContentSnapshotRuntime::new();
+    let (mut audio, _audio_control, _audio_reader) = runtime.create_audio_channel(8, 4);
+    let (mut midi, _midi_control, _midi_reader) = runtime.create_midi_channel(4, 20);
     let mut midi_events = [MidiStorageElem::default(); 32];
     for (index, event) in midi_events.iter_mut().enumerate() {
         *event = MidiStorageElem::new(index as u32, &[0x90, index as u8, 100]).expect("valid MIDI");
     }
-    let (mut audio_install, audio_control, _publisher, _reader) =
-        audio_snapshot_channel(Arc::new(SessionContentEpoch::default()), 8, 2);
+    let (mut audio_install, audio_control, _reader) = runtime.create_audio_channel(8, 2);
     let audio_prepared = audio_control
         .prepare(&[1.0, 2.0], ContentMutation::Loading)
         .expect("prepare audio");
-    let (mut midi_install, midi_control, _publisher, _reader) =
-        midi_snapshot_channel(Arc::new(SessionContentEpoch::default()), 4, 2);
+    let (mut midi_install, midi_control, _reader) = runtime.create_midi_channel(4, 2);
     let midi_prepared = midi_control
         .prepare(
             &[shoop_engine::MidiEvent::new(1, vec![0x90, 60, 100])],


### PR DESCRIPTION
## Summary
- add a session-scoped, revisioned audio/MIDI content snapshot runtime with bounded realtime publication and off-thread reclamation
- expose exact and latest-complete backend reads, revision-specific dirty acknowledgement, and coherent session-epoch capture for persistence/export
- migrate channel, frontend display, loading, save/export, and QML workflows to the snapshot protocol

## Validation
- `cargo fmt --all`
- `RUSTFLAGS="-D warnings" cargo build --workspace --features shoop_engine/app_backend`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend -- --test-threads=1`
- `QT_QPA_PLATFORM=offscreen SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test` (197 cases: 196 passed, 0 failed, 1 expected CPAL hardware skip)
