### PR TITLE
Fix processed dry/wet ringbuffer grabs

### DIFF
--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -712,7 +712,7 @@ fn validate_midi_input_events(events: &[BackendMidiEvent]) -> Result<()> {
 }
 pub const MAX_WEB_AUDIO_QUANTUM: u32 = 2048;
 pub const RECORDING_CAPACITY_SECONDS: u32 = 120;
-pub const INPUT_CAPTURE_CAPACITY_SECONDS: u32 = 10;
+pub const INPUT_CAPTURE_CAPACITY_SECONDS: u32 = 30;
 pub const WEB_MIDI_OUTPUT_QUEUE_CAPACITY: usize = 1024;
 
 pub fn tiny_synth_fx_descriptor() -> TrackProcessorDescriptor {
@@ -1605,13 +1605,17 @@ impl EngineBackend {
                 shoop_engine::PortConnectability::INTERNAL,
                 0,
             )));
-            let receive = self.session.add_port(Port::Internal(InternalAudioPort::new(
+            let mut receive = InternalAudioPort::new(
                 format!("{}:audio_out_{index}", request.port_name_base),
                 self.buffer_size as usize,
                 shoop_engine::PortConnectability::INTERNAL,
                 shoop_engine::PortConnectability::INTERNAL,
-                0,
-            )));
+                capture_block_size,
+            );
+            receive
+                .audio_mut()
+                .set_ringbuffer_n_samples(capture_samples);
+            let receive = self.session.add_port(Port::Internal(receive));
             self.session.connect_ports_internal(input, send)?;
             self.session.connect_ports_internal(receive, output)?;
             ports.push(self.register_connection_port(
@@ -5099,6 +5103,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn default_input_capture_is_thirty_seconds() {
+        assert_eq!(INPUT_CAPTURE_CAPACITY_SECONDS, 30);
+    }
+
+    #[test]
     fn dry_wet_processor_mapping_is_ordered_and_clamps_unequal_shapes() {
         assert_eq!(
             dry_wet_processor_mapping(4, 1, true, 2, 16, true),
@@ -6930,7 +6939,7 @@ mod tests {
             .set_track_control(track.track_id, BackendTrackControl::InputMonitoring(true))
             .unwrap();
         let mut output = vec![0.0; 256];
-        for _ in 0..8 {
+        for _ in 0..INPUT_CAPTURE_CAPACITY_SECONDS - 2 {
             backend
                 .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 2, 128)
                 .unwrap();

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -785,6 +785,7 @@ impl NativeRuntime {
             .resolved
             .sample_rate
             .saturating_mul(INPUT_CAPTURE_CAPACITY_SECONDS);
+        let capture_block_size = ring.div_ceil(32).max(self.resolved.buffer_size);
         for index in 0..request.audio_channels {
             let suffix = if request.audio_channels == 1 {
                 String::new()
@@ -798,7 +799,7 @@ impl NativeRuntime {
                 &self.driver,
                 &input_name,
                 &PortDirection::Input,
-                ring,
+                capture_block_size,
             )?;
             input.set_passthrough_muted(true)?;
             input.set_ringbuffer_n_samples(ring)?;
@@ -918,6 +919,7 @@ impl NativeRuntime {
             .resolved
             .sample_rate
             .saturating_mul(INPUT_CAPTURE_CAPACITY_SECONDS);
+        let capture_block_size = ring.div_ceil(32).max(self.resolved.buffer_size);
         let mut audio_inputs = Vec::with_capacity(dry_audio_channels as usize);
         let mut audio_sends = Vec::with_capacity(dry_audio_channels as usize);
         let mut audio_returns = Vec::with_capacity(wet_audio_channels as usize);
@@ -931,7 +933,7 @@ impl NativeRuntime {
                 &self.driver,
                 &input_name,
                 &PortDirection::Input,
-                ring,
+                capture_block_size,
             )?;
             input.set_passthrough_muted(true)?;
             input.set_ringbuffer_n_samples(ring)?;
@@ -968,7 +970,7 @@ impl NativeRuntime {
                 &self.driver,
                 &return_name,
                 &PortDirection::Input,
-                ring,
+                capture_block_size,
             )?;
             return_.set_passthrough_muted(true)?;
             return_.set_ringbuffer_n_samples(ring)?;
@@ -1104,12 +1106,16 @@ impl NativeRuntime {
             .resolved
             .sample_rate
             .saturating_mul(INPUT_CAPTURE_CAPACITY_SECONDS);
+        let capture_block_size = ring.div_ceil(32).max(self.resolved.buffer_size);
         let chain = if chain_type == FXChainType::TinySynthFx {
-            self.session
-                .create_tiny_synth_fx_chain(&request.port_name_base, dry_audio_channels as usize)?
+            self.session.create_tiny_synth_fx_chain(
+                &request.port_name_base,
+                dry_audio_channels as usize,
+                ring,
+            )?
         } else {
             self.session
-                .create_fx_chain(chain_type, &request.port_name_base)?
+                .create_fx_chain(chain_type, &request.port_name_base, ring)?
         };
         let last_confirmed_state = chain.try_get_state_str().ok();
         let mut audio_inputs = Vec::with_capacity(dry_audio_channels as usize);
@@ -1124,7 +1130,7 @@ impl NativeRuntime {
                 &self.driver,
                 &input_name,
                 &PortDirection::Input,
-                ring,
+                capture_block_size,
             )?;
             input.set_passthrough_muted(true)?;
             input.set_ringbuffer_n_samples(ring)?;
@@ -3042,6 +3048,155 @@ mod tests {
             restored.capture_session().unwrap().tracks[0].topology,
             captured.tracks[0].topology
         );
+    }
+
+    #[test]
+    fn native_dummy_grab_captures_processed_dry_wet_audio_and_midi() {
+        const FRAMES: u32 = 128;
+        const NOTE_FRAME: usize = 16;
+        const NOTE_VELOCITY: u8 = 102;
+
+        let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: FRAMES,
+        }))
+        .unwrap();
+        let sync = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "grab_sync".to_owned(),
+                audio_channels: 0,
+                midi: false,
+                initial_loops: 1,
+            })
+            .unwrap();
+        let target = backend
+            .create_track(TrackRequest {
+                port_name_base: "grab_processed".to_owned(),
+                topology: BackendTrackTopology::DryWetProcessor {
+                    processor_type: "test_2x2x1".to_owned(),
+                    dry_audio_channels: 2,
+                    wet_audio_channels: 2,
+                    dry_midi: true,
+                },
+                initial_loops: 1,
+            })
+            .unwrap();
+        backend.set_loop_length(sync.loops[0], FRAMES).unwrap();
+        backend
+            .transition_loop(sync.loops[0], BackendLoopMode::Playing, None)
+            .unwrap();
+        backend
+            .set_loop_sync_source(target.loops[0], Some(sync.loops[0]))
+            .unwrap();
+        backend
+            .set_track_control(target.track_id, BackendTrackControl::InputMonitoring(true))
+            .unwrap();
+
+        let dry_left = vec![0.25; FRAMES as usize];
+        let dry_right = vec![-0.5; FRAMES as usize];
+        {
+            let runtime = backend.runtime_mut().unwrap();
+            runtime.driver.dummy_enter_controlled_mode();
+            let track = &runtime.tracks[&target.track_id];
+            for input in &track.audio_inputs {
+                input.set_ringbuffer_n_samples(FRAMES).unwrap();
+            }
+            track
+                .midi_input
+                .as_ref()
+                .unwrap()
+                .set_ringbuffer_n_samples(FRAMES)
+                .unwrap();
+            runtime.loops[&sync.loops[0]]
+                .handle
+                .set_position(0)
+                .unwrap();
+            runtime.wait();
+
+            let track = &runtime.tracks[&target.track_id];
+            let left_input = track.audio_inputs[0].clone();
+            let right_input = track.audio_inputs[1].clone();
+            let midi_input = track.midi_input.as_ref().unwrap().clone();
+            for sequence in [
+                left_input.dummy_queue_data(&dry_left).unwrap(),
+                right_input.dummy_queue_data(&dry_right).unwrap(),
+                midi_input
+                    .dummy_queue_msgs(vec![
+                        MidiEvent::new(NOTE_FRAME as i32, vec![0x90, 64, NOTE_VELOCITY]),
+                        MidiEvent::new(64, vec![0x80, 64, 0]),
+                    ])
+                    .unwrap(),
+            ] {
+                runtime
+                    .session
+                    .wait_for_command(sequence, shoop_engine::DEFAULT_WAIT_TIMEOUT)
+                    .unwrap();
+            }
+            runtime.driver.dummy_request_controlled_frames(FRAMES);
+            runtime.driver.dummy_run_requested_frames();
+        }
+
+        backend
+            .grab_loops(&[BackendGrabRequest {
+                loop_id: target.loops[0],
+                reverse_start_cycle: Some(1),
+                cycles_length: Some(1),
+                go_to_cycle: Some(0),
+                go_to_mode: BackendLoopMode::Playing,
+            }])
+            .unwrap();
+
+        let captured = backend.capture_session().unwrap();
+        let target_loop = &captured
+            .tracks
+            .iter()
+            .find(|track| track.source_id == target.track_id.raw())
+            .unwrap()
+            .loops[0];
+        assert_eq!(target_loop.length, FRAMES);
+        assert_eq!(target_loop.audio[0].samples, dry_left);
+        assert_eq!(target_loop.audio[1].samples, dry_right);
+        assert_eq!(
+            target_loop.midi[0].events,
+            vec![
+                BackendMidiEvent {
+                    time: NOTE_FRAME as u32,
+                    data: vec![0x90, 64, NOTE_VELOCITY],
+                },
+                BackendMidiEvent {
+                    time: 64,
+                    data: vec![0x80, 64, 0],
+                },
+            ]
+        );
+
+        let mut expected_left = vec![0.125; FRAMES as usize];
+        let mut expected_right = vec![-0.25; FRAMES as usize];
+        let note_impulse = f32::from(NOTE_VELOCITY) / 255.0;
+        expected_left[NOTE_FRAME] += note_impulse;
+        expected_right[NOTE_FRAME] += note_impulse;
+        for (frame, (actual, expected)) in target_loop.audio[2]
+            .samples
+            .iter()
+            .zip(&expected_left)
+            .enumerate()
+        {
+            assert!(
+                (*actual - *expected).abs() < 1.0e-6,
+                "left wet sample {frame}: expected {expected}, got {actual}"
+            );
+        }
+        for (frame, (actual, expected)) in target_loop.audio[3]
+            .samples
+            .iter()
+            .zip(&expected_right)
+            .enumerate()
+        {
+            assert!(
+                (*actual - *expected).abs() < 1.0e-6,
+                "right wet sample {frame}: expected {expected}, got {actual}"
+            );
+        }
     }
 
     #[test]

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -2672,12 +2672,27 @@ impl BackendSession {
         skip_all,
         fields(session_id = self.session_id(), chain_type = chain_type as u32)
     )]
-    pub fn create_fx_chain(&self, chain_type: FXChainType, title: &str) -> Result<FXChain> {
-        self.create_fx_chain_with_channels(chain_type, title, None)
+    pub fn create_fx_chain(
+        &self,
+        chain_type: FXChainType,
+        title: &str,
+        output_ringbuffer_n_samples: u32,
+    ) -> Result<FXChain> {
+        self.create_fx_chain_with_channels(chain_type, title, None, output_ringbuffer_n_samples)
     }
 
-    pub fn create_tiny_synth_fx_chain(&self, title: &str, channel_count: usize) -> Result<FXChain> {
-        self.create_fx_chain_with_channels(FXChainType::TinySynthFx, title, Some(channel_count))
+    pub fn create_tiny_synth_fx_chain(
+        &self,
+        title: &str,
+        channel_count: usize,
+        output_ringbuffer_n_samples: u32,
+    ) -> Result<FXChain> {
+        self.create_fx_chain_with_channels(
+            FXChainType::TinySynthFx,
+            title,
+            Some(channel_count),
+            output_ringbuffer_n_samples,
+        )
     }
 
     fn create_fx_chain_with_channels(
@@ -2685,6 +2700,7 @@ impl BackendSession {
         chain_type: FXChainType,
         title: &str,
         tiny_channels: Option<usize>,
+        output_ringbuffer_n_samples: u32,
     ) -> Result<FXChain> {
         let backend = match chain_type {
             FXChainType::Test2x2x1 => FXChainBackendKind::Test2x2x1,
@@ -2800,6 +2816,7 @@ impl BackendSession {
             backend,
             state: Arc::new(Mutex::new(FXChainState::default())),
             tiny_channels: tiny_channels.unwrap_or(0),
+            output_ringbuffer_n_samples: output_ringbuffer_n_samples as usize,
             audio_inputs: Vec::new(),
             audio_outputs: Vec::new(),
             midi_inputs: Vec::new(),
@@ -5850,6 +5867,7 @@ pub struct FXChain {
     backend: FXChainBackendKind,
     state: Arc<Mutex<FXChainState>>,
     tiny_channels: usize,
+    output_ringbuffer_n_samples: usize,
     audio_inputs: Vec<AudioPort>,
     audio_outputs: Vec<AudioPort>,
     midi_inputs: Vec<MidiPort>,
@@ -6268,7 +6286,12 @@ impl FXChain {
         }
     }
     /// Queues an internal chain port and immediately returns its pending handle.
-    fn make_audio_port(&self, name: String, direction: PortDirection) -> Option<AudioPort> {
+    fn make_audio_port(
+        &self,
+        name: String,
+        direction: PortDirection,
+        ringbuffer_n_samples: usize,
+    ) -> Option<AudioPort> {
         let control = Arc::new(
             ObjectControl::<AudioPortId, engine::AudioPortStateMirror>::pending(
                 self.shared.session_id,
@@ -6284,13 +6307,21 @@ impl FXChain {
                 };
                 let Some(owned) = owned.take() else { return };
                 let n_frames = s.buffer_size().max(1) as usize;
-                let port = engine::session::Port::Internal(engine::InternalAudioPort::new(
+                let ringbuffer_buffer_size = if ringbuffer_n_samples == 0 {
+                    0
+                } else {
+                    ringbuffer_n_samples.div_ceil(32).max(n_frames)
+                };
+                let mut port = engine::InternalAudioPort::new(
                     owned,
                     n_frames,
                     engine::PortConnectability::INTERNAL,
                     engine::PortConnectability::INTERNAL,
-                    0,
-                ));
+                    ringbuffer_buffer_size,
+                );
+                port.audio_mut()
+                    .set_ringbuffer_n_samples(ringbuffer_n_samples);
+                let port = engine::session::Port::Internal(port);
                 match s.add_audio_port_with_state(port, Arc::clone(&control.mirror)) {
                     Ok(idx) => control.mark_ready(AudioPortId(idx)),
                     Err(error) => control.mark_failed(error.to_string()),
@@ -6386,6 +6417,7 @@ impl FXChain {
             if let Some(port) = self.make_audio_port(
                 format!("{}:audio_in_{}", self.title, idx),
                 PortDirection::Output,
+                0,
             ) {
                 self.audio_inputs.push(port);
             }
@@ -6394,6 +6426,7 @@ impl FXChain {
             if let Some(port) = self.make_audio_port(
                 format!("{}:audio_out_{}", self.title, idx),
                 PortDirection::Input,
+                self.output_ringbuffer_n_samples,
             ) {
                 self.audio_outputs.push(port);
             }
@@ -7789,7 +7822,7 @@ mod tests {
         let sess = BackendSession::new().expect("session");
         let mut engine = sess.shared.take_engine().expect("parked engine");
         let chain = sess
-            .create_fx_chain(FXChainType::Test2x2x1, "stable-fx")
+            .create_fx_chain(FXChainType::Test2x2x1, "stable-fx", 0)
             .expect("chain");
         let first = chain.get_audio_input_port(0).expect("first handle");
         let again = chain.get_audio_input_port(0).expect("same handle");
@@ -7815,10 +7848,45 @@ mod tests {
     }
 
     #[test]
+    fn fx_output_capture_uses_bounded_chunks() {
+        const CAPTURE_SAMPLES: u32 = 480_000;
+
+        let sess = BackendSession::new().expect("session");
+        let mut engine = sess.shared.take_engine().expect("parked engine");
+        let chain = sess
+            .create_fx_chain(FXChainType::Test2x2x1, "capturing-fx", CAPTURE_SAMPLES)
+            .expect("chain");
+        engine.pump();
+        let input = chain
+            .get_audio_input_port(0)
+            .unwrap()
+            .control
+            .ready_id()
+            .unwrap()
+            .index();
+        let output = chain
+            .get_audio_output_port(0)
+            .unwrap()
+            .control
+            .ready_id()
+            .unwrap()
+            .index();
+        let input = engine.session().port(input).unwrap().audio().unwrap();
+        let output = engine.session().port(output).unwrap().audio().unwrap();
+        let chunk_size = output.ringbuffer_contents().buffer_size;
+
+        assert_eq!(input.ringbuffer_capacity(), 0);
+        assert!(chunk_size >= (CAPTURE_SAMPLES as usize).div_ceil(32));
+        assert!(output.ringbuffer_capacity() >= CAPTURE_SAMPLES as usize);
+        assert!(output.ringbuffer_capacity() < CAPTURE_SAMPLES as usize + chunk_size);
+        sess.shared.return_engine(engine);
+    }
+
+    #[test]
     fn test_fx_chain_runs_as_a_scheduled_processor_node() {
         let sess = BackendSession::new().expect("session");
         let chain = sess
-            .create_fx_chain(FXChainType::Test2x2x1, "scheduled-fx")
+            .create_fx_chain(FXChainType::Test2x2x1, "scheduled-fx", 0)
             .expect("chain");
         chain.set_active(true);
         let mut engine = sess.shared.take_engine().expect("parked engine");
@@ -7894,7 +7962,7 @@ mod tests {
         let sess = BackendSession::new().expect("session");
         let mut engine = sess.shared.take_engine().expect("parked engine");
         let chain = sess
-            .create_fx_chain(FXChainType::Test2x2x1, "captured-fx")
+            .create_fx_chain(FXChainType::Test2x2x1, "captured-fx", 0)
             .expect("chain");
         let midi_input = chain.get_midi_input_port(0).expect("MIDI input");
         engine.pump();
@@ -7987,7 +8055,7 @@ mod tests {
     fn current_fx_chain_handle_controls_visibility_activity_and_ports() {
         let sess = BackendSession::new().expect("session");
         let chain = sess
-            .create_fx_chain(FXChainType::Test2x2x1, "test_fx")
+            .create_fx_chain(FXChainType::Test2x2x1, "test_fx", 0)
             .expect("fx chain");
 
         assert!(chain.available());
@@ -8032,7 +8100,7 @@ mod tests {
         let _exclusive = engine::lv2_carla::lock_carla_test();
         let sess = BackendSession::new().expect("session");
         let chain = sess
-            .create_fx_chain(FXChainType::CarlaRack, "carla")
+            .create_fx_chain(FXChainType::CarlaRack, "carla", 0)
             .expect("chain handle");
         if !chain.available() {
             eprintln!(


### PR DESCRIPTION
## Summary

- retain hosted processor wet outputs in bounded rolling buffers so dry/wet grabs capture the processed audio corresponding to grabbed MIDI
- raise the default input/wet-return capture window from 10 seconds to 30 seconds across native and browser backends
- size native and processor capture storage in at most roughly 32 chunks instead of one-sample or whole-window chunks
- add an exact native Test2x2x1 dry/wet audio+MIDI grab regression and bounded FX-output chunk coverage

## Testing

- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test -p shoop_backend --features native-drivers native_dummy_grab_captures_processed_dry_wet_audio_and_midi -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace --features shoop_engine/app_backend`
- `RUSTFLAGS="-D warnings" cargo test -p shoop_backend --features native-drivers --no-run`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend -- --test-threads=1`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `cargo check -p shoopdaloop_egui --no-default-features --target wasm32-unknown-unknown`
- `cargo build -p shoop_audio_worklet --target wasm32-unknown-unknown --release`
