### PR TITLE
Fix egui CI platform failures

### DIFF
--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -47,6 +47,8 @@ fn realtime_lock_guard_is_allocation_free() {
     use shoop_engine::realtime_lock_guard;
 
     let mutex = realtime_lock_guard::Mutex::new(0_u32);
+    // Warm up platform mutex state before measuring the checked guard path.
+    drop(mutex.lock().unwrap());
     realtime_lock_guard::set_enabled(true);
     assert_no_alloc(|| {
         realtime_lock_guard::forbid_locks_if_enabled(|| {

--- a/src/rust/shoopdaloop_egui/browser_smoke.mjs
+++ b/src/rust/shoopdaloop_egui/browser_smoke.mjs
@@ -92,6 +92,7 @@ try {
   const chromeArgs = [
     '--headless=new',
     '--no-sandbox',
+    '--disable-dev-shm-usage',
     '--disable-gpu-sandbox',
     '--enable-webgl',
     '--enable-unsafe-swiftshader',
@@ -104,10 +105,10 @@ try {
     `--user-data-dir=${profile}`,
     'about:blank',
   ];
-  if (!denyFirst) chromeArgs.splice(9, 0, '--use-fake-ui-for-media-stream');
+  if (!denyFirst) chromeArgs.splice(-1, 0, '--use-fake-ui-for-media-stream');
   start(chrome, chromeArgs);
 
-  const targets = await waitForJson(`http://${host}:${debugPort}/json`, 15_000);
+  const targets = await waitForJson(`http://${host}:${debugPort}/json`, 60_000);
   const target = targets.find(candidate => candidate.type === 'page');
   if (!target) throw new Error('Chrome exposed no page target');
 


### PR DESCRIPTION
## Summary
- warm the platform mutex before measuring the checked realtime lock-guard path on macOS
- keep the allocation test focused on the guard scopes and permission path rather than one-time platform mutex initialization
- make hosted Chrome startup resilient to constrained shared memory and slow DevTools startup
- insert fake-media flags relative to the browser URL instead of by a brittle fixed index

## CI failures addressed
- `macos arm64 debug`: the first standard mutex acquisition initialized platform mutex state inside `assert_no_alloc`, aborting `realtime_lock_guard_is_allocation_free`
- `web wasm32 release`: Chrome intermittently failed to expose its DevTools endpoint within 15 seconds on hosted runners

## Verification
- `cargo fmt --all`
- `RUSTFLAGS="-D warnings" cargo build`
- `cargo test -p shoop_engine --test no_alloc -- --test-threads=1`
- `cargo test -p shoop_engine realtime_lock_guard::tests --lib -- --test-threads=1`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend -- --test-threads=1`
- `node --check src/rust/shoopdaloop_egui/browser_smoke.mjs`

The first full workspace attempt reached only the expected unavailable virtual-MIDI failures and was rerun with the repository-supported missing-backend allowance. The QML self-test passed its Dummy and JACK backend files, then hit the documented unrelated `Created invalid object` environment hang while loading `tst_CompositeLoop_running.qml`.
