### PR TITLE
tracing: include severity in Tracy messages

### DIFF
--- a/.agents/skills/tracy/SKILL.md
+++ b/.agents/skills/tracy/SKILL.md
@@ -178,58 +178,58 @@ Several objects may update during one frontend refresh. Correlate object plots w
 Most Rust `log` records appear in Tracy as a `message` whose `text` field has this form:
 
 ```text
-message = <payload>, log.target = <logical target>, log.module_path = <Rust module>, log.file = <source path>, log.line = <line>
+log.level = <TRACE|DEBUG|INFO|WARN|ERROR>, message = <payload>, log.target = <logical target>, log.module_path = <Rust module>, log.file = <source path>, log.line = <line>
 ```
 
 For example:
 
 ```text
-message = Transitioning 1 loops to 2 with delay -1, sync at cycle -1, log.target = Frontend.Loop, log.module_path = frontend::cxx_qt_shoop::rust::qobj_loop_gui, log.file = src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_gui.rs, log.line = 477
+log.level = INFO, message = Transitioning 1 loops to 2 with delay -1, sync at cycle -1, log.target = Frontend.Loop, log.module_path = frontend::cxx_qt_shoop::rust::qobj_loop_gui, log.file = src/rust/frontend/src/cxx_qt_shoop/rust/qobj_loop_gui.rs, log.line = 477
 ```
 
 The embedded metadata is not promoted to separate `tracy-query` fields; filter it through `message.text`. Anchor metadata values on their labels and delimiters because the payload may itself contain commas or equals signs:
 
 ```sh
-# Logical logging target/category.
+# One exact severity.
 "$TQ" query --kind message \
+  --filter 'message.text=^log\.level = ERROR(,|$)' "$TRACE"
+
+# Warning or error severity.
+"$TQ" query --kind message \
+  --filter 'message.text=^log\.level = (WARN|ERROR)(,|$)' "$TRACE"
+
+# Severity and logical logging target/category. Repeated filters are ANDed.
+"$TQ" query --kind message \
+  --filter 'message.text=^log\.level = (DEBUG|INFO)(,|$)' \
   --filter 'message.text=(^|, )log\.target = Frontend\.Loop(,|$)' "$TRACE"
 
 # Rust module path.
 "$TQ" query --kind message \
   --filter 'message.text=(^|, )log\.module_path = frontend::cxx_qt_shoop::rust::qobj_loop_gui(,|$)' "$TRACE"
 
-# Source tree or one source file. Repeated filters are ANDed.
+# Source tree or one source file.
 "$TQ" query --kind message \
   --filter 'message.text=(^|, )log\.file = src/rust/frontend/src/' \
   --filter 'message.text=qobj_loop_gui\.rs(,|$)' "$TRACE"
 
-# Exact source line; log.line is normally the final embedded field.
+# Exact source line.
 "$TQ" query --kind message \
-  --filter 'message.text=(^|, )log\.line = 477$' "$TRACE"
+  --filter 'message.text=(^|, )log\.line = 477(,|$)' "$TRACE"
 ```
 
-`log.target` is the stable logical category normally shown as names such as `Frontend.Loop` or `Frontend.BackendWrapper`. `log.module_path` is the Rust module that emitted the record. `log.file` and `log.line` identify the call site. Prefer the logical target for durable investigations; module paths and source lines are more exact but change during refactoring.
+`log.level` is the event severity. `log.target` is the stable logical category normally shown as names such as `Frontend.Loop` or `Frontend.BackendWrapper`. `log.module_path` is the Rust module that emitted the record. `log.file` and `log.line` identify the call site. Prefer the logical target for durable investigations; module paths and source lines are more exact but change during refactoring.
 
-The Tracy message currently does **not** encode the Rust log level. Its `color` field is not a severity mapping: ordinary Shoop records are normally the default color, while red may indicate an instrumentation failure from the Tracy integration. Consequently, none of the following is a valid post-capture level filter:
+Do not treat the Tracy message `color` field as severity. Shoop encodes severity explicitly in `message.text`; ordinary records normally use the default color, while red may indicate an instrumentation failure from the Tracy integration. Searching the payload for words such as `warn`, `error`, or `failed` is likewise not a level filter.
 
-- filtering `message.color` as though it meant `WARN` or `ERROR`;
-- searching payload text for `warn`, `error`, or `failed` and calling the result a level filter;
-- assuming `SHOOP_LOG` removed lower-level records from the Tracy capture.
-
-Use the companion application output when exact levels are required. Its usual line format is:
+The companion application output remains formatted as:
 
 ```text
 [<RFC3339 timestamp>] [<thread name/id>] [<logical target>] [TRACE|DEBUG|INFO|WARN|ERROR] <payload>
 ```
 
-Filter that file by the bracketed level field, optionally combined with its logical target:
+`SHOOP_LOG`, or `RUST_LOG` when `SHOOP_LOG` is unset, controls that shell output. For example, `SHOOP_LOG='info,Frontend.Loop=debug'` enables general info output and debug output for that target. Tracy event capture is filtered independently and does not change the shell format.
 
-```sh
-rg '\[(WARN|ERROR)\]' shoopdaloop.log
-rg '\[Frontend\.Loop\] \[(DEBUG|INFO)\]' shoopdaloop.log
-```
-
-`SHOOP_LOG`, or `RUST_LOG` when `SHOOP_LOG` is unset, controls this formatted application output. For example, `SHOOP_LOG='info,Frontend.Loop=debug'` enables general info output and debug output for that target. The Tracy layer is enabled and filtered independently, so treat this as console/file capture configuration rather than a guarantee about which Tracy messages exist.
+Captures made before severity was added have messages beginning with `message =` instead of `log.level =` and cannot be filtered reliably by level after capture.
 
 Not every Tracy message must follow the Rust-log suffix format. QML, support tools, or instrumentation diagnostics may emit different text. Inspect a small sample before applying suffix-specific filters. Sampling, scheduler, lock, memory, and hardware-counter collections likewise depend on what Tracy recorded; an absent category is not proof that the corresponding behavior did not occur.
 

--- a/src/rust/common/src/logging/setup.rs
+++ b/src/rust/common/src/logging/setup.rs
@@ -1,7 +1,10 @@
 use colored::Colorize;
 use lazy_static::lazy_static;
+use std::cell::RefCell;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::sync::Mutex;
+use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::filter::filter_fn;
@@ -36,6 +39,107 @@ impl tracing_tracy::Config for ShoopTracyConfig {
 
     fn format_fields_in_zone_name(&self) -> bool {
         false
+    }
+}
+
+const TRACY_MESSAGE_MAX_BYTES: usize = u16::MAX as usize - 1;
+const TRACY_ERROR_COLOR: u32 = 0xFF000000;
+
+thread_local! {
+    static TRACY_EVENT_MESSAGES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+struct ShoopTracyEventFieldVisitor<'a> {
+    dest: &'a mut String,
+    frame_mark: bool,
+    has_fields: bool,
+}
+
+impl Visit for ShoopTracyEventFieldVisitor<'_> {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        match (value, field.name()) {
+            (_, "tracy.frame_mark") => self.frame_mark = value,
+            (true, _) => self.record_str(field, "true"),
+            (false, _) => self.record_str(field, "false"),
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.dest.push_str(", ");
+        self.dest.push_str(field.name());
+        self.dest.push_str(" = ");
+        self.dest.push_str(value);
+        self.has_fields = true;
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let _ = write!(self.dest, ", {} = {value:?}", field.name());
+        self.has_fields = true;
+    }
+}
+
+#[derive(Clone)]
+struct ShoopTracyEventLayer {
+    client: tracy_client::Client,
+}
+
+impl ShoopTracyEventLayer {
+    fn new() -> Self {
+        Self {
+            client: tracy_client::Client::start(),
+        }
+    }
+
+    fn emit_message(&self, message: &str) {
+        if message.len() < TRACY_MESSAGE_MAX_BYTES {
+            self.client.message(message, 0);
+            return;
+        }
+
+        let mut end = TRACY_MESSAGE_MAX_BYTES;
+        while !message.is_char_boundary(end) {
+            end -= 1;
+        }
+        self.client.color_message(
+            "event message is too long and was truncated",
+            TRACY_ERROR_COLOR,
+            0,
+        );
+        self.client.message(&message[..end], 0);
+    }
+}
+
+impl<S: Subscriber> Layer<S> for ShoopTracyEventLayer {
+    fn on_event(&self, event: &Event<'_>, _: tracing_subscriber::layer::Context<'_, S>) {
+        let normalized_metadata = event.normalized_metadata();
+        let metadata = normalized_metadata
+            .as_ref()
+            .unwrap_or_else(|| event.metadata());
+
+        let mut message = TRACY_EVENT_MESSAGES
+            .with(|messages| messages.borrow_mut().pop())
+            .unwrap_or_else(|| String::with_capacity(64));
+        message.clear();
+        let _ = write!(message, "log.level = {}", metadata.level());
+
+        let mut visitor = ShoopTracyEventFieldVisitor {
+            dest: &mut message,
+            frame_mark: false,
+            has_fields: false,
+        };
+        event.record(&mut visitor);
+        let has_fields = visitor.has_fields;
+        let frame_mark = visitor.frame_mark;
+        drop(visitor);
+
+        if has_fields {
+            self.emit_message(&message);
+        }
+        if frame_mark {
+            self.client.frame_mark();
+        }
+
+        TRACY_EVENT_MESSAGES.with(|messages| messages.borrow_mut().push(message));
     }
 }
 
@@ -123,16 +227,23 @@ pub fn init_logging() -> Result<(), anyhow::Error> {
         .with_writer(std::io::stdout)
         .with_filter(env_filter);
 
-    let registry = tracing_subscriber::registry().with(fmt_layer);
-    let registry = if crate::tracing_helpers::is_tracing_enabled() {
-        let tracy_layer = tracing_tracy::TracyLayer::new(ShoopTracyConfig::default())
-            .with_filter(filter_fn(|_| crate::tracing_helpers::is_tracing_enabled()));
-        registry.with(Some(tracy_layer))
-    } else {
-        registry.with(None)
-    };
+    let tracing_enabled = crate::tracing_helpers::is_tracing_enabled();
+    let tracy_span_layer = tracing_enabled.then(|| {
+        tracing_tracy::TracyLayer::new(ShoopTracyConfig::default()).with_filter(filter_fn(
+            |metadata| metadata.is_span() && crate::tracing_helpers::is_tracing_enabled(),
+        ))
+    });
+    let tracy_event_layer = tracing_enabled.then(|| {
+        ShoopTracyEventLayer::new().with_filter(filter_fn(|metadata| {
+            metadata.is_event() && crate::tracing_helpers::is_tracing_enabled()
+        }))
+    });
 
-    registry.init();
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(tracy_span_layer)
+        .with(tracy_event_layer)
+        .init();
     let _ = tracing_log::LogTracer::init();
 
     Ok(())


### PR DESCRIPTION
## Summary
- emit tracing events through a Shoop Tracy event layer with an explicit `log.level` prefix
- keep shell log formatting unchanged and retain the existing Tracy layer for spans
- document severity, target, module, file, and line filtering in the Tracy skill

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build`
- `cargo test -p common`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend -- --test-threads=1`
- `QT_QPA_PLATFORM=offscreen SHOOP_ALLOW_MISSING_BACKENDS=1 target/debug/shoopdaloop_dev.sh --self-test` (235 passed, 1 backend-unavailable skip)
- temporary Tracy capture validated with tracy-query: 650/650 messages severity-prefixed, no duplicate legacy messages, zones and frames retained

## Local test note
The default-parallel workspace command twice exposed the existing timing-sensitive `a_graph_built_through_the_api_records_and_plays` failure. It passed 10/10 in isolation and passed in the serialized workspace suite. The sandbox also lacks `/dev/snd/seq`, so the documented missing-backend skip was used for the clean broad run.