### PR TITLE
Skip Carla MIDI tests when host is unavailable

### DIFF
--- a/src/qml/test/tst_TrackControlAndLoop_drywet_carla.qml
+++ b/src/qml/test/tst_TrackControlAndLoop_drywet_carla.qml
@@ -62,6 +62,16 @@ ShoopTestFile {
                 return AppRegistries.objects_registry.get(`${track.obj_id}_${suffix}`)
             }
 
+            function require_carla(track) {
+                let chain = fx(track)
+                if (!chain.ready && session.backend.allow_missing_backends()) {
+                    skip(`Carla FX chain unavailable for ${track.obj_id}`)
+                    return false
+                }
+                verify_true(chain.ready, `Carla FX chain unavailable for ${track.obj_id}`)
+                return chain.ready
+            }
+
             function dry_channel(loop) {
                 return loop.get_audio_channels().find((channel) => channel.obj_id.match(/.*_dry_.*/))
             }
@@ -164,6 +174,9 @@ ShoopTestFile {
             }
 
             function verify_midi_gating(track) {
+                if (!require_carla(track)) {
+                    return
+                }
                 reset_track(track)
                 let external_input = port(track, "dry_midi_in")
                 let fx_input = port(track, "fx_chain_midi_in_1")


### PR DESCRIPTION
## Summary
- require the selected Carla FX chain to report ready before running MIDI activation-gating assertions
- skip those assertions when missing backends are explicitly allowed
- keep unavailable Carla as a test failure outside the missing-backend policy

## Validation
- `cargo build`
- focused QML suite with `SHOOP_ALLOW_MISSING_BACKENDS=1` and an empty `LV2_PATH`: 3 passed, 3 skipped, 0 failed
- `git diff --check`