### PR TITLE
Fix egui loop hover overlap and track balance dials

### DIFF
--- a/src/rust/shoop_egui/src/dial.rs
+++ b/src/rust/shoop_egui/src/dial.rs
@@ -1,0 +1,54 @@
+pub(crate) fn dial_indicator(rect: egui::Rect, fraction: f32) -> [egui::Pos2; 2] {
+    let angle = -2.35 + fraction.clamp(0.0, 1.0) * 4.7;
+    let direction = egui::vec2(angle.sin(), -angle.cos());
+    [
+        rect.center() + direction * rect.width() * 0.30,
+        rect.center() + direction * rect.width() * 0.43,
+    ]
+}
+
+pub(crate) fn paint_dial(
+    ui: &egui::Ui,
+    response: &egui::Response,
+    rect: egui::Rect,
+    fraction: f32,
+    label: &str,
+) {
+    let visuals = ui.style().interact(response);
+    ui.painter().circle_filled(
+        rect.center(),
+        rect.width() / 2.0,
+        egui::Color32::from_rgb(34, 34, 34),
+    );
+    ui.painter().circle_stroke(
+        rect.center(),
+        rect.width() / 2.0,
+        egui::Stroke::new(1.0, visuals.fg_stroke.color),
+    );
+    ui.painter().line_segment(
+        dial_indicator(rect, fraction),
+        egui::Stroke::new(1.5, egui::Color32::WHITE),
+    );
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        label,
+        egui::FontId::proportional(7.0),
+        egui::Color32::from_gray(180),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dial_indicator_stays_outside_the_label_area() {
+        let rect = egui::Rect::from_center_size(egui::pos2(20.0, 20.0), egui::vec2(18.0, 18.0));
+        for fraction in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            let segment = dial_indicator(rect, fraction);
+            assert!(segment[0].distance(rect.center()) >= rect.width() * 0.29);
+            assert!(segment[1].distance(rect.center()) > segment[0].distance(rect.center()));
+        }
+    }
+}

--- a/src/rust/shoop_egui/src/lib.rs
+++ b/src/rust/shoop_egui/src/lib.rs
@@ -3,6 +3,7 @@
 mod app_widget;
 mod connection_dialog;
 mod details_pane;
+mod dial;
 mod fonts;
 mod global_controls;
 mod key_input;

--- a/src/rust/shoop_egui/src/loop_widget.rs
+++ b/src/rust/shoop_egui/src/loop_widget.rs
@@ -5,14 +5,15 @@ use egui_material_icons::icons::{
 use egui_material_icons::MaterialIcon;
 
 use crate::{
-    AppIntent, CompositeKind, LoopAudioExportFormat, LoopMode, LoopState, LoopWidgetAction,
-    SelectionModifiers,
+    dial::paint_dial, AppIntent, CompositeKind, LoopAudioExportFormat, LoopMode, LoopState,
+    LoopWidgetAction, SelectionModifiers,
 };
 
 #[derive(Debug, Default)]
 pub struct LoopWidgetResponse {
     pub actions: Vec<LoopWidgetAction>,
     pub io_intents: Vec<AppIntent>,
+    pub(crate) hover_active: bool,
 }
 
 #[derive(Debug, Default)]
@@ -94,46 +95,6 @@ fn icon_for_state(
     }
 }
 
-fn dial_indicator(rect: egui::Rect, fraction: f32) -> [egui::Pos2; 2] {
-    let angle = -2.35 + fraction.clamp(0.0, 1.0) * 4.7;
-    let direction = egui::vec2(angle.sin(), -angle.cos());
-    [
-        rect.center() + direction * rect.width() * 0.30,
-        rect.center() + direction * rect.width() * 0.43,
-    ]
-}
-
-fn paint_dial(
-    ui: &egui::Ui,
-    response: &egui::Response,
-    rect: egui::Rect,
-    fraction: f32,
-    label: &str,
-) {
-    let visuals = ui.style().interact(response);
-    ui.painter().circle_filled(
-        rect.center(),
-        rect.width() / 2.0,
-        egui::Color32::from_rgb(34, 34, 34),
-    );
-    ui.painter().circle_stroke(
-        rect.center(),
-        rect.width() / 2.0,
-        egui::Stroke::new(1.0, visuals.fg_stroke.color),
-    );
-    ui.painter().line_segment(
-        dial_indicator(rect, fraction),
-        egui::Stroke::new(1.5, egui::Color32::WHITE),
-    );
-    ui.painter().text(
-        rect.center(),
-        egui::Align2::CENTER_CENTER,
-        label,
-        egui::FontId::proportional(7.0),
-        egui::Color32::from_gray(180),
-    );
-}
-
 fn popup_icon_button(
     ui: &mut egui::Ui,
     size: egui::Vec2,
@@ -174,6 +135,16 @@ impl LoopWidget {
         ui: &mut egui::Ui,
         state: &LoopState,
         size: egui::Vec2,
+    ) -> LoopWidgetResponse {
+        self.show_with_hover(ui, state, size, true)
+    }
+
+    pub(crate) fn show_with_hover(
+        &mut self,
+        ui: &mut egui::Ui,
+        state: &LoopState,
+        size: egui::Vec2,
+        hover_allowed: bool,
     ) -> LoopWidgetResponse {
         let mut result = LoopWidgetResponse::default();
         let (rect, response) = ui.allocate_exact_size(size, egui::Sense::click());
@@ -224,7 +195,7 @@ impl LoopWidget {
                 }
             }
         });
-        let hovered = ui.rect_contains_pointer(rect);
+        let hovered = hover_allowed && ui.rect_contains_pointer(rect);
         let rounding = egui::CornerRadius::same(2);
         let background = if state.composite_kind == CompositeKind::Regular {
             egui::Color32::from_rgb(255, 192, 203)
@@ -461,20 +432,24 @@ impl LoopWidget {
         let now = ui.input(|input| input.time);
         let pointer = ui.input(|input| input.pointer.hover_pos());
         let non_script = state.composite_kind != CompositeKind::Script;
-        let play_hovered = pointer.is_some_and(|pointer| {
-            egui::Rect::from_two_pos(play_rect.min, play_popup_rect.max).contains(pointer)
-        });
-        let record_hovered = pointer.is_some_and(|pointer| {
-            egui::Rect::from_two_pos(record_rect.min, record_popup_rect.max).contains(pointer)
-        });
+        let play_hovered = hover_allowed
+            && pointer.is_some_and(|pointer| {
+                egui::Rect::from_two_pos(play_rect.min, play_popup_rect.max).contains(pointer)
+            });
+        let record_hovered = hover_allowed
+            && pointer.is_some_and(|pointer| {
+                egui::Rect::from_two_pos(record_rect.min, record_popup_rect.max).contains(pointer)
+            });
         if non_script && play_hovered {
             self.play_popup_until = now + 0.08;
         }
         if non_script && record_hovered {
             self.record_popup_until = now + 0.08;
         }
-        let show_play_popup = non_script && (play_hovered || now < self.play_popup_until);
-        let show_record_popup = non_script && (record_hovered || now < self.record_popup_until);
+        let show_play_popup =
+            hover_allowed && non_script && (play_hovered || now < self.play_popup_until);
+        let show_record_popup =
+            hover_allowed && non_script && (record_hovered || now < self.record_popup_until);
         let controls_visible = hovered || show_play_popup || show_record_popup;
         let icon_size = button_width.min(button_height) * 0.9;
 
@@ -648,16 +623,17 @@ impl LoopWidget {
 
             if state.stereo {
                 let balance_rect = balance_rect.expect("stereo gain has a balance rectangle");
-                let balance_hovered = pointer.is_some_and(|pointer| {
-                    egui::Rect::from_two_pos(dial_rect.min, balance_rect.max).contains(pointer)
-                });
+                let balance_hovered = hover_allowed
+                    && pointer.is_some_and(|pointer| {
+                        egui::Rect::from_two_pos(dial_rect.min, balance_rect.max).contains(pointer)
+                    });
                 if balance_hovered
                     || self.gain_drag_start.is_some()
                     || self.balance_drag_start.is_some()
                 {
                     self.balance_popup_until = now + 0.08;
                 }
-                if balance_hovered || now < self.balance_popup_until {
+                if hover_allowed && (balance_hovered || now < self.balance_popup_until) {
                     egui::Area::new(ui.id().with("loop_balance_popup"))
                         .order(egui::Order::Foreground)
                         .fixed_pos(balance_rect.min)
@@ -692,12 +668,27 @@ impl LoopWidget {
                 }
             }
         }
-        if show_play_popup || show_record_popup || now < self.balance_popup_until {
+        result.hover_active = hover_allowed
+            && (controls_visible
+                || now < self.balance_popup_until
+                || self.gain_drag_start.is_some()
+                || self.balance_drag_start.is_some());
+        if result.hover_active {
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(50));
         }
 
         result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_record_rect(&self) -> Option<egui::Rect> {
+        self.test_record_rect
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_record_popup_rect(&self) -> Option<egui::Rect> {
+        self.test_record_popup_rect
     }
 }
 
@@ -779,16 +770,6 @@ mod tests {
             stereo: true,
             balance: 0.5,
             ..Default::default()
-        }
-    }
-
-    #[test]
-    fn dial_indicator_stays_outside_the_label_area() {
-        let rect = egui::Rect::from_center_size(egui::pos2(20.0, 20.0), egui::vec2(18.0, 18.0));
-        for fraction in [0.0, 0.25, 0.5, 0.75, 1.0] {
-            let segment = dial_indicator(rect, fraction);
-            assert!(segment[0].distance(rect.center()) >= rect.width() * 0.29);
-            assert!(segment[1].distance(rect.center()) > segment[0].distance(rect.center()));
         }
     }
 

--- a/src/rust/shoop_egui/src/track_controls.rs
+++ b/src/rust/shoop_egui/src/track_controls.rs
@@ -1,10 +1,14 @@
-use crate::{TrackControlState, TrackWidgetAction, MAX_TRACK_GAIN_DB, MIN_TRACK_GAIN_DB};
+use crate::{
+    dial::paint_dial, TrackControlState, TrackWidgetAction, MAX_TRACK_GAIN_DB, MIN_TRACK_GAIN_DB,
+};
 use egui_material_icons::icons::{ICON_HEARING, ICON_VOLUME_MUTE, ICON_VOLUME_UP};
 
 const METER_MIN_DB: f32 = -50.0;
 
 #[derive(Debug, Default)]
 pub struct TrackControls {
+    output_balance_drag_start: Option<f32>,
+    input_balance_drag_start: Option<f32>,
     #[cfg(test)]
     test_rects: TestTrackControlRects,
 }
@@ -74,6 +78,7 @@ impl TrackControls {
                     let response = balance_control(
                         ui,
                         state.output_balance,
+                        &mut self.output_balance_drag_start,
                         TrackWidgetAction::OutputBalanceChanged,
                         &mut actions,
                     );
@@ -127,6 +132,7 @@ impl TrackControls {
                     let response = balance_control(
                         ui,
                         state.input_balance,
+                        &mut self.input_balance_drag_start,
                         TrackWidgetAction::InputBalanceChanged,
                         &mut actions,
                     );
@@ -170,23 +176,30 @@ impl TrackControls {
 fn balance_control(
     ui: &mut egui::Ui,
     value: f32,
+    drag_start: &mut Option<f32>,
     action: impl FnOnce(f32) -> TrackWidgetAction,
     actions: &mut Vec<TrackWidgetAction>,
 ) -> egui::Response {
+    let (rect, response) =
+        ui.allocate_exact_size(egui::vec2(20.0, 20.0), egui::Sense::click_and_drag());
+    if response.drag_started() {
+        *drag_start = Some(value);
+    }
     let mut balance = value;
-    let response = ui
-        .add(
-            egui::DragValue::new(&mut balance)
-                .range(-1.0..=1.0)
-                .speed(0.01)
-                .prefix("B ")
-                .max_decimals(2),
-        )
-        .on_hover_text(format!("Stereo balance: {balance:.2}"));
-    if response.changed() {
+    if response.dragged() {
+        balance = (drag_start.unwrap_or(value) - response.drag_delta().y / 50.0).clamp(-1.0, 1.0);
+    }
+    if response.double_clicked() {
+        balance = 0.0;
+    }
+    if (balance - value).abs() > f32::EPSILON {
         actions.push(action(balance));
     }
-    response
+    if response.drag_stopped() {
+        *drag_start = None;
+    }
+    paint_dial(ui, &response, rect, (balance + 1.0) / 2.0, "B");
+    response.on_hover_text(format!("Stereo balance: {balance:.2}"))
 }
 
 fn meter(ui: &mut egui::Ui, stereo: bool, left_db: f32, right_db: f32, midi_activity: bool) {
@@ -342,9 +355,8 @@ mod tests {
         frame(&context, &mut controls, &state, Vec::new());
 
         assert!(controls.test_rect(TestTrackControl::OutputGain).is_some());
-        assert!(controls
-            .test_rect(TestTrackControl::OutputBalance)
-            .is_some());
+        let output_balance = controls.test_rect(TestTrackControl::OutputBalance).unwrap();
+        assert!((output_balance.width() - output_balance.height()).abs() < f32::EPSILON);
         assert!(controls.test_rect(TestTrackControl::InputGain).is_some());
         assert!(controls.test_rect(TestTrackControl::InputBalance).is_some());
         assert_eq!(
@@ -364,6 +376,35 @@ mod tests {
                 TestTrackControl::InputMonitoring
             ),
             vec![TrackWidgetAction::InputMonitoringChanged(true)]
+        );
+    }
+
+    #[test]
+    fn balance_dial_double_click_resets_to_center() {
+        let context = egui::Context::default();
+        crate::initialize(&context);
+        let state = TrackControlState {
+            has_output: true,
+            has_output_audio: true,
+            output_stereo: true,
+            output_balance: 0.5,
+            ..Default::default()
+        };
+        let mut controls = TrackControls::default();
+        let _ = click(
+            &context,
+            &mut controls,
+            &state,
+            TestTrackControl::OutputBalance,
+        );
+        assert_eq!(
+            click(
+                &context,
+                &mut controls,
+                &state,
+                TestTrackControl::OutputBalance,
+            ),
+            vec![TrackWidgetAction::OutputBalanceChanged(0.0)]
         );
     }
 }

--- a/src/rust/shoop_egui/src/track_widget.rs
+++ b/src/rust/shoop_egui/src/track_widget.rs
@@ -19,6 +19,7 @@ pub struct TrackWidget {
     name_edit: String,
     source_name: String,
     loop_widgets: BTreeMap<LoopId, LoopWidget>,
+    hovered_loop: Option<LoopId>,
     controls: TrackControls,
     #[cfg(test)]
     test_loop_rects: Vec<egui::Rect>,
@@ -45,6 +46,12 @@ impl TrackWidget {
     ) -> TrackWidgetResponse {
         self.loop_widgets
             .retain(|id, _| state.loops.iter().any(|loop_state| loop_state.id == *id));
+        if self
+            .hovered_loop
+            .is_some_and(|id| !self.loop_widgets.contains_key(&id))
+        {
+            self.hovered_loop = None;
+        }
         let mut result = TrackWidgetResponse::default();
         #[cfg(test)]
         self.test_loop_rects.clear();
@@ -57,20 +64,29 @@ impl TrackWidget {
                     self.show_header(ui, state, &mut result);
                     ui.add_space(2.0);
                     for loop_state in &state.loops {
+                        let hover_allowed = self
+                            .hovered_loop
+                            .is_none_or(|hovered| hovered == loop_state.id);
                         let widget = self.loop_widgets.entry(loop_state.id).or_default();
-                        let _loop_response = ui.push_id(loop_state.id, |ui| {
+                        let loop_response = ui.push_id(loop_state.id, |ui| {
                             let size = egui::vec2(ui.available_width(), 26.0);
-                            let response = widget.show(ui, loop_state, size);
-                            result.loop_actions.extend(
-                                response
-                                    .actions
-                                    .into_iter()
-                                    .map(|action| (loop_state.id, action)),
-                            );
-                            result.io_intents.extend(response.io_intents);
+                            widget.show_with_hover(ui, loop_state, size, hover_allowed)
                         });
+                        if loop_response.inner.hover_active {
+                            self.hovered_loop = Some(loop_state.id);
+                        } else if self.hovered_loop == Some(loop_state.id) {
+                            self.hovered_loop = None;
+                        }
+                        result.loop_actions.extend(
+                            loop_response
+                                .inner
+                                .actions
+                                .into_iter()
+                                .map(|action| (loop_state.id, action)),
+                        );
+                        result.io_intents.extend(loop_response.inner.io_intents);
                         #[cfg(test)]
-                        self.test_loop_rects.push(_loop_response.response.rect);
+                        self.test_loop_rects.push(loop_response.response.rect);
                         ui.add_space(2.0);
                     }
                     if show_add_loop {
@@ -274,6 +290,54 @@ mod tests {
             first_widget,
             &widget.loop_widgets[&first] as *const LoopWidget
         );
+    }
+
+    #[test]
+    fn popup_hover_keeps_the_source_loop_as_the_only_hover_owner() {
+        let context = egui::Context::default();
+        crate::initialize(&context);
+        let first = LoopId::from_raw(1);
+        let state = TrackState {
+            id: TrackId::from_raw(1),
+            loops: vec![
+                LoopState {
+                    id: first,
+                    ..Default::default()
+                },
+                LoopState {
+                    id: LoopId::from_raw(2),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let mut widget = TrackWidget::default();
+        let _ = frame(&context, &mut widget, &state, Vec::new());
+        let second_rect = widget.test_loop_rects[1];
+        let record = widget.loop_widgets[&first]
+            .test_record_rect()
+            .unwrap()
+            .center();
+        let _ = frame(
+            &context,
+            &mut widget,
+            &state,
+            vec![egui::Event::PointerMoved(record)],
+        );
+        assert_eq!(widget.hovered_loop, Some(first));
+
+        let popup_over_second = widget.loop_widgets[&first]
+            .test_record_popup_rect()
+            .unwrap()
+            .center();
+        assert!(second_rect.contains(popup_over_second));
+        let _ = frame(
+            &context,
+            &mut widget,
+            &state,
+            vec![egui::Event::PointerMoved(popup_over_second)],
+        );
+        assert_eq!(widget.hovered_loop, Some(first));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep hover ownership scoped to one loop so dropdown controls do not activate loops underneath them
- render track stereo balance controls as dials matching loop balance controls
- share dial painting behavior and retain drag plus double-click-to-center interactions

## Tests
- `RUSTFLAGS="-D warnings" cargo test -p shoop_egui`
- `RUSTFLAGS="-D warnings" cargo build -p shoopdaloop_egui`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend`

The QML self-test runner was also attempted offscreen, but did not complete after `tst_CompositeLoop_running.qml` reported `Created invalid object`; these changes only affect the egui implementation.
