### PR TITLE
Add web application loading splash

### DIFF
--- a/src/rust/shoopdaloop/browser_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_smoke.mjs
@@ -885,6 +885,12 @@ try {
     }
     console.log(`${selfContained ? 'direct-file' : 'hosted'} browser Web Audio self-test passed at ${browserSize}, callback ${state.callbacks}`);
   }
+  const splashHidden = await evaluate(
+    "document.getElementById('loading_splash')?.hidden === true",
+  );
+  if (!splashHidden) {
+    throw new Error('loading splash remained visible after application startup');
+  }
   if (failures.length > 0) {
     throw new Error(`browser reported runtime errors: ${JSON.stringify(failures)}`);
   }

--- a/src/rust/shoopdaloop/build_single_file_app.py
+++ b/src/rust/shoopdaloop/build_single_file_app.py
@@ -21,6 +21,7 @@ ROBOTO_FONT_FILES = (
     "Roboto-BoldItalic.ttf",
 )
 ICON_FILE = "icon.png"
+SPLASH_LOGO_FILE = "logo.png"
 
 
 def exactly_one(paths: list[Path], description: str) -> Path:
@@ -74,6 +75,19 @@ def build_single_file(dist: Path, output: Path) -> None:
         raise RuntimeError("could not identify application icon URL")
     encoded_icon = base64.b64encode(icon_path.read_bytes()).decode("ascii")
     html = html.replace(icon_url, f'href="data:image/png;base64,{encoded_icon}"')
+
+    splash_logo_path = dist / SPLASH_LOGO_FILE
+    if not splash_logo_path.is_file():
+        raise RuntimeError(f"missing splash logo: {splash_logo_path}")
+    splash_logo_url = f'src="./{SPLASH_LOGO_FILE}"'
+    if html.count(splash_logo_url) != 1:
+        raise RuntimeError("could not identify splash logo URL")
+    encoded_splash_logo = base64.b64encode(splash_logo_path.read_bytes()).decode(
+        "ascii"
+    )
+    html = html.replace(
+        splash_logo_url, f'src="data:image/png;base64,{encoded_splash_logo}"'
+    )
 
     for name in ROBOTO_FONT_FILES:
         font_path = dist / "roboto" / name

--- a/src/rust/shoopdaloop/index.html
+++ b/src/rust/shoopdaloop/index.html
@@ -8,6 +8,7 @@
     <title>ShoopDaLoop browser audio</title>
     <link data-trunk rel="rust" data-bin="shoopdaloop" />
     <link data-trunk rel="copy-file" href="../../../resources/iconset/icon.png" />
+    <link data-trunk rel="copy-file" href="../../../resources/logo.png" />
     <link data-trunk rel="copy-file" href="audio_worklet.js" />
     <link data-trunk rel="copy-dir" href="generated" />
     <link data-trunk rel="copy-dir" href="../../../resources/fonts/roboto" />
@@ -55,6 +56,31 @@
         height: 100%;
         display: block;
         touch-action: none;
+      }
+
+      #loading_splash {
+        position: fixed;
+        inset: 0;
+        z-index: 20;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        padding: 32px;
+        color: #aaa;
+        background: #181818;
+        font-size: 14px;
+      }
+
+      #loading_splash[hidden] {
+        display: none;
+      }
+
+      #loading_splash img {
+        width: min(650px, 80vw);
+        height: auto;
       }
 
       #runtime_status {
@@ -164,9 +190,21 @@
         background: #444;
       }
     </style>
+    <noscript>
+      <style>
+        #loading_splash,
+        #browser_permissions_dialog {
+          display: none;
+        }
+      </style>
+    </noscript>
   </head>
   <body>
     <canvas id="shoop_canvas"></canvas>
+    <div id="loading_splash" role="status" aria-live="polite">
+      <img src="./logo.png" alt="ShoopDaLoop" />
+      <span>Loading ShoopDaLoop…</span>
+    </div>
     <div
       id="browser_permissions_dialog"
       role="dialog"

--- a/src/rust/shoopdaloop/package_artifacts.py
+++ b/src/rust/shoopdaloop/package_artifacts.py
@@ -22,6 +22,7 @@ ARCHIVE_ROOT = "shoopdaloop"
 PROFILES = ("debug", "release")
 NATIVE_PLATFORMS = ("linux", "windows", "macos")
 APPLICATION_ICON = ROOT / "resources" / "iconset" / "icon.png"
+SPLASH_LOGO = ROOT / "resources" / "logo.png"
 ROBOTO_FILES = (
     "LICENSE.txt",
     "README.md",
@@ -33,6 +34,7 @@ ROBOTO_FILES = (
 WEB_REQUIRED_FILES = (
     "index.html",
     "icon.png",
+    "logo.png",
     "audio_worklet.js",
     "generated/shoop_audio_worklet.wasm",
     *(f"roboto/{name}" for name in ROBOTO_FILES),
@@ -255,6 +257,9 @@ def verify_web(bundle: Path, html: Path) -> None:
     icon = archive_file(bundle, f"{root}icon.png")
     if icon != APPLICATION_ICON.read_bytes():
         raise RuntimeError("hosted web archive contains the wrong application icon")
+    logo = archive_file(bundle, f"{root}logo.png")
+    if logo != SPLASH_LOGO.read_bytes():
+        raise RuntimeError("hosted web archive contains the wrong splash logo")
     require_click_assets(archive_file(bundle, wasm[0]), "hosted application Wasm")
     text = html.read_text(encoding="utf-8")
     if "TrunkApplicationStarted" not in text or "shoopWasmBytes" not in text:
@@ -282,6 +287,13 @@ def verify_web(bundle: Path, html: Path) -> None:
         embedded_icon.group(1), validate=True
     ) != APPLICATION_ICON.read_bytes():
         raise RuntimeError("self-contained HTML does not contain the application icon")
+    embedded_logo = re.search(
+        r'src="data:image/png;base64,([A-Za-z0-9+/=]+)"', text
+    )
+    if not embedded_logo or base64.b64decode(
+        embedded_logo.group(1), validate=True
+    ) != SPLASH_LOGO.read_bytes():
+        raise RuntimeError("self-contained HTML does not contain the splash logo")
     application_binary = None
     for variable in ("shoopWasmBinary", "shoopAudioWorkletBinary"):
         match = re.search(rf'const {variable} = atob\("([A-Za-z0-9+/=]+)"\);', text)

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -3799,10 +3799,13 @@ fn main() {
             .dyn_into::<web_sys::HtmlCanvasElement>()
             .expect("#shoop_canvas is not a canvas");
 
-        match eframe::WebRunner::new()
+        let result = eframe::WebRunner::new()
             .start(canvas, eframe::WebOptions::default(), Box::new(create_app))
-            .await
-        {
+            .await;
+        if let Some(splash) = document.get_element_by_id("loading_splash") {
+            let _ = splash.set_attribute("hidden", "");
+        }
+        match result {
             Ok(()) => set_browser_status("Awaiting browser audio enable action", None),
             Err(error) => {
                 let message = format!("Browser application failed: {error:?}");
@@ -3864,6 +3867,9 @@ mod tests {
         let html = include_str!("../index.html");
         assert!(html.contains("data-trunk"));
         assert!(html.contains(&format!("id=\"{WEB_CANVAS_ID}\"")));
+        assert!(html.contains("id=\"loading_splash\""));
+        assert!(html.contains("src=\"./logo.png\""));
+        assert!(html.contains("Loading ShoopDaLoop…"));
         assert!(html.contains("id=\"browser_permissions_dialog\""));
         assert!(html.contains("Browser audio and MIDI permissions"));
         assert!(html.contains("Enable microphone audio"));


### PR DESCRIPTION
## Summary
- show the ShoopDaLoop logo while the browser Wasm application initializes
- hide the splash after the egui web runner starts
- include and verify the logo in hosted and standalone HTML artifacts
- assert splash dismissal in browser smoke coverage

## Testing
- Package tests, warning-denying native/Wasm checks, formatting, and synthetic standalone packaging passed before the final rebase
- No tests rerun after rebasing, per request
- Full Trunk/browser smoke was unavailable because Trunk is not installed in the environment