### PR TITLE
Stabilize master native and browser CI

### DIFF
--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -3036,6 +3036,25 @@ mod tests {
         backend
             .transition_loop(created.loops[0], BackendLoopMode::Stopped, None)
             .unwrap();
+        {
+            let runtime = backend.runtime_mut().unwrap();
+            let wet = runtime.loops[&created.loops[0]].audio[2].clone();
+            assert!(matches!(
+                wet.try_get_current_data_snapshot(),
+                Err(
+                    shoop_engine::content_snapshot::CurrentDataError::MutationActive(
+                        shoop_engine::content_snapshot::ContentMutation::Recording
+                    )
+                )
+            ));
+            runtime.driver.dummy_request_controlled_frames(1);
+            runtime.driver.dummy_run_requested_frames();
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+            while wet.try_get_current_data_snapshot().is_err() {
+                assert!(std::time::Instant::now() < deadline);
+                std::thread::yield_now();
+            }
+        }
         let captured = backend.capture_session().unwrap();
         assert_eq!(
             captured.tracks[0].loops[0].audio[2].samples,

--- a/src/rust/shoopdaloop/browser_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_smoke.mjs
@@ -191,7 +191,9 @@ try {
   async function clickEnable(id = 'enable_audio') {
     const bounds = await evaluate(`(() => {
       document.getElementById('browser_permissions_dialog').hidden = false;
-      const rect = document.getElementById('${id}').getBoundingClientRect();
+      const button = document.getElementById('${id}');
+      button.scrollIntoView({ block: 'center', inline: 'center' });
+      const rect = button.getBoundingClientRect();
       return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
     })()`);
     await call('Input.dispatchMouseEvent', { type: 'mousePressed', x: bounds.x, y: bounds.y, button: 'left', clickCount: 1 });


### PR DESCRIPTION
## Summary
- finalize the controlled dummy recording cycle before asserting captured wet audio
- scroll browser permission controls into the visible modal viewport before dispatching a trusted DevTools click

## Root causes
The Windows release failure captured a controlled recording immediately after an idle stop command. The stop command had been applied, but the channel needed one more requested frame to finalize and publish its snapshot.

The 360x200 browser smoke opened a permission dialog whose microphone button was below the scrollable panel's visible area. DevTools dispatched the click at the off-viewport coordinates, so no trusted enable gesture reached the application and the test remained in `AwaitingGesture`.

## Verification
- `node --check src/rust/shoopdaloop/browser_smoke.mjs`
- `cargo fmt --all -- --check`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `git diff --check`

The focused native test is locally blocked before project compilation because this host does not provide the external ALSA pkg-config package. GitHub's Windows and browser jobs are the authoritative verification for the failing paths.

Supersedes #716 by combining that Windows fix with the browser smoke fix on current `master`.
