### PR TITLE
Add realtime mutex acquisition guard

### DIFF
--- a/plan_realtime_lock_guard.md
+++ b/plan_realtime_lock_guard.md
@@ -1,0 +1,107 @@
+# Make realtime mutex acquisition explicit
+
+Status: not started
+
+Branch: `content-snapshots-code`
+
+Base: `origin/master` at `996de36a`
+
+## Goals
+
+- Detect unapproved project-owned mutex acquisition from `shoop_engine` realtime sections, including uncontended acquisitions that never enter a futex syscall.
+- Make every currently known realtime mutex site explicit and locally justified in source.
+- Prevent new `std::sync::Mutex` use in `shoop_engine` from bypassing the detector.
+- Extend realtime-section coverage from the engine cycle alone to the complete project-owned JACK, CPAL, and dummy callback plumbing.
+- Preserve behavior when the developer guard is disabled.
+
+## Scope
+
+This includes a checked mutex abstraction for project-owned `shoop_engine` mutexes, realtime-section tracking, explicit temporary permissions for known callback lock debt, static enforcement, a developer CLI switch, and focused tests. It covers project-owned Rust callsites currently using `std::sync::Mutex`, including command-reachable sites.
+
+This does not remove the known locks, redesign driver/capture/plugin data flow, interpose native synchronization APIs, or claim coverage of locks inside JACK, CPAL, midir, lilv, LV2 plugins, libc, or operating-system audio code. Optional futex/pthread tracing is follow-up diagnostic work, not part of this implementation.
+
+## Acceptance criteria (immutable)
+
+- [ ] Every project-owned mutex declaration in production `shoop_engine` code uses the checked mutex abstraction; a structural check fails if production code imports, names, or directly acquires `std::sync::Mutex` outside the abstraction module.
+- [ ] Checked `lock()` and `try_lock()` attempts made in a marked realtime section are detected before acquisition, including uncontended attempts.
+- [ ] Realtime marking covers `Engine::process`, `Engine::run_cycle`, and `Engine::pump`, plus the complete project-owned JACK process callback, CPAL input/output callbacks, and dummy process iteration. Nested marking is correct and thread-local.
+- [ ] An unapproved realtime lock attempt is a deterministic guard violation in tests and terminates immediately in developer strict mode rather than blocking the callback.
+- [ ] Every known realtime lock site that remains is wrapped in a narrowly scoped, reason-labelled permission at the individual acquisition expression; there is no blanket permission around the command executor, whole engine cycle, whole driver callback, or arbitrary closure body.
+- [ ] The detector and permission path do not allocate, log, format, take another lock, or perform blocking I/O in realtime context.
+- [ ] Mutex poisoning behavior, guard lifetimes, `Condvar` interoperability, `Send`/`Sync` properties, and existing public engine behavior remain compatible.
+- [ ] The guard is disabled by default, can be enabled through a documented developer CLI option, and adds no lock-policy behavior change while disabled.
+- [ ] Focused tests cover disabled and enabled behavior, non-realtime acquisition, `lock`, `try_lock`, nested scopes, permission scope containment, thread locality, and representative engine/driver/capture/plugin lock sites.
+- [ ] Formatting, warning-free build, Rust tests, realtime no-allocation tests, and the QML self-test suite pass; a guard-enabled supported-backend test run reports no unapproved project-owned lock attempt.
+
+## Design rules
+
+- Detect at the Rust mutex API boundary, not at the futex boundary. Futex and pthread observation misses uncontended fast paths and is platform-dependent.
+- Use a project-owned wrapper around `std::sync::Mutex` that delegates to the standard mutex and returns standard guards/results where possible. Do not introduce a different locking algorithm.
+- Check a cheap global enable flag before consulting constant-initialized thread-local realtime and permission depths. Disabled control-thread mutex use must remain cheap.
+- Realtime and permission scopes must be panic-safe RAII scopes and support nesting without leaking state into later work.
+- The strict violation path must be realtime-safe. Human-readable diagnostics may use static site metadata and postmortem/control-thread reporting, but must not format or print from the callback.
+- Permission labels are literals describing why the lock remains. Permission wraps only the acquisition; code executed while holding the guard is not placed inside a broad detector bypass.
+- Migrate all project-owned mutexes, including control-only mutexes, so a future call-graph change cannot silently move an uninstrumented mutex into realtime context.
+- Explicitly inventory command-reachable lock paths. The allocation permission around command execution must not imply lock permission.
+- Treat third-party and native locking as an explicit coverage boundary in code and documentation; do not imply allocator-guard-equivalent dependency coverage.
+- Preserve existing source formatting and avoid unrelated lock removal or architectural changes in this work.
+
+## Implementation plan
+
+### Stage 1 — Establish the lock inventory and guard contract
+
+- [ ] Record the production `shoop_engine` mutex declarations and classify each acquisition as control-only, driver-callback, engine/session processing, capture, plugin/URID, or command-reachable.
+- [ ] Record the initial explicit realtime permission inventory, including JACK port/decoupled MIDI locks, CPAL rings/registries/endpoints/queues, dummy driver state, external capture, Carla/URID locks, object failure publication, and queued external-connection operations.
+- [ ] Add focused contract tests for realtime scope nesting, thread locality, unapproved acquisition, exact permission scope, and disabled behavior before migrating production callsites.
+- [ ] Verify the focused tests expose an unapproved synthetic mutex acquisition and do not classify ordinary control-thread acquisition as realtime; commit the stage.
+
+### Stage 2 — Add the checked mutex and realtime lock guard
+
+- [ ] Implement the checked mutex abstraction with compatible construction, `lock`, `try_lock`, mutable access, ownership extraction, poisoning, and debug behavior required by current users.
+- [ ] Implement allocation-free global enablement and thread-local realtime/permission RAII scopes.
+- [ ] Implement a strict unapproved-lock violation path and a test-observable policy that does not weaken production strict behavior.
+- [ ] Add a reason-labelled permission macro or method whose scope covers only one acquisition expression.
+- [ ] Test `lock`, `try_lock`, poisoning, nested scopes, permission non-leakage, cross-thread isolation, and `Condvar` use; build warning-free and commit the stage.
+
+### Stage 3 — Migrate and statically enforce project-owned mutex use
+
+- [ ] Replace every production `shoop_engine` `std::sync::Mutex` declaration/import with the checked abstraction, including control-only and feature-gated LV2 code.
+- [ ] Preserve public signatures or migrate all workspace callers where a mutex-bearing public engine type crosses a module or crate boundary.
+- [ ] Add a crate-local structural test or lint that permits direct `std::sync::Mutex` use only inside the abstraction implementation and catches both declarations and direct `lock`/`try_lock` bypasses.
+- [ ] Run package tests with default features and `app_backend`, plus a warning-free build, before committing the mechanical migration.
+
+### Stage 4 — Mark complete realtime boundaries and annotate existing debt
+
+- [ ] Mark engine `process`, `run_cycle`, and `pump` sections while preserving correct nested behavior under driver-level scopes.
+- [ ] Mark the full JACK process callback and annotate each retained JACK registered-port and decoupled-MIDI acquisition individually.
+- [ ] Mark CPAL input and output callbacks and annotate each retained connection registry, capture ring, endpoint registry, and decoupled queue acquisition individually.
+- [ ] Mark the dummy process iteration and annotate each retained driver-state acquisition individually.
+- [ ] Annotate retained processing locks in external audio/MIDI capture, Carla host processing, and URID mapping individually.
+- [ ] Audit queued commands for lock acquisition and annotate only the individual retained sites, including failure publication and deferred external connection operations; do not permit the command executor as a whole.
+- [ ] Add representative tests proving each callback family accepts its explicit baseline while an added unlabelled acquisition fails. Use mocks/structural coverage where hardware callbacks are unavailable.
+- [ ] Verify guard code itself remains allocation-free under the existing allocator test harness; commit the stage.
+
+### Stage 5 — Expose and document developer operation
+
+- [ ] Add a disabled-by-default `--rt-lock-guard` developer option and enable the engine guard during application startup alongside the allocation guard.
+- [ ] Document that the guard covers project-owned checked mutexes and that dependency/native locks require separate OS-level diagnostics.
+- [ ] Ensure strict violations retain static callsite/reason evidence suitable for crash diagnosis without realtime logging.
+- [ ] Add CLI parsing/startup tests and a supported mock/dummy run with the guard enabled; commit the stage.
+
+### Stage 6 — End-to-end validation
+
+- [ ] Run `cargo fmt --all -- --check` and `git diff --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build`.
+- [ ] Run focused checked-mutex, callback-boundary, structural enforcement, and no-allocation tests.
+- [ ] Run `cargo test --workspace --features shoop_engine/app_backend`, using serialized execution and the documented missing-backend allowance if required by the environment.
+- [ ] Build and run `SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test`.
+- [ ] Run the supported self-test or focused driver suite with `--rt-lock-guard` enabled and verify that only the committed explicit permission baseline is exercised and no unapproved lock terminates the run.
+- [ ] Re-audit every acceptance criterion against code and test evidence, document any unavailable hardware-only verification, commit final evidence, and mark the plan complete.
+
+## Execution contract
+
+- Keep this plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised only for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.

--- a/plan_realtime_lock_guard.md
+++ b/plan_realtime_lock_guard.md
@@ -1,6 +1,6 @@
 # Make realtime mutex acquisition explicit
 
-Status: not started
+Status: complete
 
 Branch: `content-snapshots-code`
 
@@ -22,16 +22,16 @@ This does not remove the known locks, redesign driver/capture/plugin data flow, 
 
 ## Acceptance criteria (immutable)
 
-- [ ] Every project-owned mutex declaration in production `shoop_engine` code uses the checked mutex abstraction; a structural check fails if production code imports, names, or directly acquires `std::sync::Mutex` outside the abstraction module.
-- [ ] Checked `lock()` and `try_lock()` attempts made in a marked realtime section are detected before acquisition, including uncontended attempts.
-- [ ] Realtime marking covers `Engine::process`, `Engine::run_cycle`, and `Engine::pump`, plus the complete project-owned JACK process callback, CPAL input/output callbacks, and dummy process iteration. Nested marking is correct and thread-local.
-- [ ] An unapproved realtime lock attempt is a deterministic guard violation in tests and terminates immediately in developer strict mode rather than blocking the callback.
-- [ ] Every known realtime lock site that remains is wrapped in a narrowly scoped, reason-labelled permission at the individual acquisition expression; there is no blanket permission around the command executor, whole engine cycle, whole driver callback, or arbitrary closure body.
-- [ ] The detector and permission path do not allocate, log, format, take another lock, or perform blocking I/O in realtime context.
-- [ ] Mutex poisoning behavior, guard lifetimes, `Condvar` interoperability, `Send`/`Sync` properties, and existing public engine behavior remain compatible.
-- [ ] The guard is disabled by default, can be enabled through a documented developer CLI option, and adds no lock-policy behavior change while disabled.
-- [ ] Focused tests cover disabled and enabled behavior, non-realtime acquisition, `lock`, `try_lock`, nested scopes, permission scope containment, thread locality, and representative engine/driver/capture/plugin lock sites.
-- [ ] Formatting, warning-free build, Rust tests, realtime no-allocation tests, and the QML self-test suite pass; a guard-enabled supported-backend test run reports no unapproved project-owned lock attempt.
+- [x] Every project-owned mutex declaration in production `shoop_engine` code uses the checked mutex abstraction; a structural check fails if production code imports, names, or directly acquires `std::sync::Mutex` outside the abstraction module.
+- [x] Checked `lock()` and `try_lock()` attempts made in a marked realtime section are detected before acquisition, including uncontended attempts.
+- [x] Realtime marking covers `Engine::process`, `Engine::run_cycle`, and `Engine::pump`, plus the complete project-owned JACK process callback, CPAL input/output callbacks, and dummy process iteration. Nested marking is correct and thread-local.
+- [x] An unapproved realtime lock attempt is a deterministic guard violation in tests and terminates immediately in developer strict mode rather than blocking the callback.
+- [x] Every known realtime lock site that remains is wrapped in a narrowly scoped, reason-labelled permission at the individual acquisition expression; there is no blanket permission around the command executor, whole engine cycle, whole driver callback, or arbitrary closure body.
+- [x] The detector and permission path do not allocate, log, format, take another lock, or perform blocking I/O in realtime context.
+- [x] Mutex poisoning behavior, guard lifetimes, `Condvar` interoperability, `Send`/`Sync` properties, and existing public engine behavior remain compatible.
+- [x] The guard is disabled by default, can be enabled through a documented developer CLI option, and adds no lock-policy behavior change while disabled.
+- [x] Focused tests cover disabled and enabled behavior, non-realtime acquisition, `lock`, `try_lock`, nested scopes, permission scope containment, thread locality, and representative engine/driver/capture/plugin lock sites.
+- [x] Formatting, warning-free build, Rust tests, realtime no-allocation tests, and the QML self-test suite pass; a guard-enabled supported-backend test run reports no unapproved project-owned lock attempt.
 
 ## Design rules
 
@@ -46,57 +46,84 @@ This does not remove the known locks, redesign driver/capture/plugin data flow, 
 - Treat third-party and native locking as an explicit coverage boundary in code and documentation; do not imply allocator-guard-equivalent dependency coverage.
 - Preserve existing source formatting and avoid unrelated lock removal or architectural changes in this work.
 
+## Explicit permission baseline
+
+The structural test fixes the initial production baseline at 34 individually labelled acquisitions:
+
+- object creation failure publication: 1;
+- JACK registered-port and decoupled MIDI queues: 3;
+- CPAL capture rings, connection/endpoint registries, and decoupled MIDI queues: 9;
+- dummy driver engine claim and iteration state: 5;
+- deferred external audio/MIDI connection operations: 4;
+- external audio capture: 4;
+- external MIDI capture: 3;
+- Carla host processing: 1;
+- LV2 URID map/unmap operations: 4.
+
+Changing this count requires an intentional test and inventory update. It is a debt baseline, not evidence that these locks are realtime-safe.
+
 ## Implementation plan
 
 ### Stage 1 — Establish the lock inventory and guard contract
 
-- [ ] Record the production `shoop_engine` mutex declarations and classify each acquisition as control-only, driver-callback, engine/session processing, capture, plugin/URID, or command-reachable.
-- [ ] Record the initial explicit realtime permission inventory, including JACK port/decoupled MIDI locks, CPAL rings/registries/endpoints/queues, dummy driver state, external capture, Carla/URID locks, object failure publication, and queued external-connection operations.
-- [ ] Add focused contract tests for realtime scope nesting, thread locality, unapproved acquisition, exact permission scope, and disabled behavior before migrating production callsites.
-- [ ] Verify the focused tests expose an unapproved synthetic mutex acquisition and do not classify ordinary control-thread acquisition as realtime; commit the stage.
+- [x] Record the production `shoop_engine` mutex declarations and classify each acquisition as control-only, driver-callback, engine/session processing, capture, plugin/URID, or command-reachable.
+- [x] Record the initial explicit realtime permission inventory, including JACK port/decoupled MIDI locks, CPAL rings/registries/endpoints/queues, dummy driver state, external capture, Carla/URID locks, object failure publication, and queued external-connection operations.
+- [x] Add focused contract tests for realtime scope nesting, thread locality, unapproved acquisition, exact permission scope, and disabled behavior before migrating production callsites.
+- [x] Verify the focused tests expose an unapproved synthetic mutex acquisition and do not classify ordinary control-thread acquisition as realtime; commit the stage.
 
 ### Stage 2 — Add the checked mutex and realtime lock guard
 
-- [ ] Implement the checked mutex abstraction with compatible construction, `lock`, `try_lock`, mutable access, ownership extraction, poisoning, and debug behavior required by current users.
-- [ ] Implement allocation-free global enablement and thread-local realtime/permission RAII scopes.
-- [ ] Implement a strict unapproved-lock violation path and a test-observable policy that does not weaken production strict behavior.
-- [ ] Add a reason-labelled permission macro or method whose scope covers only one acquisition expression.
-- [ ] Test `lock`, `try_lock`, poisoning, nested scopes, permission non-leakage, cross-thread isolation, and `Condvar` use; build warning-free and commit the stage.
+- [x] Implement the checked mutex abstraction with compatible construction, `lock`, `try_lock`, mutable access, ownership extraction, poisoning, and debug behavior required by current users.
+- [x] Implement allocation-free global enablement and thread-local realtime/permission RAII scopes.
+- [x] Implement a strict unapproved-lock violation path and a test-observable policy that does not weaken production strict behavior.
+- [x] Add a reason-labelled permission macro or method whose scope covers only one acquisition expression.
+- [x] Test `lock`, `try_lock`, poisoning, nested scopes, permission non-leakage, cross-thread isolation, and `Condvar` use; build warning-free and commit the stage.
 
 ### Stage 3 — Migrate and statically enforce project-owned mutex use
 
-- [ ] Replace every production `shoop_engine` `std::sync::Mutex` declaration/import with the checked abstraction, including control-only and feature-gated LV2 code.
-- [ ] Preserve public signatures or migrate all workspace callers where a mutex-bearing public engine type crosses a module or crate boundary.
-- [ ] Add a crate-local structural test or lint that permits direct `std::sync::Mutex` use only inside the abstraction implementation and catches both declarations and direct `lock`/`try_lock` bypasses.
-- [ ] Run package tests with default features and `app_backend`, plus a warning-free build, before committing the mechanical migration.
+- [x] Replace every production `shoop_engine` `std::sync::Mutex` declaration/import with the checked abstraction, including control-only and feature-gated LV2 code.
+- [x] Preserve public signatures or migrate all workspace callers where a mutex-bearing public engine type crosses a module or crate boundary.
+- [x] Add a crate-local structural test or lint that permits direct `std::sync::Mutex` use only inside the abstraction implementation and catches both declarations and direct `lock`/`try_lock` bypasses.
+- [x] Run package tests with default features and `app_backend`, plus a warning-free build, before committing the mechanical migration.
 
 ### Stage 4 — Mark complete realtime boundaries and annotate existing debt
 
-- [ ] Mark engine `process`, `run_cycle`, and `pump` sections while preserving correct nested behavior under driver-level scopes.
-- [ ] Mark the full JACK process callback and annotate each retained JACK registered-port and decoupled-MIDI acquisition individually.
-- [ ] Mark CPAL input and output callbacks and annotate each retained connection registry, capture ring, endpoint registry, and decoupled queue acquisition individually.
-- [ ] Mark the dummy process iteration and annotate each retained driver-state acquisition individually.
-- [ ] Annotate retained processing locks in external audio/MIDI capture, Carla host processing, and URID mapping individually.
-- [ ] Audit queued commands for lock acquisition and annotate only the individual retained sites, including failure publication and deferred external connection operations; do not permit the command executor as a whole.
-- [ ] Add representative tests proving each callback family accepts its explicit baseline while an added unlabelled acquisition fails. Use mocks/structural coverage where hardware callbacks are unavailable.
-- [ ] Verify guard code itself remains allocation-free under the existing allocator test harness; commit the stage.
+- [x] Mark engine `process`, `run_cycle`, and `pump` sections while preserving correct nested behavior under driver-level scopes.
+- [x] Mark the full JACK process callback and annotate each retained JACK registered-port and decoupled-MIDI acquisition individually.
+- [x] Mark CPAL input and output callbacks and annotate each retained connection registry, capture ring, endpoint registry, and decoupled queue acquisition individually.
+- [x] Mark the dummy process iteration and annotate each retained driver-state acquisition individually.
+- [x] Annotate retained processing locks in external audio/MIDI capture, Carla host processing, and URID mapping individually.
+- [x] Audit queued commands for lock acquisition and annotate only the individual retained sites, including failure publication and deferred external connection operations; do not permit the command executor as a whole.
+- [x] Add representative tests proving each callback family accepts its explicit baseline while an added unlabelled acquisition fails. Use mocks/structural coverage where hardware callbacks are unavailable.
+- [x] Verify guard code itself remains allocation-free under the existing allocator test harness; commit the stage.
 
 ### Stage 5 — Expose and document developer operation
 
-- [ ] Add a disabled-by-default `--rt-lock-guard` developer option and enable the engine guard during application startup alongside the allocation guard.
-- [ ] Document that the guard covers project-owned checked mutexes and that dependency/native locks require separate OS-level diagnostics.
-- [ ] Ensure strict violations retain static callsite/reason evidence suitable for crash diagnosis without realtime logging.
-- [ ] Add CLI parsing/startup tests and a supported mock/dummy run with the guard enabled; commit the stage.
+- [x] Add a disabled-by-default `--rt-lock-guard` developer option and enable the engine guard during application startup alongside the allocation guard.
+- [x] Document that the guard covers project-owned checked mutexes and that dependency/native locks require separate OS-level diagnostics.
+- [x] Ensure strict violations retain static callsite/reason evidence suitable for crash diagnosis without realtime logging.
+- [x] Add CLI parsing/startup tests and a supported mock/dummy run with the guard enabled; commit the stage.
 
 ### Stage 6 — End-to-end validation
 
-- [ ] Run `cargo fmt --all -- --check` and `git diff --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build`.
-- [ ] Run focused checked-mutex, callback-boundary, structural enforcement, and no-allocation tests.
-- [ ] Run `cargo test --workspace --features shoop_engine/app_backend`, using serialized execution and the documented missing-backend allowance if required by the environment.
-- [ ] Build and run `SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test`.
-- [ ] Run the supported self-test or focused driver suite with `--rt-lock-guard` enabled and verify that only the committed explicit permission baseline is exercised and no unapproved lock terminates the run.
-- [ ] Re-audit every acceptance criterion against code and test evidence, document any unavailable hardware-only verification, commit final evidence, and mark the plan complete.
+- [x] Run `cargo fmt --all -- --check` and `git diff --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build`.
+- [x] Run focused checked-mutex, callback-boundary, structural enforcement, and no-allocation tests.
+- [x] Run `cargo test --workspace --features shoop_engine/app_backend`, using serialized execution and the documented missing-backend allowance if required by the environment.
+- [x] Build and run `SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test`.
+- [x] Run the supported self-test or focused driver suite with `--rt-lock-guard` enabled and verify that only the committed explicit permission baseline is exercised and no unapproved lock terminates the run.
+- [x] Re-audit every acceptance criterion against code and test evidence, document any unavailable hardware-only verification, commit final evidence, and mark the plan complete.
+
+## Validation evidence
+
+- `cargo fmt --all -- --check` and `git diff --check` passed.
+- `RUSTFLAGS="-D warnings" cargo build` passed.
+- Focused checked-mutex unit tests passed, including detection, nesting, permission containment, thread locality, poisoning, mutable/owned access, and `Condvar` interoperability.
+- Focused structural, no-allocation, dummy callback, and CLI tests passed. The structural baseline is 34 production permission expressions; the no-allocation suite passed all 22 tests.
+- The serialized workspace test run with `shoop_engine/app_backend` passed.
+- The normal and guard-enabled QML self-test runs passed with 197 testcases: 196 passed and one CPAL testcase skipped because this environment has no CPAL settings. The guard-enabled run completed without an unapproved project-owned lock attempt.
+- Five additional guard-enabled focused CPAL self-test launches passed and consistently reported the same environment-driven skip.
+- Hardware CPAL callbacks and a physical JACK server were unavailable. CPAL/JACK callback-boundary and permission placement are therefore covered structurally; the repository's `JackTest` QML test and the supported dummy backend passed, but no claim is made about dependency/native locks.
 
 ## Execution contract
 

--- a/plan_realtime_lock_guard.md
+++ b/plan_realtime_lock_guard.md
@@ -2,9 +2,9 @@
 
 Status: complete
 
-Branch: `content-snapshots-code`
+Branch: `feature/realtime-lock-guard`
 
-Base: `origin/master` at `996de36a`
+Base: `origin/master` at `8328200d`
 
 ## Goals
 

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -9,6 +9,7 @@
 
 use crate as engine;
 use crate::graph_scheduler::{GraphScheduler, DEFAULT_WINDOW};
+use crate::realtime_lock_guard::Mutex;
 use anyhow::{anyhow, Result};
 use arc_swap::ArcSwap;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -22,7 +23,7 @@ pub use engine::{
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::{Arc, OnceLock, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -203,7 +204,8 @@ impl<I: ObjectIdentity, M> ObjectControl<I, M> {
     }
 
     fn mark_failed(&self, error: impl Into<String>) {
-        *self.error.lock().unwrap_or_else(|e| e.into_inner()) = Some(error.into());
+        *crate::realtime_allow_lock!("object creation failure publication", self.error.lock())
+            .unwrap_or_else(|e| e.into_inner()) = Some(error.into());
         self.lifecycle
             .store(ObjectLifecycle::Failed as u8, Ordering::Release);
     }
@@ -319,6 +321,12 @@ struct JackProcess {
 }
 impl jack::ProcessHandler for JackProcess {
     fn process(&mut self, _: &jack::Client, ps: &jack::ProcessScope) -> jack::Control {
+        crate::realtime_lock_guard::forbid_locks_if_enabled(|| self.process_inner(ps))
+    }
+}
+
+impl JackProcess {
+    fn process_inner(&mut self, ps: &jack::ProcessScope) -> jack::Control {
         let n_frames = ps.n_frames() as usize;
         let _driver_kind =
             shoop_tracing::realtime_span!("engine.rt.driver", value = AudioDriverType::Jack as i32);
@@ -348,7 +356,8 @@ impl jack::ProcessHandler for JackProcess {
         let session = engine.session_mut();
         session.set_sample_rate(sample_rate);
         session.set_buffer_size(n_frames as u32);
-        let mut ports = ports.lock().unwrap_or_else(|e| e.into_inner());
+        let mut ports = crate::realtime_allow_lock!("JACK registered port registry", ports.lock())
+            .unwrap_or_else(|e| e.into_inner());
 
         for p in ports.iter() {
             match p {
@@ -373,7 +382,11 @@ impl jack::ProcessHandler for JackProcess {
                     }
                 }
                 JackRegisteredPort::DecoupledMidiIn { queue, jack } => {
-                    let mut queue = queue.lock().unwrap_or_else(|e| e.into_inner());
+                    let mut queue = crate::realtime_allow_lock!(
+                        "JACK decoupled MIDI input queue",
+                        queue.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner());
                     for e in jack.iter(ps) {
                         queue.push(MidiEvent::new(e.time as i32, e.bytes.to_vec()));
                     }
@@ -426,7 +439,11 @@ impl jack::ProcessHandler for JackProcess {
                 }
                 JackRegisteredPort::DecoupledMidiOut { queue, jack } => {
                     let mut writer = jack.writer(ps);
-                    let mut queue = queue.lock().unwrap_or_else(|e| e.into_inner());
+                    let mut queue = crate::realtime_allow_lock!(
+                        "JACK decoupled MIDI output queue",
+                        queue.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner());
                     for e in queue.drain(..) {
                         let time = (e.time.max(0) as u32).min(n_frames.saturating_sub(1) as u32);
                         let _ = writer.write(&jack::RawMidi {
@@ -698,7 +715,9 @@ fn route_virtual_midi_inputs(
             .iter()
             .filter(|p| p.port_id == *port_id && p.direction == PortDirection::Input)
         {
-            let mut queue = port.queue.lock().unwrap_or_else(|e| e.into_inner());
+            let mut queue =
+                crate::realtime_allow_lock!("CPAL decoupled MIDI input queue", port.queue.lock())
+                    .unwrap_or_else(|e| e.into_inner());
             for e in events {
                 queue.push(MidiEvent::new(0, e.data().to_vec()));
             }
@@ -722,7 +741,9 @@ fn drain_decoupled_midi_output_events(
         {
             continue;
         }
-        let mut queue = port.queue.lock().unwrap_or_else(|e| e.into_inner());
+        let mut queue =
+            crate::realtime_allow_lock!("CPAL decoupled MIDI output queue", port.queue.lock())
+                .unwrap_or_else(|e| e.into_inner());
         for e in queue.drain(..) {
             if let Some(elem) =
                 engine::midi_storage::MidiStorageElem::new(e.time.max(0) as u32, &e.data)
@@ -800,24 +821,31 @@ impl CpalBackend {
                 input_stream = Some(input_device.build_input_stream(
                     &input_config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                        let _driver_kind = shoop_tracing::realtime_span!(
-                            "engine.rt.driver",
-                            value = AudioDriverType::Cpal as i32
-                        );
-                        let n_frames = data.len().checked_div(input_channels.max(1)).unwrap_or(0);
-                        let _span = shoop_tracing::realtime_span!(
-                            "engine.rt.driver.cpal_input",
-                            value = n_frames
-                        );
-                        let mut ring = cb_ring.lock().unwrap_or_else(|e| e.into_inner());
-                        for &s in data {
-                            if ring.len() >= cap {
-                                ring.pop_front();
-                                cb_xruns_in.fetch_add(1, Ordering::Relaxed);
-                                cb_capture_overruns.fetch_add(1, Ordering::Relaxed);
+                        crate::realtime_lock_guard::forbid_locks_if_enabled(|| {
+                            let _driver_kind = shoop_tracing::realtime_span!(
+                                "engine.rt.driver",
+                                value = AudioDriverType::Cpal as i32
+                            );
+                            let n_frames =
+                                data.len().checked_div(input_channels.max(1)).unwrap_or(0);
+                            let _span = shoop_tracing::realtime_span!(
+                                "engine.rt.driver.cpal_input",
+                                value = n_frames
+                            );
+                            let mut ring = crate::realtime_allow_lock!(
+                                "CPAL capture ring input",
+                                cb_ring.lock()
+                            )
+                            .unwrap_or_else(|e| e.into_inner());
+                            for &s in data {
+                                if ring.len() >= cap {
+                                    ring.pop_front();
+                                    cb_xruns_in.fetch_add(1, Ordering::Relaxed);
+                                    cb_capture_overruns.fetch_add(1, Ordering::Relaxed);
+                                }
+                                ring.push_back(s);
                             }
-                            ring.push_back(s);
-                        }
+                        });
                     },
                     |_| {},
                     None,
@@ -927,134 +955,155 @@ impl CpalBackend {
         let output_stream = output_device.build_output_stream(
             &output_config,
             move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                let n_frames = data.len().checked_div(output_channels.max(1)).unwrap_or(0);
-                let _driver_kind = shoop_tracing::realtime_span!(
-                    "engine.rt.driver",
-                    value = AudioDriverType::Cpal as i32
-                );
-                let _span =
-                    shoop_tracing::realtime_span!("engine.rt.driver.cpal_output", value = n_frames);
-                last_processed_cb.store(n_frames as u32, Ordering::Relaxed);
-                for s in data.iter_mut() {
-                    *s = 0.0;
-                }
-                if let Some(callback) = maybe_process_callback {
-                    unsafe {
-                        callback();
+                crate::realtime_lock_guard::forbid_locks_if_enabled(|| {
+                    let n_frames = data.len().checked_div(output_channels.max(1)).unwrap_or(0);
+                    let _driver_kind = shoop_tracing::realtime_span!(
+                        "engine.rt.driver",
+                        value = AudioDriverType::Cpal as i32
+                    );
+                    let _span = shoop_tracing::realtime_span!(
+                        "engine.rt.driver.cpal_output",
+                        value = n_frames
+                    );
+                    last_processed_cb.store(n_frames as u32, Ordering::Relaxed);
+                    for s in data.iter_mut() {
+                        *s = 0.0;
                     }
-                }
-                let connections = external_cb
-                    .lock()
+                    if let Some(callback) = maybe_process_callback {
+                        unsafe {
+                            callback();
+                        }
+                    }
+                    let connections = crate::realtime_allow_lock!(
+                        "CPAL external connection registry",
+                        external_cb.lock()
+                    )
                     .unwrap_or_else(|e| e.into_inner())
                     .connections();
-                let wanted = n_frames * input_channels;
-                if capture_scratch.len() < wanted {
-                    capture_scratch.resize(wanted, 0.0);
-                }
-                if let Some(ring) = input_ring_cb.as_ref() {
-                    let mut ring = ring.lock().unwrap_or_else(|e| e.into_inner());
-                    let mut underflowed = false;
-                    for s in &mut capture_scratch[..wanted] {
-                        match ring.pop_front() {
-                            Some(value) => *s = value,
-                            None => {
-                                *s = 0.0;
-                                underflowed = true;
-                            }
-                        }
+                    let wanted = n_frames * input_channels;
+                    if capture_scratch.len() < wanted {
+                        capture_scratch.resize(wanted, 0.0);
                     }
-                    if underflowed {
-                        capture_underruns_cb.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-                engine.stats().capture_underruns.store(
-                    capture_underruns_cb.load(Ordering::Relaxed),
-                    Ordering::Relaxed,
-                );
-                engine.stats().capture_overruns.store(
-                    capture_overruns_cb.load(Ordering::Relaxed),
-                    Ordering::Relaxed,
-                );
-
-                // Control work first, at the cycle boundary, and with no lock anywhere: the
-                // callback owns the engine, so a GUI thread polling state cannot make this
-                // one wait. On cpal that waiting showed up as glitching rather than as a
-                // zombied client, which made it easier to miss and no less real.
-                engine.pump();
-                let session = engine.session_mut();
-                session.set_sample_rate(sample_rate);
-                session.set_buffer_size(n_frames as u32);
-
-                stage_virtual_audio_inputs(
-                    session,
-                    &connections,
-                    &capture_names_cb,
-                    input_channels,
-                    &capture_scratch[..wanted],
-                    n_frames,
-                );
-                {
-                    let decoupled = decoupled_cb
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .clone();
-                    let mut inputs = midi_inputs_cb.lock().unwrap_or_else(|e| e.into_inner());
-                    for input in inputs.iter_mut() {
-                        let events = input.capture.drain_pending();
-                        if !events.is_empty() {
-                            route_virtual_midi_inputs(
-                                session,
-                                &connections,
-                                &input.name,
-                                &events,
-                                &decoupled,
-                            );
-                        }
-                    }
-                }
-
-                engine.run_cycle(n_frames);
-                let session = engine.session();
-                stale_cb.store(session.n_stale_cycles(), Ordering::Relaxed);
-
-                collect_virtual_audio_outputs(
-                    session,
-                    &connections,
-                    &playback_names_cb,
-                    output_channels,
-                    data,
-                    n_frames,
-                );
-                {
-                    let decoupled = decoupled_cb
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .clone();
-                    let mut outputs = midi_outputs_cb.lock().unwrap_or_else(|e| e.into_inner());
-                    for output in outputs.iter_mut() {
-                        for (port_id, ext_name) in &connections {
-                            if ext_name != &output.name {
-                                continue;
-                            }
-                            if let Some(session_idx) = port_id.0.checked_sub(1).map(|v| v as usize)
-                            {
-                                if let Some(port) =
-                                    session.port(session_idx).and_then(|p| p.as_external_midi())
-                                {
-                                    output.playback.send_from(port);
+                    if let Some(ring) = input_ring_cb.as_ref() {
+                        let mut ring =
+                            crate::realtime_allow_lock!("CPAL capture ring output", ring.lock())
+                                .unwrap_or_else(|e| e.into_inner());
+                        let mut underflowed = false;
+                        for s in &mut capture_scratch[..wanted] {
+                            match ring.pop_front() {
+                                Some(value) => *s = value,
+                                None => {
+                                    *s = 0.0;
+                                    underflowed = true;
                                 }
                             }
                         }
-                        let events = drain_decoupled_midi_output_events(
-                            &connections,
-                            &output.name,
-                            &decoupled,
-                        );
-                        if !events.is_empty() {
-                            output.playback.send_events(&events);
+                        if underflowed {
+                            capture_underruns_cb.fetch_add(1, Ordering::Relaxed);
                         }
                     }
-                }
+                    engine.stats().capture_underruns.store(
+                        capture_underruns_cb.load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
+                    engine.stats().capture_overruns.store(
+                        capture_overruns_cb.load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
+
+                    // Control work first, at the cycle boundary, and with no lock anywhere: the
+                    // callback owns the engine, so a GUI thread polling state cannot make this
+                    // one wait. On cpal that waiting showed up as glitching rather than as a
+                    // zombied client, which made it easier to miss and no less real.
+                    engine.pump();
+                    let session = engine.session_mut();
+                    session.set_sample_rate(sample_rate);
+                    session.set_buffer_size(n_frames as u32);
+
+                    stage_virtual_audio_inputs(
+                        session,
+                        &connections,
+                        &capture_names_cb,
+                        input_channels,
+                        &capture_scratch[..wanted],
+                        n_frames,
+                    );
+                    {
+                        let decoupled = crate::realtime_allow_lock!(
+                            "CPAL decoupled MIDI input registry",
+                            decoupled_cb.lock()
+                        )
+                        .unwrap_or_else(|e| e.into_inner())
+                        .clone();
+                        let mut inputs = crate::realtime_allow_lock!(
+                            "CPAL MIDI input endpoint registry",
+                            midi_inputs_cb.lock()
+                        )
+                        .unwrap_or_else(|e| e.into_inner());
+                        for input in inputs.iter_mut() {
+                            let events = input.capture.drain_pending();
+                            if !events.is_empty() {
+                                route_virtual_midi_inputs(
+                                    session,
+                                    &connections,
+                                    &input.name,
+                                    &events,
+                                    &decoupled,
+                                );
+                            }
+                        }
+                    }
+
+                    engine.run_cycle(n_frames);
+                    let session = engine.session();
+                    stale_cb.store(session.n_stale_cycles(), Ordering::Relaxed);
+
+                    collect_virtual_audio_outputs(
+                        session,
+                        &connections,
+                        &playback_names_cb,
+                        output_channels,
+                        data,
+                        n_frames,
+                    );
+                    {
+                        let decoupled = crate::realtime_allow_lock!(
+                            "CPAL decoupled MIDI output registry",
+                            decoupled_cb.lock()
+                        )
+                        .unwrap_or_else(|e| e.into_inner())
+                        .clone();
+                        let mut outputs = crate::realtime_allow_lock!(
+                            "CPAL MIDI output endpoint registry",
+                            midi_outputs_cb.lock()
+                        )
+                        .unwrap_or_else(|e| e.into_inner());
+                        for output in outputs.iter_mut() {
+                            for (port_id, ext_name) in &connections {
+                                if ext_name != &output.name {
+                                    continue;
+                                }
+                                if let Some(session_idx) =
+                                    port_id.0.checked_sub(1).map(|v| v as usize)
+                                {
+                                    if let Some(port) =
+                                        session.port(session_idx).and_then(|p| p.as_external_midi())
+                                    {
+                                        output.playback.send_from(port);
+                                    }
+                                }
+                            }
+                            let events = drain_decoupled_midi_output_events(
+                                &connections,
+                                &output.name,
+                                &decoupled,
+                            );
+                            if !events.is_empty() {
+                                output.playback.send_events(&events);
+                            }
+                        }
+                    }
+                });
             },
             move |_| {
                 xruns_cb.fetch_add(1, Ordering::Relaxed);
@@ -1561,7 +1610,9 @@ impl SharedSession {
 
     /// Hands the engine to a driver that is about to start cycling it.
     fn take_engine(&self) -> Option<engine::Engine> {
-        self.parked.lock().unwrap_or_else(|e| e.into_inner()).take()
+        crate::realtime_allow_lock!("dummy driver engine claim", self.parked.lock())
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
     }
 
     /// Takes the engine back from a driver that has stopped.
@@ -2758,8 +2809,18 @@ fn process_dummy_driver_iteration(
     inner: &Arc<Mutex<DriverInner>>,
     engine: &mut Option<engine::Engine>,
 ) {
+    crate::realtime_lock_guard::forbid_locks_if_enabled(|| {
+        process_dummy_driver_iteration_inner(inner, engine)
+    });
+}
+
+fn process_dummy_driver_iteration_inner(
+    inner: &Arc<Mutex<DriverInner>>,
+    engine: &mut Option<engine::Engine>,
+) {
     let (session, n, sample_rate, buffer_size, callback, driver_type) = {
-        let mut i = inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut i = crate::realtime_allow_lock!("dummy driver iteration state", inner.lock())
+            .unwrap_or_else(|e| e.into_inner());
         if !i.dummy.active() || !driver_uses_dummy_processing(i.driver_type) {
             i.last_processed = 0;
             i.process_generation = i.process_generation.wrapping_add(1);
@@ -2796,8 +2857,7 @@ fn process_dummy_driver_iteration(
     }
     let Some(engine) = engine.as_mut() else {
         if n == 0 {
-            inner
-                .lock()
+            crate::realtime_allow_lock!("dummy driver idle state", inner.lock())
                 .unwrap_or_else(|e| e.into_inner())
                 .last_processed = 0;
         }
@@ -2810,8 +2870,7 @@ fn process_dummy_driver_iteration(
     engine.pump();
 
     if n == 0 {
-        inner
-            .lock()
+        crate::realtime_allow_lock!("dummy driver zero-frame state", inner.lock())
             .unwrap_or_else(|e| e.into_inner())
             .last_processed = 0;
         return;
@@ -2826,8 +2885,7 @@ fn process_dummy_driver_iteration(
     // changes are applied by the scheduler thread within its window; a caller that needs them
     // landed first calls `AudioDriver::wait_process`, which flushes.
     engine.run_cycle(n as usize);
-    inner
-        .lock()
+    crate::realtime_allow_lock!("dummy driver completion state", inner.lock())
         .unwrap_or_else(|e| e.into_inner())
         .last_processed = n;
 }
@@ -4737,10 +4795,12 @@ impl AudioPort {
             let (control, name) = (Arc::clone(&self.control), name.to_string());
             if let Err(error) = self.shared.send_control(move |_: &mut engine::Session| {
                 if let Some(id) = control.ready_id() {
-                    let _ = ext
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .connect(compat_port_id(id.index()), &name);
+                    let _ = crate::realtime_allow_lock!(
+                        "deferred external audio connection",
+                        ext.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner())
+                    .connect(compat_port_id(id.index()), &name);
                 }
             }) {
                 log::error!("could not queue external audio connection: {error}");
@@ -4778,10 +4838,12 @@ impl AudioPort {
             let (control, name) = (Arc::clone(&self.control), name.to_string());
             if let Err(error) = self.shared.send_control(move |_: &mut engine::Session| {
                 if let Some(id) = control.ready_id() {
-                    let _ = ext
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .disconnect(compat_port_id(id.index()), &name);
+                    let _ = crate::realtime_allow_lock!(
+                        "deferred external audio disconnection",
+                        ext.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner())
+                    .disconnect(compat_port_id(id.index()), &name);
                 }
             }) {
                 log::error!("could not queue external audio disconnection: {error}");
@@ -5056,10 +5118,12 @@ impl MidiPort {
             let (control, name) = (Arc::clone(&self.control), name.to_string());
             if let Err(error) = self.shared.send_control(move |_: &mut engine::Session| {
                 if let Some(id) = control.ready_id() {
-                    let _ = ext
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .connect(compat_port_id(id.index()), &name);
+                    let _ = crate::realtime_allow_lock!(
+                        "deferred external MIDI connection",
+                        ext.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner())
+                    .connect(compat_port_id(id.index()), &name);
                 }
             }) {
                 log::error!("could not queue external MIDI connection: {error}");
@@ -5097,10 +5161,12 @@ impl MidiPort {
             let (control, name) = (Arc::clone(&self.control), name.to_string());
             if let Err(error) = self.shared.send_control(move |_: &mut engine::Session| {
                 if let Some(id) = control.ready_id() {
-                    let _ = ext
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .disconnect(compat_port_id(id.index()), &name);
+                    let _ = crate::realtime_allow_lock!(
+                        "deferred external MIDI disconnection",
+                        ext.lock()
+                    )
+                    .unwrap_or_else(|e| e.into_inner())
+                    .disconnect(compat_port_id(id.index()), &name);
                 }
             }) {
                 log::error!("could not queue external MIDI disconnection: {error}");
@@ -6783,6 +6849,49 @@ mod tests {
 
         assert_eq!(driver.dummy_n_requested_frames(), 0);
         assert_eq!(loop_.get_state().expect("state").position, REQUEST);
+    }
+
+    #[test]
+    fn dummy_iteration_uses_only_explicit_realtime_lock_permissions() {
+        struct DisableGuard;
+        impl Drop for DisableGuard {
+            fn drop(&mut self) {
+                crate::realtime_lock_guard::set_enabled(false);
+            }
+        }
+
+        let mut dummy = engine::DummyDriver::default();
+        dummy.start(engine::DriverSettings {
+            sample_rate: 48_000,
+            buffer_size: 64,
+            client_name: "lock-guard-test".to_string(),
+        });
+        let inner = Arc::new(Mutex::new(DriverInner {
+            driver_type: AudioDriverType::Dummy,
+            dummy,
+            last_processed: 0,
+            process_generation: 0,
+            finish: Arc::new(AtomicBool::new(false)),
+            dummy_thread: None,
+            session: None,
+            jack: None,
+            cpal: None,
+            cpal_settings: None,
+            cpal_decoupled_midi_ports: Arc::new(Mutex::new(Vec::new())),
+            maybe_process_callback: None,
+        }));
+        let mut session = engine::Session::default();
+        session.apply_graph_changes().unwrap();
+        let (engine, _handle) = engine::split(session, 4);
+        let mut engine = Some(engine);
+
+        crate::realtime_lock_guard::set_enabled(true);
+        let _disable = DisableGuard;
+        process_dummy_driver_iteration(&inner, &mut engine);
+        crate::realtime_lock_guard::set_enabled(false);
+
+        let state = inner.lock().unwrap_or_else(|error| error.into_inner());
+        assert_eq!(state.last_processed, 64);
     }
 
     #[test]

--- a/src/rust/shoop_engine/src/content_snapshot/runtime.rs
+++ b/src/rust/shoop_engine/src/content_snapshot/runtime.rs
@@ -3,8 +3,9 @@ use super::{
     AudioSnapshotControl, AudioSnapshotPublisher, AudioSnapshotReader, MidiProcessSnapshotWriter,
     MidiSnapshotControl, MidiSnapshotPublisher, MidiSnapshotReader, SessionContentEpoch,
 };
+use crate::realtime_lock_guard::Mutex;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 

--- a/src/rust/shoop_engine/src/dummy_driver.rs
+++ b/src/rust/shoop_engine/src/dummy_driver.rs
@@ -17,7 +17,8 @@
 use crate::dummy_port::{DummyExternalConnections, ExternalPortDescriptor, PortId};
 use crate::port::{PortDataType, PortDirection};
 
-use std::sync::{Arc, Mutex};
+use crate::realtime_lock_guard::Mutex;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverSettings {

--- a/src/rust/shoop_engine/src/engine.rs
+++ b/src/rust/shoop_engine/src/engine.rs
@@ -293,7 +293,9 @@ impl Engine {
     pub fn process(&mut self, n_frames: usize) {
         let _span = shoop_tracing::realtime_span!("engine.rt.callback", value = n_frames);
         let started = shoop_tracing::is_tracing_requested().then(std::time::Instant::now);
-        crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| self.process_inner(n_frames));
+        crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| {
+            crate::realtime_lock_guard::forbid_locks_if_enabled(|| self.process_inner(n_frames))
+        });
         self.finish_callback_timing(started, n_frames);
         shoop_tracing::realtime_frame_mark!("engine.callback");
     }
@@ -309,7 +311,9 @@ impl Engine {
     pub fn run_cycle(&mut self, n_frames: usize) {
         let _span = shoop_tracing::realtime_span!("engine.rt.callback", value = n_frames);
         let started = shoop_tracing::is_tracing_requested().then(std::time::Instant::now);
-        crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| self.cycle_inner(n_frames));
+        crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| {
+            crate::realtime_lock_guard::forbid_locks_if_enabled(|| self.cycle_inner(n_frames))
+        });
         self.finish_callback_timing(started, n_frames);
         shoop_tracing::realtime_frame_mark!("engine.callback");
     }
@@ -419,14 +423,16 @@ impl Engine {
     pub fn pump(&mut self) {
         let _span = shoop_tracing::realtime_span!("engine.rt.pump");
         crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| {
-            {
-                let _commands_span = shoop_tracing::realtime_span!("engine.rt.commands");
-                self.apply_commands();
-            }
-            {
-                let _graph_span = shoop_tracing::realtime_span!("engine.rt.graph_state");
-                self.publish_graph_staleness();
-            }
+            crate::realtime_lock_guard::forbid_locks_if_enabled(|| {
+                {
+                    let _commands_span = shoop_tracing::realtime_span!("engine.rt.commands");
+                    self.apply_commands();
+                }
+                {
+                    let _graph_span = shoop_tracing::realtime_span!("engine.rt.graph_state");
+                    self.publish_graph_staleness();
+                }
+            });
         });
     }
 

--- a/src/rust/shoop_engine/src/external_audio_port.rs
+++ b/src/rust/shoop_engine/src/external_audio_port.rs
@@ -11,7 +11,8 @@
 //! cycles so a test can set up a whole sequence up front.
 
 use crate::port::{AudioPort, PortConnectability, PortDataType, PortDirection};
-use std::sync::{Arc, Mutex};
+use crate::realtime_lock_guard::Mutex;
+use std::sync::Arc;
 
 /// Ceiling on retained output, in samples. Roughly a second at 48 kHz.
 ///
@@ -170,8 +171,7 @@ impl ExternalAudioPort {
 
     pub fn clear_output_queue(&mut self) {
         self.capture_output = true;
-        self.outgoing
-            .lock()
+        crate::realtime_allow_lock!("external audio output capture reset", self.outgoing.lock())
             .unwrap_or_else(|e| e.into_inner())
             .clear();
         self.processed_len = 0;
@@ -192,7 +192,11 @@ impl ExternalAudioPort {
             *output += *sample;
         }
         if self.capture_output && self.direction == PortDirection::Output {
-            let mut outgoing = self.outgoing.lock().unwrap_or_else(|e| e.into_inner());
+            let mut outgoing = crate::realtime_allow_lock!(
+                "external audio late output capture",
+                self.outgoing.lock()
+            )
+            .unwrap_or_else(|e| e.into_inner());
             if outgoing.len() >= samples.len() {
                 let start = outgoing.len() - samples.len();
                 for (output, sample) in outgoing[start..].iter_mut().zip(samples) {
@@ -220,7 +224,11 @@ impl ExternalAudioPort {
         if self.capture_output && self.direction == PortDirection::Output && self.processed_len > 0
         {
             let n = self.processed_len.min(self.buffer.len());
-            let mut outgoing = self.outgoing.lock().unwrap_or_else(|e| e.into_inner());
+            let mut outgoing = crate::realtime_allow_lock!(
+                "external audio deferred output capture",
+                self.outgoing.lock()
+            )
+            .unwrap_or_else(|e| e.into_inner());
             crate::realtime_allow_alloc_once!("ExternalAudioPort::prepare outgoing extend", || {
                 outgoing.extend_from_slice(&self.buffer[..n])
             });
@@ -257,7 +265,11 @@ impl ExternalAudioPort {
         if self.direction == PortDirection::Output {
             self.processed_len = n_frames;
             if self.capture_output {
-                let mut outgoing = self.outgoing.lock().unwrap_or_else(|e| e.into_inner());
+                let mut outgoing = crate::realtime_allow_lock!(
+                    "external audio process output capture",
+                    self.outgoing.lock()
+                )
+                .unwrap_or_else(|e| e.into_inner());
                 crate::realtime_allow_alloc_once!(
                     "ExternalAudioPort::process shared output capture",
                     || outgoing.extend_from_slice(&self.buffer[..n_frames])

--- a/src/rust/shoop_engine/src/external_midi_port.rs
+++ b/src/rust/shoop_engine/src/external_midi_port.rs
@@ -19,7 +19,8 @@ use crate::midi_sorting_buffer::MidiSortingBuffer;
 use crate::midi_state::TrackWhat;
 use crate::midi_storage::MidiStorageElem;
 use crate::port::{PortConnectability, PortDataType, PortDirection};
-use std::sync::{Arc, Mutex};
+use crate::realtime_lock_guard::Mutex;
+use std::sync::Arc;
 
 /// Events reserved per cycle, so a normal cycle never grows either buffer.
 const RESERVE: usize = 256;
@@ -143,7 +144,9 @@ impl ExternalMidiPort {
         self.outgoing.prepare();
         self.outgoing_collected.clear();
         if let Some(output) = &self.output_capture {
-            output.lock().unwrap_or_else(|e| e.into_inner()).clear();
+            crate::realtime_allow_lock!("external MIDI capture clear", output.lock())
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
         }
         self.collect_pos = 0;
         self.last_collect_start = 0;
@@ -153,7 +156,9 @@ impl ExternalMidiPort {
     pub fn request_output(&mut self) {
         self.outgoing_collected.clear();
         if let Some(output) = &self.output_capture {
-            output.lock().unwrap_or_else(|e| e.into_inner()).clear();
+            crate::realtime_allow_lock!("external MIDI capture reset", output.lock())
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
         }
         self.collect_pos = 0;
         self.last_collect_start = 0;
@@ -266,10 +271,12 @@ impl ExternalMidiPort {
                 if !is_initial_all_sound_off {
                     self.outgoing_collected.push(e);
                     if let Some(output) = &self.output_capture {
-                        output
-                            .lock()
-                            .unwrap_or_else(|error| error.into_inner())
-                            .push(MidiEvent::new(e.time as i32, data.to_vec()));
+                        crate::realtime_allow_lock!(
+                            "external MIDI process output capture",
+                            output.lock()
+                        )
+                        .unwrap_or_else(|error| error.into_inner())
+                        .push(MidiEvent::new(e.time as i32, data.to_vec()));
                     }
                 }
             }

--- a/src/rust/shoop_engine/src/graph_scheduler.rs
+++ b/src/rust/shoop_engine/src/graph_scheduler.rs
@@ -22,7 +22,8 @@
 //! runs the last-applied schedule and counts the cycle, so the window costs slightly stale
 //! routing rather than dropped audio.
 
-use std::sync::{Arc, Condvar, Mutex};
+use crate::realtime_lock_guard::Mutex;
+use std::sync::{Arc, Condvar};
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/src/rust/shoop_engine/src/lib.rs
+++ b/src/rust/shoop_engine/src/lib.rs
@@ -50,6 +50,7 @@ pub mod multichannel_audio;
 pub mod port;
 pub mod profiling;
 pub mod realtime_alloc_guard;
+pub mod realtime_lock_guard;
 pub mod resample;
 pub mod session;
 pub mod state;

--- a/src/rust/shoop_engine/src/lv2_carla.rs
+++ b/src/rust/shoop_engine/src/lv2_carla.rs
@@ -5,6 +5,7 @@
 //! afterwards; realtime processing/state/UI instantiation can build on this without
 //! making frontend code depend on Lilv lifetimes.
 
+use crate::realtime_lock_guard::Mutex;
 use crate::FXChainType;
 use anyhow::{anyhow, Result};
 use base64::Engine;
@@ -13,7 +14,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uint, c_void};
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -896,15 +897,15 @@ impl UridMapper {
     }
 
     fn map_str(&self, uri: &str) -> LV2Urid {
-        let mut by_uri = self.by_uri.lock().unwrap_or_else(|e| e.into_inner());
+        let mut by_uri = crate::realtime_allow_lock!("LV2 URID map", self.by_uri.lock())
+            .unwrap_or_else(|e| e.into_inner());
         if let Some(id) = by_uri.get(uri) {
             *id
         } else {
             let id = by_uri.len() as LV2Urid + 1;
             by_uri.insert(uri.to_string(), id);
             drop(by_uri);
-            self.by_id
-                .lock()
+            crate::realtime_allow_lock!("LV2 URID reverse map update", self.by_id.lock())
                 .unwrap_or_else(|e| e.into_inner())
                 .insert(id, CString::new(uri).unwrap_or_default());
             id
@@ -912,8 +913,7 @@ impl UridMapper {
     }
 
     fn unmap(&self, urid: LV2Urid) -> Option<String> {
-        self.by_id
-            .lock()
+        crate::realtime_allow_lock!("LV2 URID unmap", self.by_id.lock())
             .unwrap_or_else(|e| e.into_inner())
             .get(&urid)
             .map(|s| s.to_string_lossy().to_string())
@@ -934,9 +934,7 @@ extern "C" fn unmap_urid(handle: LV2UridMapHandle, urid: LV2Urid) -> *const c_ch
         return std::ptr::null();
     }
     let mapper = unsafe { &*(handle.cast::<UridMapper>()) };
-    mapper
-        .by_id
-        .lock()
+    crate::realtime_allow_lock!("LV2 URID callback unmap", mapper.by_id.lock())
         .unwrap_or_else(|e| e.into_inner())
         .get(&urid)
         .map(|s| s.as_ptr())

--- a/src/rust/shoop_engine/src/multichannel_audio.rs
+++ b/src/rust/shoop_engine/src/multichannel_audio.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use crate::realtime_lock_guard::Mutex;
 
 use thiserror::Error;
 

--- a/src/rust/shoop_engine/src/realtime_lock_guard.rs
+++ b/src/rust/shoop_engine/src/realtime_lock_guard.rs
@@ -1,0 +1,262 @@
+//! Runtime guard for project-owned mutex acquisition in realtime sections.
+//!
+//! Unlike allocation, mutex acquisition has no process-wide hook. [`Mutex`]
+//! therefore wraps project-owned standard mutexes and checks each acquisition
+//! against a thread-local realtime scope.
+
+use std::cell::Cell;
+use std::fmt;
+use std::panic::Location;
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::{LockResult, Mutex as StdMutex, MutexGuard, TryLockResult};
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static FIRST_VIOLATION: AtomicPtr<Location<'static>> = AtomicPtr::new(std::ptr::null_mut());
+
+thread_local! {
+    static REALTIME_DEPTH: Cell<u32> = const { Cell::new(0) };
+    static PERMISSION_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+struct DepthGuard {
+    depth: &'static std::thread::LocalKey<Cell<u32>>,
+}
+
+impl DepthGuard {
+    fn enter(depth: &'static std::thread::LocalKey<Cell<u32>>) -> Self {
+        depth.with(|value| value.set(value.get().saturating_add(1)));
+        Self { depth }
+    }
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        self.depth.with(|value| value.set(value.get() - 1));
+    }
+}
+
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn forbid_locks_if_enabled<T>(f: impl FnOnce() -> T) -> T {
+    if !enabled() {
+        return f();
+    }
+    let _scope = DepthGuard::enter(&REALTIME_DEPTH);
+    f()
+}
+
+pub fn allow_lock<T>(_reason: &'static str, f: impl FnOnce() -> T) -> T {
+    if !enabled() {
+        return f();
+    }
+    let _scope = DepthGuard::enter(&PERMISSION_DEPTH);
+    f()
+}
+
+pub fn first_violation() -> Option<&'static Location<'static>> {
+    let location = FIRST_VIOLATION.load(Ordering::Acquire);
+    if location.is_null() {
+        None
+    } else {
+        // SAFETY: only `&'static Location` pointers are stored here.
+        Some(unsafe { &*location })
+    }
+}
+
+#[cfg(test)]
+fn clear_first_violation() {
+    FIRST_VIOLATION.store(std::ptr::null_mut(), Ordering::Release);
+}
+
+#[track_caller]
+fn check_lock_attempt() {
+    if !enabled() {
+        return;
+    }
+    let forbidden = REALTIME_DEPTH.with(|realtime| realtime.get() > 0)
+        && PERMISSION_DEPTH.with(|permission| permission.get() == 0);
+    if !forbidden {
+        return;
+    }
+
+    let location = Location::caller();
+    let _ = FIRST_VIOLATION.compare_exchange(
+        std::ptr::null_mut(),
+        std::ptr::from_ref(location).cast_mut(),
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    );
+
+    #[cfg(test)]
+    panic!("unapproved mutex acquisition in realtime section");
+
+    #[cfg(not(test))]
+    std::process::abort();
+}
+
+pub struct Mutex<T: ?Sized> {
+    inner: StdMutex<T>,
+}
+
+impl<T> Mutex<T> {
+    pub const fn new(value: T) -> Self {
+        Self {
+            inner: StdMutex::new(value),
+        }
+    }
+
+    pub fn into_inner(self) -> LockResult<T> {
+        self.inner.into_inner()
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    #[track_caller]
+    pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
+        check_lock_attempt();
+        self.inner.lock()
+    }
+
+    #[track_caller]
+    pub fn try_lock(&self) -> TryLockResult<MutexGuard<'_, T>> {
+        check_lock_attempt();
+        self.inner.try_lock()
+    }
+
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.inner.get_mut()
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.inner.is_poisoned()
+    }
+
+    pub fn clear_poison(&self) {
+        self.inner.clear_poison();
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    #[track_caller]
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        check_lock_attempt();
+        self.inner.fmt(formatter)
+    }
+}
+
+#[macro_export]
+macro_rules! realtime_allow_lock {
+    ($reason:literal, $acquire:expr) => {{
+        $crate::realtime_lock_guard::allow_lock($reason, || $acquire)
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn realtime_detection_contract() {
+        clear_first_violation();
+        set_enabled(false);
+        let mutex = Mutex::new(1_u32);
+        forbid_locks_if_enabled(|| {
+            *mutex.lock().unwrap() += 1;
+        });
+        assert_eq!(*mutex.lock().unwrap(), 2);
+        assert!(first_violation().is_none());
+
+        set_enabled(true);
+        let violation = std::panic::catch_unwind(|| {
+            forbid_locks_if_enabled(|| {
+                let _guard = mutex.lock().unwrap();
+            });
+        });
+        assert!(violation.is_err());
+        assert!(first_violation().is_some());
+
+        forbid_locks_if_enabled(|| {
+            {
+                let mut guard =
+                    crate::realtime_allow_lock!("test permission", mutex.lock()).unwrap();
+                *guard += 1;
+            }
+            forbid_locks_if_enabled(|| {
+                let _guard =
+                    crate::realtime_allow_lock!("nested test permission", mutex.try_lock())
+                        .unwrap();
+            });
+        });
+
+        let leaked = std::panic::catch_unwind(|| {
+            forbid_locks_if_enabled(|| {
+                let _guard = mutex.try_lock().unwrap();
+            });
+        });
+        assert!(leaked.is_err());
+
+        let shared = Arc::new(Mutex::new(0_u32));
+        let other = Arc::clone(&shared);
+        std::thread::spawn(move || {
+            *other.lock().unwrap() = 1;
+        })
+        .join()
+        .unwrap();
+        assert_eq!(*shared.lock().unwrap(), 1);
+        set_enabled(false);
+    }
+
+    #[test]
+    fn wrapper_preserves_poisoning_and_mutable_access() {
+        let mut mutex = Mutex::new(1_u32);
+        *mutex.get_mut().unwrap() = 2;
+        assert_eq!(mutex.into_inner().unwrap(), 2);
+
+        let mutex = Arc::new(Mutex::new(0_u32));
+        let poisoned = Arc::clone(&mutex);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoned.lock().unwrap();
+            panic!("poison checked mutex");
+        })
+        .join();
+        assert!(mutex.is_poisoned());
+        mutex.clear_poison();
+        assert!(!mutex.is_poisoned());
+    }
+
+    #[test]
+    fn checked_guard_interoperates_with_condvar() {
+        let pair = Arc::new((Mutex::new(false), std::sync::Condvar::new()));
+        let worker = Arc::clone(&pair);
+        let thread = std::thread::spawn(move || {
+            let (mutex, cv) = &*worker;
+            *mutex.lock().unwrap() = true;
+            cv.notify_one();
+        });
+        let (mutex, cv) = &*pair;
+        let mut ready = mutex.lock().unwrap();
+        while !*ready {
+            ready = cv.wait(ready).unwrap();
+        }
+        thread.join().unwrap();
+    }
+}

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -11,10 +11,10 @@
 //!
 //! Audio only for now: MIDI channels are not yet routed through the session.
 
+#[cfg(feature = "lv2")]
+use crate::realtime_lock_guard::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-#[cfg(feature = "lv2")]
-use std::sync::Mutex;
 
 use crate::audio_channel::PreparedAudioChannelData;
 use crate::audio_midi_loop::AudioMidiLoop;
@@ -2119,7 +2119,8 @@ impl Session {
             .map(|(title, host)| (title.clone(), host.clone()))
             .collect();
         for (title, host) in chains {
-            let mut host = host.lock().unwrap_or_else(|e| e.into_inner());
+            let mut host = crate::realtime_allow_lock!("Carla host processing", host.lock())
+                .unwrap_or_else(|e| e.into_inner());
             if !host.is_active() {
                 continue;
             }
@@ -3995,7 +3996,7 @@ mod tests {
             );
             return;
         };
-        let host = std::sync::Arc::new(std::sync::Mutex::new(host));
+        let host = std::sync::Arc::new(Mutex::new(host));
         let mut s = Session::default();
         s.set_sample_rate(48_000);
         s.set_buffer_size(64);
@@ -4023,7 +4024,7 @@ mod tests {
             return;
         };
         host.set_active(true);
-        let host = std::sync::Arc::new(std::sync::Mutex::new(host));
+        let host = std::sync::Arc::new(Mutex::new(host));
         let mut s = Session::default();
         s.set_sample_rate(48_000);
         s.set_buffer_size(64);

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -43,6 +43,24 @@ fn realtime_guard_reverse_guard_allows_exceptional_allocations() {
 }
 
 #[test]
+fn realtime_lock_guard_is_allocation_free() {
+    use shoop_engine::realtime_lock_guard;
+
+    let mutex = realtime_lock_guard::Mutex::new(0_u32);
+    realtime_lock_guard::set_enabled(true);
+    assert_no_alloc(|| {
+        realtime_lock_guard::forbid_locks_if_enabled(|| {
+            let mut value =
+                shoop_engine::realtime_allow_lock!("no-allocation test permission", mutex.lock())
+                    .unwrap();
+            *value += 1;
+        });
+    });
+    realtime_lock_guard::set_enabled(false);
+    assert_eq!(*mutex.lock().unwrap(), 1);
+}
+
+#[test]
 fn snapshot_process_publication_is_allocation_free() {
     let runtime = ContentSnapshotRuntime::new();
     let (mut audio, _audio_control, _audio_reader) = runtime.create_audio_channel(8, 4);

--- a/src/rust/shoop_engine/tests/no_std_mutex.rs
+++ b/src/rust/shoop_engine/tests/no_std_mutex.rs
@@ -27,7 +27,10 @@ fn production_engine_mutexes_use_the_checked_abstraction() {
             continue;
         }
         let source = fs::read_to_string(&path).expect("read Rust source");
-        let production = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        let production = source
+            .split("\n#[cfg(test)]\nmod tests")
+            .next()
+            .unwrap_or(&source);
         permission_count += production.matches("realtime_allow_lock!").count();
         let compact: String = production
             .chars()

--- a/src/rust/shoop_engine/tests/no_std_mutex.rs
+++ b/src/rust/shoop_engine/tests/no_std_mutex.rs
@@ -1,0 +1,69 @@
+use regex::Regex;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn rust_sources(directory: &Path, output: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("read source directory") {
+        let path = entry.expect("read source entry").path();
+        if path.is_dir() {
+            rust_sources(&path, output);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            output.push(path);
+        }
+    }
+}
+
+#[test]
+fn production_engine_mutexes_use_the_checked_abstraction() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let checked_mutex = source_root.join("realtime_lock_guard.rs");
+    let direct_import = Regex::new(r"usestd::sync::\{[^}]*Mutex").unwrap();
+    let mut sources = Vec::new();
+    let mut permission_count = 0;
+    rust_sources(&source_root, &mut sources);
+
+    for path in sources {
+        if path == checked_mutex {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("read Rust source");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(&source);
+        permission_count += production.matches("realtime_allow_lock!").count();
+        let compact: String = production
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .collect();
+        assert!(
+            !compact.contains("std::sync::Mutex") && !direct_import.is_match(&compact),
+            "{} bypasses the checked mutex abstraction",
+            path.display()
+        );
+    }
+    assert_eq!(
+        permission_count, 34,
+        "the explicit realtime lock permission baseline changed"
+    );
+}
+
+#[test]
+fn engine_and_driver_realtime_boundaries_are_marked() {
+    let source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let engine = fs::read_to_string(source_root.join("engine.rs")).expect("read engine source");
+    let backend =
+        fs::read_to_string(source_root.join("app_backend.rs")).expect("read backend source");
+
+    assert!(engine.matches("forbid_locks_if_enabled").count() >= 3);
+    assert!(backend.matches("forbid_locks_if_enabled").count() >= 4);
+    for permission in [
+        "JACK registered port registry",
+        "CPAL capture ring input",
+        "CPAL external connection registry",
+        "dummy driver iteration state",
+        "object creation failure publication",
+    ] {
+        assert!(
+            backend.contains(permission),
+            "missing explicit realtime lock permission: {permission}"
+        );
+    }
+}

--- a/src/rust/shoop_engine/tests/realtime_lock_app.rs
+++ b/src/rust/shoop_engine/tests/realtime_lock_app.rs
@@ -1,0 +1,81 @@
+#![cfg(feature = "app_backend")]
+
+use shoop_engine::app_backend::{
+    AudioDriver, AudioDriverSettings, AudioPort, BackendSession, DummyAudioDriverSettings, MidiPort,
+};
+use shoop_engine::realtime_lock_guard;
+use shoop_engine::{AudioDriverType, ChannelMode, LoopMode, MidiEvent, PortDirection};
+
+struct DisableGuard;
+
+impl Drop for DisableGuard {
+    fn drop(&mut self) {
+        realtime_lock_guard::set_enabled(false);
+    }
+}
+
+#[test]
+fn dummy_app_processing_uses_only_explicit_realtime_lock_permissions() {
+    const BUFFER: u32 = 64;
+
+    let driver = AudioDriver::new(AudioDriverType::Dummy, None).expect("driver");
+    driver
+        .start(&AudioDriverSettings::Dummy(DummyAudioDriverSettings {
+            client_name: "realtime-lock-app-test".to_string(),
+            sample_rate: 48_000,
+            buffer_size: BUFFER,
+        }))
+        .expect("start driver");
+    let session = BackendSession::new().expect("session");
+    session.set_audio_driver(&driver).expect("attach driver");
+    driver.dummy_enter_controlled_mode();
+
+    realtime_lock_guard::set_enabled(true);
+    let _disable = DisableGuard;
+
+    let loop_ = session.create_loop().expect("loop");
+    let channel = loop_
+        .add_audio_channel(ChannelMode::Direct)
+        .expect("channel");
+    let midi_channel = loop_
+        .add_midi_channel(ChannelMode::Direct)
+        .expect("MIDI channel");
+    let output = AudioPort::new_driver_port(
+        &session,
+        &driver,
+        "guarded-output",
+        &PortDirection::Output,
+        BUFFER,
+    )
+    .expect("output port");
+    let midi_output = MidiPort::new_driver_port(
+        &session,
+        &driver,
+        "guarded-MIDI-output",
+        &PortDirection::Output,
+        BUFFER,
+    )
+    .expect("MIDI output port");
+    channel.connect_output(&output).expect("connect output");
+    midi_channel
+        .connect_output(&midi_output)
+        .expect("connect MIDI output");
+    midi_channel
+        .load_all_midi_data(&[MidiEvent::new(0, vec![0x90, 60, 100])])
+        .expect("load MIDI");
+    loop_.set_length(BUFFER * 2).expect("length");
+    loop_
+        .transition(LoopMode::Playing, -1, -1)
+        .expect("playing");
+    output.dummy_request_data(BUFFER).expect("request capture");
+    midi_output
+        .dummy_request_data(BUFFER)
+        .expect("request MIDI capture");
+
+    driver.wait_process();
+    driver.dummy_request_controlled_frames(BUFFER);
+    driver.dummy_run_requested_frames();
+
+    realtime_lock_guard::set_enabled(false);
+    assert_eq!(loop_.get_state().expect("state").position, BUFFER);
+}

--- a/src/rust/shoopdaloop/src/cli_args.rs
+++ b/src/rust/shoopdaloop/src/cli_args.rs
@@ -172,6 +172,10 @@ pub struct DeveloperOptions {
     #[clap(long = "rt-alloc-guard", help_heading = "Developer options")]
     pub rt_alloc_guard: bool,
 
+    /// Abort on an unapproved project-owned mutex acquisition in realtime processing.
+    #[clap(long = "rt-lock-guard", help_heading = "Developer options")]
+    pub rt_lock_guard: bool,
+
     // Disables the crash handler.
     #[clap(long = "no-crash-handling", help_heading = "Developer options")]
     pub no_crash_handling: bool,
@@ -249,4 +253,18 @@ where
     I::Item: Into<std::ffi::OsString> + Clone,
 {
     CliArgs::parse_from(args_iter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn realtime_lock_guard_is_disabled_by_default_and_can_be_enabled() {
+        let defaults = parse_arguments(["shoopdaloop"]);
+        assert!(!defaults.developer_options.rt_lock_guard);
+
+        let enabled = parse_arguments(["shoopdaloop", "--rt-lock-guard"]);
+        assert!(enabled.developer_options.rt_lock_guard);
+    }
 }

--- a/src/rust/shoopdaloop/src/lib_impl.rs
+++ b/src/rust/shoopdaloop/src/lib_impl.rs
@@ -32,20 +32,35 @@ thread_local! {
 
 fn crash_info_callback_impl() -> Result<Vec<crashhandling::AdditionalCrashAttachment>, anyhow::Error>
 {
-    let maybe_qml_engine = unsafe { get_registered_qml_engine()? };
+    let mut attachments = Vec::new();
+    if let Some(location) = shoop_engine::realtime_lock_guard::first_violation() {
+        attachments.push(crashhandling::AdditionalCrashAttachment {
+            id: "realtime_lock_violation".to_string(),
+            contents: format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            ),
+        });
+    }
+
+    let maybe_qml_engine = match unsafe { get_registered_qml_engine() } {
+        Ok(engine) => engine,
+        Err(_) if !attachments.is_empty() => return Ok(attachments),
+        Err(error) => return Err(error),
+    };
     if !maybe_qml_engine.is_null() {
         unsafe {
             let maybe_qml_engine = std::pin::Pin::new_unchecked(&mut *maybe_qml_engine);
             let qml_stack = get_qml_engine_stack(maybe_qml_engine);
-            let info = crashhandling::AdditionalCrashAttachment {
+            attachments.push(crashhandling::AdditionalCrashAttachment {
                 id: "qml_stack".to_string(),
                 contents: qml_stack,
-            };
-            Ok(vec![info])
+            });
         }
-    } else {
-        Ok(vec![])
     }
+    Ok(attachments)
 }
 
 fn crash_info_callback() -> Vec<crashhandling::AdditionalCrashAttachment> {
@@ -392,6 +407,10 @@ fn entry_point<'py>(config: ShoopConfig) -> Result<i32, anyhow::Error> {
     shoop_engine::realtime_alloc_guard::set_enabled(cli_args.developer_options.rt_alloc_guard);
     if cli_args.developer_options.rt_alloc_guard {
         info!("Realtime allocation guard enabled for top-level process calls");
+    }
+    shoop_engine::realtime_lock_guard::set_enabled(cli_args.developer_options.rt_lock_guard);
+    if cli_args.developer_options.rt_lock_guard {
+        info!("Realtime project mutex guard enabled for process callbacks");
     }
 
     if cli_args.print_backends {


### PR DESCRIPTION
## Summary
- add a checked `shoop_engine` mutex abstraction that detects project-owned `lock` and `try_lock` attempts before acquisition in marked realtime sections
- mark complete engine, JACK, CPAL, and dummy callback boundaries, with 34 individually reason-labelled permissions for the existing lock-debt baseline
- statically reject direct production `std::sync::Mutex` use outside the wrapper and test guard nesting, thread locality, standard mutex compatibility, callback coverage, and allocation-free operation
- add the disabled-by-default `--rt-lock-guard` developer option and preserve the first violating callsite for crash diagnostics

## Coverage boundary
This guard covers project-owned checked Rust mutexes. It does not claim to detect dependency or native locks inside JACK, CPAL, midir, LV2 plugins, libc, or operating-system audio code.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' cargo build`
- focused checked-mutex, structural, no-allocation, dummy callback, and CLI tests
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend -- --test-threads=1` (including 621 serialized `shoop_engine` library tests)
- `SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test --rt-lock-guard` (197 cases: 196 passed, 0 failed, 1 CPAL environment skip)
