### PR TITLE
Stop only recorded MIDI notes at loop boundaries

### DIFF
--- a/src/qml/test/tst_Midi.qml
+++ b/src/qml/test/tst_Midi.qml
@@ -269,7 +269,6 @@ ShoopTestFile {
                         { 'time': 6, 'data':  input[1]['data']  },
                         { 'time': 8, 'data':  input[2]['data']  },
                         { 'time': 12, 'data': input[3]['data']  },
-                        { 'time': 20, 'data':  Midi.create_all_sound_off(0) }, // end-of-loop
                         { 'time': 20, 'data':  input[0]['data']  }, // from state (no pre-play was done)
                         { 'time': 26, 'data':  input[1]['data']  },
                         { 'time': 28, 'data':  input[2]['data']  },

--- a/src/rust/shoop_engine/src/dummy_midi_port.rs
+++ b/src/rust/shoop_engine/src/dummy_midi_port.rs
@@ -20,8 +20,7 @@ use thiserror::Error;
 pub struct RequestPending;
 
 /// Messages reserved for each of the port's buffers, so a cycle that emits
-/// messages does not allocate. A loop wrap alone emits All Sound Off, so even an
-/// idle output port needs room.
+/// messages does not allocate. Playback interruption may emit targeted note-offs.
 const RESERVE: usize = 256;
 
 /// Output-side reserve: a playback state restore arrives as one burst, and this

--- a/src/rust/shoop_engine/src/midi_channel.rs
+++ b/src/rust/shoop_engine/src/midi_channel.rs
@@ -18,7 +18,6 @@
 use crate::channel_mode::{channel_process_params, ChannelMode, ProcessFlags};
 use crate::content_snapshot::MidiProcessSnapshotWriter;
 use crate::loop_mode::LoopMode;
-use crate::midi;
 use crate::midi_state::{MidiStateTracker, TrackWhat, MAX_DIFF_MESSAGES};
 use crate::midi_storage::{Cursor, MidiStorage, MidiStorageElem, TruncateSide};
 use crate::state_mirror::MidiChannelStateMirror;
@@ -564,13 +563,13 @@ impl MidiChannel {
             }
         }
 
-        // Anything other than plain forward playback leaves notes hanging.
+        // Anything other than plain forward playback can leave played notes hanging.
         let interrupted = self.prev_process_flags.contains(ProcessFlags::PLAYBACK)
             && (!flags.contains(ProcessFlags::PLAYBACK)
                 || pos_before != self.prev_pos_after as i32);
         if interrupted && n_samples > 0 {
             let time = self.play.map(|p| p.n_frames_processed).unwrap_or(0);
-            self.send_all_sound_off(out, time);
+            self.stop_active_playback_notes(out, time);
         }
 
         let mut adopted_prerecording = false;
@@ -1000,16 +999,20 @@ impl MidiChannel {
         }
     }
 
-    /// arguably it should cover all 16.
-    fn send_all_sound_off(&mut self, out: &mut Vec<MidiStorageElem>, time: u32) {
-        let msg = midi::all_sound_off(0);
-        self.send(out, time, &msg);
+    fn stop_active_playback_notes(&mut self, out: &mut Vec<MidiStorageElem>, time: u32) {
+        let mut cleanup = std::mem::take(&mut self.restore_scratch);
+        self.output_state.all_notes_off_into(&mut cleanup);
+        for message in &cleanup {
+            self.send(out, time, message.data());
+        }
+        self.restore_scratch = cleanup;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::midi;
     use assert2::{check, let_assert};
 
     use ChannelMode as C;
@@ -1463,7 +1466,31 @@ mod tests {
     }
 
     #[test]
-    fn interrupting_playback_sends_all_sound_off() {
+    fn loop_wrap_stops_only_notes_owned_by_playback() {
+        let mut ch = channel();
+        ch.set_contents(&[ev(0, &midi::note_on(0, 60, 100))], 4, None);
+        let mut mixed_state = MidiStateTracker::new(TrackWhat::ALL);
+        mixed_state.process(&midi::note_on(0, 64, 100));
+        for message in cycle(&mut ch, L::Playing, 4, 0, 4, &[]) {
+            mixed_state.process(message.data());
+        }
+
+        let out = cycle(&mut ch, L::Playing, 4, 0, 4, &[]);
+        for message in &out {
+            mixed_state.process(message.data());
+        }
+        check!(out.len() == 2);
+        check!(out[0].data() == midi::note_off(0, 60, 0).as_slice());
+        check!(out[1].data() == midi::note_on(0, 60, 100).as_slice());
+        check!(!out
+            .iter()
+            .any(|message| midi::all_sound_off_channel(message.data()).is_some()));
+        check!(mixed_state.note_velocity(0, 60) == Some(100));
+        check!(mixed_state.note_velocity(0, 64) == Some(100));
+    }
+
+    #[test]
+    fn interrupting_playback_stops_its_active_notes() {
         let mut ch = channel();
         cycle(
             &mut ch,
@@ -1477,7 +1504,7 @@ mod tests {
         // Stopping mid-playback must silence anything left sounding.
         let out = cycle(&mut ch, L::Stopped, 4, 0, 4, &[]);
         check!(out.len() == 1);
-        check!(midi::all_sound_off_channel(out[0].data()) == Some(0));
+        check!(out[0].data() == midi::note_off(0, 60, 0).as_slice());
     }
 
     #[test]
@@ -1496,11 +1523,11 @@ mod tests {
         let out = cycle(&mut ch, L::Playing, 4, 6, 8, &[]);
         check!(out
             .iter()
-            .any(|m| midi::all_sound_off_channel(m.data()) == Some(0)));
+            .any(|message| message.data() == midi::note_off(0, 60, 0).as_slice()));
     }
 
     #[test]
-    fn uninterrupted_forward_playback_sends_no_all_sound_off() {
+    fn uninterrupted_forward_playback_sends_no_cleanup() {
         let mut ch = channel();
         cycle(
             &mut ch,
@@ -1515,9 +1542,6 @@ mod tests {
         );
         cycle(&mut ch, L::Playing, 4, 0, 8, &[]);
         let out = cycle(&mut ch, L::Playing, 4, 4, 8, &[]);
-        check!(!out
-            .iter()
-            .any(|m| midi::all_sound_off_channel(m.data()) == Some(0)));
         check!(times(&out) == vec![1]); // frame 5 is buffer-relative frame 1
     }
 

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -500,7 +500,7 @@ pub fn build_schedule(topology: Topology) -> Result<PreparedSchedule, SessionErr
     // Scratch sized for the widest loop, so a cycle neither searches nor grows a buffer.
     // Room inside each buffer as well as for the buffers themselves: a cycle pushing its
     // first message into a zero-capacity vector would allocate on the audio thread, and a
-    // loop wrap alone emits All Sound Off, so even an idle playing loop needs room.
+    // playback interruption may emit targeted note-offs.
     let widest = midi_by_loop.iter().map(|v| v.len()).max().unwrap_or(0);
     let mut midi_in_scratch: Vec<Vec<MidiStorageElem>> = Vec::with_capacity(widest);
     let mut midi_out_scratch: Vec<Vec<MidiStorageElem>> = Vec::with_capacity(widest);

--- a/src/rust/shoop_engine/tests/audio_midi_loop_midi.rs
+++ b/src/rust/shoop_engine/tests/audio_midi_loop_midi.rs
@@ -625,13 +625,11 @@ fn midi_corner_case_note_started_before_loop_boundary() {
     // not reassigned, so times continue from 30.
     let out = process(&mut l, 30, &source);
     let played: Vec<(u32, Vec<u8>)> = out.iter().map(as_pair).collect();
-    check!(played.len() == 5);
-    // A loop wrap counts as a playback interruption, so All Sound Off leads.
-    check!(midi::is_cc(&played[0].1));
-    check!(played[1] == (30, midi::note_on(0, 100, 90).to_vec()));
-    check!(played[2] == (38, midi::note_off(0, 100, 80).to_vec()));
-    check!(played[3] == (48, midi::note_on(0, 100, 70).to_vec()));
-    check!(played[4] == (58, midi::note_off(0, 100, 60).to_vec()));
+    check!(played.len() == 4);
+    check!(played[0] == (30, midi::note_on(0, 100, 90).to_vec()));
+    check!(played[1] == (38, midi::note_off(0, 100, 80).to_vec()));
+    check!(played[2] == (48, midi::note_on(0, 100, 70).to_vec()));
+    check!(played[3] == (58, midi::note_off(0, 100, 60).to_vec()));
 }
 
 ///
@@ -769,16 +767,14 @@ fn midi_corner_case_note_started_during_pre_play() {
     check!(played[1] == (17, midi::note_on(0, 100, 70).to_vec()));
     check!(played[2] == (19, midi::note_off(0, 100, 60).to_vec()));
 
-    // Another cycle. There is no pre-play left, so the wrap emits All Sound Off and
-    // the note-on has to be inserted.
+    // Another cycle. There is no pre-play left, so the note-on is inserted.
     let out = process_synced(&mut l, &mut sync_source, 10, &source);
     let played: Vec<(u32, Vec<u8>)> = out.iter().map(as_pair).collect();
-    check!(played.len() == 5);
-    check!(midi::is_cc(&played[0].1));
-    check!(played[1] == (20, midi::note_on(0, 100, 90).to_vec()));
-    check!(played[2] == (25, midi::note_off(0, 100, 80).to_vec()));
-    check!(played[3] == (27, midi::note_on(0, 100, 70).to_vec()));
-    check!(played[4] == (29, midi::note_off(0, 100, 60).to_vec()));
+    check!(played.len() == 4);
+    check!(played[0] == (20, midi::note_on(0, 100, 90).to_vec()));
+    check!(played[1] == (25, midi::note_off(0, 100, 80).to_vec()));
+    check!(played[2] == (27, midi::note_on(0, 100, 70).to_vec()));
+    check!(played[3] == (29, midi::note_off(0, 100, 60).to_vec()));
 }
 
 #[test]
@@ -858,12 +854,11 @@ fn midi_corner_case_note_pre_recorded_but_no_preplay() {
 
     let out = process_synced(&mut l, &mut sync_source, 10, &source);
     let played: Vec<(u32, Vec<u8>)> = out.iter().map(as_pair).collect();
-    check!(played.len() == 5);
-    check!(midi::is_cc(&played[0].1));
-    check!(played[1] == (20, midi::note_on(0, 100, 90).to_vec()));
-    check!(played[2] == (25, midi::note_off(0, 100, 80).to_vec()));
-    check!(played[3] == (27, midi::note_on(0, 100, 70).to_vec()));
-    check!(played[4] == (29, midi::note_off(0, 100, 60).to_vec()));
+    check!(played.len() == 4);
+    check!(played[0] == (20, midi::note_on(0, 100, 90).to_vec()));
+    check!(played[1] == (25, midi::note_off(0, 100, 80).to_vec()));
+    check!(played[2] == (27, midi::note_on(0, 100, 70).to_vec()));
+    check!(played[3] == (29, midi::note_off(0, 100, 60).to_vec()));
 }
 
 #[test]

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -140,6 +140,52 @@ fn midi_replacement_is_allocation_free() {
 }
 
 #[test]
+fn interrupting_midi_playback_is_allocation_free() {
+    let mut channel =
+        shoop_engine::midi_channel::MidiChannel::with_capacity_elems(1, ChannelMode::Direct);
+    channel.set_contents(
+        &[MidiStorageElem::new(0, &midi::note_on(0, 60, 100)).unwrap()],
+        4,
+        None,
+    );
+    let mut output = Vec::with_capacity(2);
+    channel.set_playback_buffer(4);
+    channel
+        .process(
+            LoopMode::Playing,
+            LoopMode::Unknown,
+            None,
+            None,
+            4,
+            0,
+            4,
+            4,
+            &[],
+            &mut output,
+        )
+        .unwrap();
+    output.clear();
+    channel.set_playback_buffer(4);
+
+    assert_no_alloc(|| {
+        channel
+            .process(
+                LoopMode::Playing,
+                LoopMode::Unknown,
+                None,
+                None,
+                4,
+                0,
+                4,
+                4,
+                &[],
+                &mut output,
+            )
+            .unwrap();
+    });
+}
+
+#[test]
 fn midi_passthrough_cleanup_is_allocation_free() {
     let mut session = Session::default();
     let source = session.add_port(midi_port(1, "source", PortDirection::Input));


### PR DESCRIPTION
## Summary

- replace the channel-wide All Sound Off emitted on MIDI playback interruption with targeted Note Off messages for notes currently owned by that loop channel
- preserve unrelated live MIDI notes mixed into the same Tiny Synth/FX input across synchronized loop wraps
- update MIDI wrap/stateful playback expectations and add realtime no-allocation coverage

## Root cause

Analysis of `traces/0002-application.tracy` confirmed the reported click-track, recording, `loop.play_dry`, MIDI playback, and Tiny Synth/FX path. MIDI payloads are intentionally not captured, so a focused engine regression test completed the diagnosis: a loop position wrap was classified as playback interruption and emitted `B0 78 00` (All Sound Off). Since live and recorded MIDI share the destination channel, that message also stopped unrelated live notes.

The new regression mixes recorded note 60 with held live note 64. At the loop boundary, only note 60 receives targeted cleanup before retriggering; note 64 remains active.

## Tests

- `SHOOP_ALLOW_MISSING_BACKENDS=1 RUSTFLAGS="-D warnings" cargo test --workspace --features shoop_engine/app_backend`
- `QT_QPA_PLATFORM=offscreen target/debug/shoopdaloop_dev.sh --self-test` (236/236)
