### PR TITLE
Upgrade TinyViolin to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5450,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "tinyviolin"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342a93e896646151693c80052cf7a02070f9770c98b202d6b837636a29e385e2"
+checksum = "e69cf6c01e440dc464f648f0a5cb20ac525d32e854f628456083d2ffbc875dbb"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "0.11", features = ["ondemand"] }
 tracy-client = { version = "0.18.4", features = ["ondemand", "delayed-init", "timer-fallback"] }
 shoop_tracing = { path = "src/rust/shoop_tracing", default-features = false }
-tinyviolin = "=0.2.0"
+tinyviolin = "=0.3.0"
 
 # cxx-qt =  { path = "C:/sdev/cxx-qt/crates/cxx-qt" }
 # qt-build-utils = { path = "C:/sdev/cxx-qt/crates/qt-build-utils" }


### PR DESCRIPTION
## Summary

- pin TinyViolin 0.3.0 in the workspace dependency list
- refresh the lockfile for the new release

## Testing

- `cargo fmt --all`
- `RUSTFLAGS="-D warnings" cargo build`
- `cargo test -p shoop_engine tiny_synth_fx` (10 focused unit tests and the realtime no-allocation test passed)