### PR TITLE
Finalize controlled recording before capture

### DIFF
--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -3036,6 +3036,25 @@ mod tests {
         backend
             .transition_loop(created.loops[0], BackendLoopMode::Stopped, None)
             .unwrap();
+        {
+            let runtime = backend.runtime_mut().unwrap();
+            let wet = runtime.loops[&created.loops[0]].audio[2].clone();
+            assert!(matches!(
+                wet.try_get_current_data_snapshot(),
+                Err(
+                    shoop_engine::content_snapshot::CurrentDataError::MutationActive(
+                        shoop_engine::content_snapshot::ContentMutation::Recording
+                    )
+                )
+            ));
+            runtime.driver.dummy_request_controlled_frames(1);
+            runtime.driver.dummy_run_requested_frames();
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            while wet.try_get_current_data_snapshot().is_err() {
+                assert!(std::time::Instant::now() < deadline);
+                std::thread::yield_now();
+            }
+        }
         let captured = backend.capture_session().unwrap();
         assert_eq!(
             captured.tracks[0].loops[0].audio[2].samples,


### PR DESCRIPTION
## Summary
- make the processed-track recording test explicitly finish its controlled recording cycle before capturing the session
- assert the channel snapshot is still in the recording mutation after an idle stop command, exposing the synchronization requirement deterministically
- wait for the finalized snapshot before checking captured wet audio

## Root cause
The test entered dummy controlled mode, processed exactly the requested recording frames, issued a stop command while no more frames were requested, and immediately captured the session. An idle dummy iteration can apply the loop stop command, but channel snapshot finalization occurs when the channel processes its next cycle. Until then `get_data()` takes its legacy stale-read path and gives the asynchronous publisher only 2 ms to publish the latest recording block. Windows occasionally missed that window and returned the prior empty snapshot.

The test now demonstrates that state directly (`MutationActive(Recording)` after the idle stop), requests one post-stop frame to finalize the channel snapshot, and waits for exact publication before capture.

## Verification
- pre-fix original test reproduced locally: 19/20 passes, 1 failure
- focused test with deterministic state assertion and post-stop cycle: 200/200 fresh-process passes
- `RUSTFLAGS="-D warnings" SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --locked -p shoop_engine -p shoop_backend --features shoop_engine/app_backend,shoop_backend/native-drivers -- --test-threads=1`
- `cargo fmt --all -- --check`
- `python3 scripts/check_tracing_coverage.py --require-closed`

The complete local workspace suite additionally requires the Windows vcpkg `lilv`/`pkgconf` setup installed by CI; this machine does not have those external packages.
