### PR TITLE
Offload egui waveform preprocessing

### DIFF
--- a/src/rust/shoop_egui/src/details_pane.rs
+++ b/src/rust/shoop_egui/src/details_pane.rs
@@ -1,8 +1,8 @@
-use crate::{LoopDetailsState, WaveformWidget};
+use crate::{LoopDetailsState, LoopId, WaveformWidget};
 
 #[derive(Debug, Default)]
 pub struct DetailsPane {
-    generation: u64,
+    loop_id: LoopId,
     waveforms: Vec<WaveformWidget>,
 }
 
@@ -13,8 +13,8 @@ impl DetailsPane {
             return;
         };
 
-        if self.generation != details.generation {
-            self.generation = details.generation;
+        if self.loop_id != details.loop_id {
+            self.loop_id = details.loop_id;
             self.waveforms.clear();
         }
 

--- a/src/rust/shoop_egui/src/waveform.rs
+++ b/src/rust/shoop_egui/src/waveform.rs
@@ -1,7 +1,25 @@
+use std::sync::Arc;
+
+const PYRAMID_BASE_BLOCK_SIZE: usize = 64;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct WaveformBin {
     pub min: f32,
     pub max: f32,
+}
+
+impl WaveformBin {
+    fn include_sample(&mut self, sample: f32) {
+        if sample.is_finite() {
+            self.min = self.min.min(sample);
+            self.max = self.max.max(sample);
+        }
+    }
+
+    fn include_bin(&mut self, other: Self) {
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
+    }
 }
 
 pub fn waveform_bins(samples: &[f32], requested_bins: usize) -> Vec<WaveformBin> {
@@ -14,17 +32,117 @@ pub fn waveform_bins(samples: &[f32], requested_bins: usize) -> Vec<WaveformBin>
         .map(|bin| {
             let start = bin * samples.len() / n_bins;
             let end = ((bin + 1) * samples.len() / n_bins).max(start + 1);
-            samples[start..end]
-                .iter()
-                .copied()
-                .filter(|sample| sample.is_finite())
-                .fold(WaveformBin::default(), |mut result, sample| {
-                    result.min = result.min.min(sample);
-                    result.max = result.max.max(sample);
-                    result
-                })
+            summarize_samples(&samples[start..end])
         })
         .collect()
+}
+
+fn summarize_samples(samples: &[f32]) -> WaveformBin {
+    samples
+        .iter()
+        .copied()
+        .fold(WaveformBin::default(), |mut result, sample| {
+            result.include_sample(sample);
+            result
+        })
+}
+
+#[derive(Debug)]
+pub(crate) struct WaveformPyramid {
+    samples: Arc<[f32]>,
+    levels: Vec<Vec<WaveformBin>>,
+}
+
+impl WaveformPyramid {
+    pub(crate) fn new(samples: Arc<[f32]>) -> Self {
+        let mut levels = Vec::new();
+        let mut level: Vec<_> = samples
+            .chunks(PYRAMID_BASE_BLOCK_SIZE)
+            .map(summarize_samples)
+            .collect();
+        if !level.is_empty() {
+            levels.push(level.clone());
+        }
+        while level.len() > 1 {
+            level = level
+                .chunks(2)
+                .map(|children| {
+                    children
+                        .iter()
+                        .copied()
+                        .fold(WaveformBin::default(), |mut result, child| {
+                            result.include_bin(child);
+                            result
+                        })
+                })
+                .collect();
+            levels.push(level.clone());
+        }
+        Self { samples, levels }
+    }
+
+    pub(crate) fn matches(&self, samples: &Arc<[f32]>) -> bool {
+        Arc::ptr_eq(&self.samples, samples)
+    }
+
+    pub(crate) fn bins(
+        &self,
+        offset: usize,
+        sample_count: usize,
+        requested_bins: usize,
+    ) -> Vec<WaveformBin> {
+        let end = offset.saturating_add(sample_count).min(self.samples.len());
+        if offset >= end || requested_bins == 0 {
+            return Vec::new();
+        }
+        let sample_count = end - offset;
+        let n_bins = requested_bins.min(sample_count);
+        (0..n_bins)
+            .map(|bin| {
+                let start = offset + bin * sample_count / n_bins;
+                let end = offset + ((bin + 1) * sample_count / n_bins).max(bin + 1);
+                self.summarize_range(start, end)
+            })
+            .collect()
+    }
+
+    fn summarize_range(&self, start: usize, end: usize) -> WaveformBin {
+        let first_block = start.div_ceil(PYRAMID_BASE_BLOCK_SIZE);
+        let last_block = end / PYRAMID_BASE_BLOCK_SIZE;
+        if first_block >= last_block || self.levels.is_empty() {
+            return summarize_samples(&self.samples[start..end]);
+        }
+
+        let mut result =
+            summarize_samples(&self.samples[start..first_block * PYRAMID_BASE_BLOCK_SIZE]);
+        self.include_block_range(&mut result, first_block, last_block);
+        let suffix_start = last_block * PYRAMID_BASE_BLOCK_SIZE;
+        for sample in self.samples[suffix_start..end].iter().copied() {
+            result.include_sample(sample);
+        }
+        result
+    }
+
+    fn include_block_range(
+        &self,
+        result: &mut WaveformBin,
+        mut first_block: usize,
+        last_block: usize,
+    ) {
+        while first_block < last_block {
+            let remaining_level = usize::BITS - 1 - (last_block - first_block).leading_zeros();
+            let alignment_level = if first_block == 0 {
+                remaining_level
+            } else {
+                first_block.trailing_zeros()
+            };
+            let level = remaining_level
+                .min(alignment_level)
+                .min((self.levels.len() - 1) as u32) as usize;
+            result.include_bin(self.levels[level][first_block >> level]);
+            first_block += 1 << level;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -91,5 +209,36 @@ mod tests {
                 max: 0.0,
             }]
         );
+    }
+
+    #[test]
+    fn pyramid_queries_match_direct_binning() {
+        let mut samples: Vec<_> = (0..1_037)
+            .map(|index| ((index as f32 * 0.17).sin() * 1.2).clamp(-1.0, 1.0))
+            .collect();
+        samples[70] = f32::NAN;
+        samples[511] = f32::INFINITY;
+        let samples: Arc<[f32]> = Arc::from(samples);
+        let pyramid = WaveformPyramid::new(Arc::clone(&samples));
+
+        for (offset, sample_count) in [(0, 1_037), (1, 1_000), (63, 701), (64, 512), (129, 73)] {
+            for requested_bins in [1, 7, 64, 200, 2_000] {
+                assert_eq!(
+                    pyramid.bins(offset, sample_count, requested_bins),
+                    waveform_bins(&samples[offset..offset + sample_count], requested_bins),
+                    "offset {offset}, count {sample_count}, bins {requested_bins}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pyramid_matches_only_the_source_allocation() {
+        let samples: Arc<[f32]> = Arc::from([0.1, -0.2, 0.3]);
+        let same_values: Arc<[f32]> = Arc::from([0.1, -0.2, 0.3]);
+        let pyramid = WaveformPyramid::new(Arc::clone(&samples));
+
+        assert!(pyramid.matches(&samples));
+        assert!(!pyramid.matches(&same_values));
     }
 }

--- a/src/rust/shoop_egui/src/waveform_widget.rs
+++ b/src/rust/shoop_egui/src/waveform_widget.rs
@@ -1,9 +1,93 @@
-use crate::{colors, waveform_bins, WaveformChannelState};
+use crate::{colors, waveform::WaveformPyramid, WaveformChannelState};
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
+
+#[cfg(not(target_arch = "wasm32"))]
+struct WaveformPreparationRequest {
+    samples: Arc<[f32]>,
+    context: egui::Context,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Default)]
+struct WaveformPreprocessor {
+    request_sender: Option<SyncSender<WaveformPreparationRequest>>,
+    result_receiver: Option<Receiver<WaveformPyramid>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl std::fmt::Debug for WaveformPreprocessor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WaveformPreprocessor")
+            .field("started", &self.request_sender.is_some())
+            .finish()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl WaveformPreprocessor {
+    fn request(&mut self, samples: Arc<[f32]>, context: egui::Context) -> bool {
+        self.ensure_started();
+        let request = WaveformPreparationRequest { samples, context };
+        match self
+            .request_sender
+            .as_ref()
+            .expect("waveform preprocessor was started")
+            .try_send(request)
+        {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => false,
+            Err(TrySendError::Disconnected(_)) => {
+                self.request_sender = None;
+                self.result_receiver = None;
+                false
+            }
+        }
+    }
+
+    fn try_receive(&self) -> Option<WaveformPyramid> {
+        match self.result_receiver.as_ref()?.try_recv() {
+            Ok(pyramid) => Some(pyramid),
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => None,
+        }
+    }
+
+    fn ensure_started(&mut self) {
+        if self.request_sender.is_some() {
+            return;
+        }
+        let (request_sender, request_receiver) =
+            mpsc::sync_channel::<WaveformPreparationRequest>(1);
+        let (result_sender, result_receiver) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("egui-waveform".to_owned())
+            .spawn(move || {
+                while let Ok(request) = request_receiver.recv() {
+                    let pyramid = WaveformPyramid::new(request.samples);
+                    if result_sender.send(pyramid).is_err() {
+                        break;
+                    }
+                    request.context.request_repaint();
+                }
+            })
+            .expect("spawn egui waveform preprocessor");
+        self.request_sender = Some(request_sender);
+        self.result_receiver = Some(result_receiver);
+    }
+}
 
 #[derive(Debug)]
 pub struct WaveformWidget {
     zoom: f32,
     offset: usize,
+    pyramid: Option<WaveformPyramid>,
+    #[cfg(not(target_arch = "wasm32"))]
+    requested_samples: Option<Arc<[f32]>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    preprocessor: WaveformPreprocessor,
 }
 
 impl Default for WaveformWidget {
@@ -11,6 +95,11 @@ impl Default for WaveformWidget {
         Self {
             zoom: 1.0,
             offset: 0,
+            pyramid: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            requested_samples: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            preprocessor: WaveformPreprocessor::default(),
         }
     }
 }
@@ -65,13 +154,10 @@ impl WaveformWidget {
         } else {
             self.offset = self.offset.min(max_offset);
         }
-        let end = self.offset + visible_samples;
-        let samples = &channel.samples[self.offset..end];
-        let bins = waveform_bins(samples, rect.width().round().max(1.0) as usize);
 
+        let offset = self.offset;
         let sample_to_x = |sample: i64| {
-            rect.left()
-                + (sample as f32 - self.offset as f32) / visible_samples as f32 * rect.width()
+            rect.left() + (sample as f32 - offset as f32) / visible_samples as f32 * rect.width()
         };
         let loop_start = channel.start_offset;
         let loop_end = loop_start.saturating_add_unsigned(channel.loop_length);
@@ -87,6 +173,27 @@ impl WaveformWidget {
                 colors::WAVEFORM_LOOP_REGION,
             );
         }
+
+        self.update_pyramid(ui.ctx(), &channel.samples);
+        let Some(pyramid) = self
+            .pyramid
+            .as_ref()
+            .filter(|pyramid| pyramid.matches(&channel.samples))
+        else {
+            painter.text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                "Preparing waveform…",
+                egui::FontId::proportional(12.0),
+                colors::MUTED_FOREGROUND,
+            );
+            return;
+        };
+        let bins = pyramid.bins(
+            self.offset,
+            visible_samples,
+            rect.width().round().max(1.0) as usize,
+        );
 
         let center = rect.center().y;
         let half_height = rect.height() * 0.5 - 2.0;
@@ -112,5 +219,88 @@ impl WaveformWidget {
                 );
             }
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn update_pyramid(&mut self, context: &egui::Context, samples: &Arc<[f32]>) {
+        while let Some(pyramid) = self.preprocessor.try_receive() {
+            if self
+                .requested_samples
+                .as_ref()
+                .is_some_and(|requested| pyramid.matches(requested))
+            {
+                self.requested_samples = None;
+            }
+            if pyramid.matches(samples) {
+                self.pyramid = Some(pyramid);
+            }
+        }
+        if self
+            .pyramid
+            .as_ref()
+            .is_some_and(|pyramid| pyramid.matches(samples))
+            || self
+                .requested_samples
+                .as_ref()
+                .is_some_and(|requested| Arc::ptr_eq(requested, samples))
+        {
+            return;
+        }
+        if self
+            .preprocessor
+            .request(Arc::clone(samples), context.clone())
+        {
+            self.requested_samples = Some(Arc::clone(samples));
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn update_pyramid(&mut self, _context: &egui::Context, samples: &Arc<[f32]>) {
+        if !self
+            .pyramid
+            .as_ref()
+            .is_some_and(|pyramid| pyramid.matches(samples))
+        {
+            self.pyramid = Some(WaveformPyramid::new(Arc::clone(samples)));
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn asynchronously_prepares_and_caches_samples() {
+        let context = egui::Context::default();
+        let samples: Arc<[f32]> = Arc::from(
+            (0..100_000)
+                .map(|index| (index as f32 / 100.0).sin())
+                .collect::<Vec<_>>(),
+        );
+        let mut widget = WaveformWidget::default();
+
+        widget.update_pyramid(&context, &samples);
+        assert!(widget.pyramid.is_none());
+        assert!(widget
+            .requested_samples
+            .as_ref()
+            .is_some_and(|requested| Arc::ptr_eq(requested, &samples)));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while widget.pyramid.is_none() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+            widget.update_pyramid(&context, &samples);
+        }
+
+        assert!(widget
+            .pyramid
+            .as_ref()
+            .is_some_and(|pyramid| pyramid.matches(&samples)));
+        assert!(widget.requested_samples.is_none());
+
+        widget.update_pyramid(&context, &samples);
+        assert!(widget.requested_samples.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- build and cache signed min/max waveform pyramids outside the egui render path
- query cached extrema with bounded per-pixel work during rendering
- preserve waveform widget caches across ordinary application revisions

## Tests
- `cargo test -p shoop_egui`
- `RUSTFLAGS="-D warnings" cargo build -p shoop_egui`

The full local workspace build could not run because this environment does not have Qt, pkg-config, or Lilv installed.
