### PR TITLE
Add failure-only Tracy nextest lane

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,5 @@
+nextest-version = { required = "0.9.116" }
+
 # Carla worker integration tests spawn full child processes and include paced
 # scheduler measurements. Running them against each other distorts deadlines
 # and can make an OS kill an otherwise independent sibling under runner load.
@@ -12,3 +14,12 @@ threads-required = "num-test-threads"
 [[profile.default.overrides]]
 filter = 'test(/carla_processor::tests::bridge_/)'
 threads-required = "num-test-threads"
+
+[profile.tracy-collector]
+fail-fast = false
+test-threads = 1
+retries = 0
+slow-timeout = { period = "8s", terminate-after = 1 }
+junit = { path = "junit.xml" }
+success-output = "never"
+failure-output = "immediate-final"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,12 +14,3 @@ threads-required = "num-test-threads"
 [[profile.default.overrides]]
 filter = 'test(/carla_processor::tests::bridge_/)'
 threads-required = "num-test-threads"
-
-[profile.tracy-collector]
-fail-fast = false
-test-threads = 1
-retries = 0
-slow-timeout = { period = "8s", terminate-after = 1 }
-junit = { path = "junit.xml" }
-success-output = "never"
-failure-output = "immediate-final"

--- a/.config/tracy-nextest.toml
+++ b/.config/tracy-nextest.toml
@@ -1,0 +1,10 @@
+nextest-version = { required = "0.9.116" }
+
+[profile.tracy-collector]
+fail-fast = false
+test-threads = 1
+retries = 0
+slow-timeout = { period = "8s", terminate-after = 1 }
+junit = { path = "junit.xml" }
+success-output = "never"
+failure-output = "immediate-final"

--- a/.github/workflows/tracy_nextest.yml
+++ b/.github/workflows/tracy_nextest.yml
@@ -28,15 +28,16 @@ jobs:
       - name: Install pinned cargo-nextest
         shell: bash
         run: |
-          curl -LsSf https://get.nexte.st/0.9.116/linux | tar zxf - -C "${CARGO_HOME}/bin"
-          cargo nextest --version | grep 'cargo-nextest 0.9.116'
+          mkdir -p /tmp/cargo-nextest-bin
+          curl -LsSf https://get.nexte.st/0.9.116/linux | tar zxf - -C /tmp/cargo-nextest-bin
+          /tmp/cargo-nextest-bin/cargo-nextest --version | grep 'cargo-nextest 0.9.116'
 
       - name: Build pinned Tracy collector and query tools
         shell: bash
         run: |
           set -euo pipefail
           git clone https://github.com/SanderVocke/tracy-query.git /tmp/tracy-query
-          git -C /tmp/tracy-query checkout 7d964dc9c48ae022a290b198142b6a28a221b27d
+          git -C /tmp/tracy-query checkout ac4159ace5dba56d8a067da210ef8f40effcceac
           cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF
           cmake --build /tmp/tracy-query-build --parallel 2 \
@@ -49,7 +50,7 @@ jobs:
           python3 scripts/run_tracy_nextest.py
           --collector /tmp/tracy-query-build/tracy-collector
           --query /tmp/tracy-query-build/tracy-query
-          --nextest "${CARGO_HOME}/bin/cargo-nextest"
+          --nextest /tmp/cargo-nextest-bin/cargo-nextest
           --output artifacts/tracy-nextest
           --expect-controlled-failures
 

--- a/.github/workflows/tracy_nextest.yml
+++ b/.github/workflows/tracy_nextest.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           git clone https://github.com/SanderVocke/tracy-query.git /tmp/tracy-query
-          git -C /tmp/tracy-query checkout b59b6e56db93fd1d8bd9a06d4b348f58717073ab
+          git -C /tmp/tracy-query checkout dc341c8b0f92f23e7dc7f8b0bcc3ff9798cc97c0
           cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF
           cmake --build /tmp/tracy-query-build --parallel 2 \

--- a/.github/workflows/tracy_nextest.yml
+++ b/.github/workflows/tracy_nextest.yml
@@ -1,0 +1,88 @@
+name: Failure-only Tracy nextest
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/tracy_nextest.yml'
+      - '.config/nextest.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'scripts/run_tracy_nextest.py'
+      - 'src/rust/shoop_engine/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tracy-nextest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  traced-engine-subset:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pinned cargo-nextest
+        shell: bash
+        run: |
+          curl -LsSf https://get.nexte.st/0.9.116/linux | tar zxf - -C "${CARGO_HOME}/bin"
+          cargo nextest --version | grep 'cargo-nextest 0.9.116'
+
+      - name: Build pinned Tracy collector and query tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone https://github.com/SanderVocke/tracy-query.git /tmp/tracy-query
+          git -C /tmp/tracy-query checkout 7d964dc9c48ae022a290b198142b6a28a221b27d
+          cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF
+          cmake --build /tmp/tracy-query-build --parallel 2 \
+            --target tracy-query tracy-collector
+          /tmp/tracy-query-build/tracy-query --version
+          /tmp/tracy-query-build/tracy-collector --version
+
+      - name: Run and validate controlled traced subset
+        run: >-
+          python3 scripts/run_tracy_nextest.py
+          --collector /tmp/tracy-query-build/tracy-collector
+          --query /tmp/tracy-query-build/tracy-query
+          --nextest "${CARGO_HOME}/bin/cargo-nextest"
+          --output artifacts/tracy-nextest
+          --expect-controlled-failures
+
+      - name: Reject partial or successful-attempt captures
+        if: always()
+        shell: bash
+        run: |
+          if compgen -G 'artifacts/tracy-nextest/traces/*.partial' >/dev/null; then
+            echo 'partial capture leaked' >&2
+            exit 1
+          fi
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path('artifacts/tracy-nextest/traces/manifest.json')
+          if not path.exists():
+              raise SystemExit('manifest missing')
+          manifest = json.loads(path.read_text())
+          for record in manifest['sessions']:
+              if record['state'] == 'discarded' and record['output_name']:
+                  raise SystemExit('discarded attempt names a capture')
+          PY
+
+      - name: Upload finalized failure evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shoop-tracy-nextest-evidence
+          path: |
+            artifacts/tracy-nextest/junit.xml
+            artifacts/tracy-nextest/metrics.json
+            artifacts/tracy-nextest/collector.log
+            artifacts/tracy-nextest/nextest.*.log
+            artifacts/tracy-nextest/traces/manifest.json
+            artifacts/tracy-nextest/traces/*.tracy
+          if-no-files-found: error

--- a/.github/workflows/tracy_nextest.yml
+++ b/.github/workflows/tracy_nextest.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/tracy_nextest.yml'
       - '.config/nextest.toml'
+      - '.config/tracy-nextest.toml'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/run_tracy_nextest.py'
@@ -37,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           git clone https://github.com/SanderVocke/tracy-query.git /tmp/tracy-query
-          git -C /tmp/tracy-query checkout ac4159ace5dba56d8a067da210ef8f40effcceac
+          git -C /tmp/tracy-query checkout b59b6e56db93fd1d8bd9a06d4b348f58717073ab
           cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF
           cmake --build /tmp/tracy-query-build --parallel 2 \

--- a/.github/workflows/tracy_nextest.yml
+++ b/.github/workflows/tracy_nextest.yml
@@ -38,9 +38,15 @@ jobs:
         run: |
           set -euo pipefail
           git clone https://github.com/SanderVocke/tracy-query.git /tmp/tracy-query
-          git -C /tmp/tracy-query checkout dc341c8b0f92f23e7dc7f8b0bcc3ff9798cc97c0
-          cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF
+          git -C /tmp/tracy-query checkout faca26563ff0994f5d889d60014cb6b546e2e213
+          for attempt in 1 2 3; do
+            if cmake -S /tmp/tracy-query -B /tmp/tracy-query-build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DTRACY_QUERY_FULLY_STATIC=OFF; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then exit 1; fi
+            sleep 5
+          done
           cmake --build /tmp/tracy-query-build --parallel 2 \
             --target tracy-query tracy-collector
           /tmp/tracy-query-build/tracy-query --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "0.11", features = ["ondemand"] }
-tracy-client = { version = "0.18.4", features = ["ondemand", "delayed-init", "timer-fallback"] }
+tracy-client = { version = "0.18.4", features = ["ondemand", "delayed-init", "manual-lifetime", "only-localhost", "timer-fallback"] }
 shoop_tracing = { path = "src/rust/shoop_tracing", default-features = false }
 tinyviolin = "=0.3.0"
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ See [INSTALL.md](INSTALL.md) for prerequisites and artifact details. The applica
 
 The main workflow builds Linux x86_64, Windows x86_64, macOS arm64, and WebAssembly in debug and release. Native outputs are unsigned application archives. Web outputs include a hosted bundle and a self-contained HTML file. Browser media and MIDI access depend on browser support, permissions, secure-context policy, and device availability.
 
+A separate opt-in [failure-only Tracy nextest lane](docs/tracy_nextest.md) profiles a small engine subset without changing the ordinary cargo-test correctness jobs.
+
 ## License and credits
 
 Copyright © Sander Vocke (2023–present) and other credited contributors. See [LICENSE](LICENSE).

--- a/docs/tracy_nextest.md
+++ b/docs/tracy_nextest.md
@@ -9,7 +9,7 @@ nextest discovery/listing, and every other test executable neither initializes
 Tracy nor contacts a collector.
 
 The job pins cargo-nextest 0.9.116 and tracy-query commit
-`dc341c8b0f92f23e7dc7f8b0bcc3ff9798cc97c0` (the collector implementation under
+`faca26563ff0994f5d889d60014cb6b546e2e213` (the collector implementation under
 review in `SanderVocke/tracy-query#1`). Replace that source pin with the first
 released collector asset after the upstream PR is merged; the orchestration
 command already accepts arbitrary released `--collector` and `--query` paths.

--- a/docs/tracy_nextest.md
+++ b/docs/tracy_nextest.md
@@ -9,7 +9,7 @@ nextest discovery/listing, and every other test executable neither initializes
 Tracy nor contacts a collector.
 
 The job pins cargo-nextest 0.9.116 and tracy-query commit
-`b59b6e56db93fd1d8bd9a06d4b348f58717073ab` (the collector implementation under
+`dc341c8b0f92f23e7dc7f8b0bcc3ff9798cc97c0` (the collector implementation under
 review in `SanderVocke/tracy-query#1`). Replace that source pin with the first
 released collector asset after the upstream PR is merged; the orchestration
 command already accepts arbitrary released `--collector` and `--query` paths.

--- a/docs/tracy_nextest.md
+++ b/docs/tracy_nextest.md
@@ -9,7 +9,7 @@ nextest discovery/listing, and every other test executable neither initializes
 Tracy nor contacts a collector.
 
 The job pins cargo-nextest 0.9.116 and tracy-query commit
-`ac4159ace5dba56d8a067da210ef8f40effcceac` (the collector implementation under
+`b59b6e56db93fd1d8bd9a06d4b348f58717073ab` (the collector implementation under
 review in `SanderVocke/tracy-query#1`). Replace that source pin with the first
 released collector asset after the upstream PR is merged; the orchestration
 command already accepts arbitrary released `--collector` and `--query` paths.

--- a/docs/tracy_nextest.md
+++ b/docs/tracy_nextest.md
@@ -9,7 +9,7 @@ nextest discovery/listing, and every other test executable neither initializes
 Tracy nor contacts a collector.
 
 The job pins cargo-nextest 0.9.116 and tracy-query commit
-`7d964dc9c48ae022a290b198142b6a28a221b27d` (the collector implementation under
+`ac4159ace5dba56d8a067da210ef8f40effcceac` (the collector implementation under
 review in `SanderVocke/tracy-query#1`). Replace that source pin with the first
 released collector asset after the upstream PR is merged; the orchestration
 command already accepts arbitrary released `--collector` and `--query` paths.

--- a/docs/tracy_nextest.md
+++ b/docs/tracy_nextest.md
@@ -1,0 +1,85 @@
+# Failure-only Tracy captures under nextest
+
+ShoopDaLoop keeps its ordinary `cargo test -- --test-threads=1` correctness lanes
+unchanged. A separate Linux job traces only
+`shoop_engine/tests/tracy_collector_contract.rs`. The lane is opt-in:
+`SHOOP_TRACY_NEXTEST=1`, nextest's attempt variables, and collector endpoint
+variables must all be present before the startup hook does anything. Cargo test,
+nextest discovery/listing, and every other test executable neither initializes
+Tracy nor contacts a collector.
+
+The job pins cargo-nextest 0.9.116 and tracy-query commit
+`7d964dc9c48ae022a290b198142b6a28a221b27d` (the collector implementation under
+review in `SanderVocke/tracy-query#1`). Replace that source pin with the first
+released collector asset after the upstream PR is merged; the orchestration
+command already accepts arbitrary released `--collector` and `--query` paths.
+The Rust client is exactly `tracy-client` 0.18.4/`tracy-client-sys` 0.28.0,
+compatible with the daemon's Tracy 0.13.1 protocol.
+
+## Architecture
+
+`scripts/run_tracy_nextest.py` starts the suite-scoped daemon and then invokes
+cargo-nextest directly. Nextest remains the parent and supervisor of every test;
+there is no per-test wrapper. The in-executable support module:
+
+1. checks the explicit opt-in and `NEXTEST_ATTEMPT_ID`;
+2. registers run, attempt, binary, test, retry, and stress identity;
+3. sets the assigned `TRACY_PORT` before manual/delayed Tracy startup;
+4. waits for a completed collector handshake;
+5. enables coarse direct engine tracing (detail tracing requires the separate
+   `SHOOP_TRACY_DETAIL=1` opt-in).
+
+The profile caps concurrency at one. The initial subset executes real
+`BasicLoop` processing and controlled pass, panic, abort, and timeout outcomes.
+The timeout is terminated by nextest, not by the collector.
+
+After nextest exits, the script parses authoritative JUnit. One unambiguous pass
+is discarded; failure/error outcomes are saved; absent, duplicate, or unknown
+outcomes default to save. It finalizes the daemon, validates every saved file
+with `tracy-query check`, `range`, `info`, and an attempt-identity message query,
+and returns nextest's status. CI passes `--expect-controlled-failures` only
+because this fixture deliberately contains failures.
+
+## Run locally
+
+Install cargo-nextest 0.9.116 and obtain matching `tracy-collector` and
+`tracy-query` binaries, then run:
+
+```sh
+python3 scripts/run_tracy_nextest.py \
+  --collector /path/to/tracy-collector \
+  --query /path/to/tracy-query \
+  --nextest "$(command -v cargo-nextest)" \
+  --output artifacts/tracy-nextest \
+  --expect-controlled-failures
+```
+
+Without `--expect-controlled-failures`, the command propagates nextest's
+non-zero suite status. This is the mode to use for a real selected test set.
+
+## Artifacts and resource policy
+
+On `if: always()`, CI uploads only JUnit, finalized `.tracy` files,
+`manifest.json`, collector/nextest diagnostics, and `metrics.json`. It never
+uploads `.partial` files or captures for successful attempts. `metrics.json`
+records traced and ordinary wall time, process peak RSS, finalized trace count
+and bytes, nextest status, concurrency, and detail mode.
+
+The first local constrained run used concurrency 1 and coarse tracing:
+
+```json
+{
+  "baseline_wall_seconds": 0.11,
+  "traced_wall_seconds": 18.87,
+  "wall_overhead_seconds": 18.76,
+  "peak_rss_kib": 113180,
+  "trace_count": 3,
+  "trace_bytes": 446008
+}
+```
+
+These fixture numbers include collector startup and intentional timeout. Do not
+expand the filter or raise concurrency until CI measurements show acceptable
+wall time, CPU/RSS, artifact size, and identical traced/untraced test behavior.
+The collector's in-memory captures are not durable across SIGKILL, machine loss,
+or runner cancellation.

--- a/scripts/run_tracy_nextest.py
+++ b/scripts/run_tracy_nextest.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Run ShoopDaLoop's opt-in traced nextest subset against tracy-collector."""
+
+import argparse
+import json
+import os
+import re
+import resource
+import shutil
+import socket
+import struct
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def field(value):
+    data = value.encode()
+    return struct.pack("!H", len(data)) + data
+
+
+def take_field(data, offset):
+    size = struct.unpack_from("!H", data, offset)[0]
+    offset += 2
+    return data[offset:offset + size].decode(), offset + size
+
+
+def recv_exact(sock, size):
+    result = b""
+    while len(result) < size:
+        part = sock.recv(size - len(result))
+        if not part:
+            raise RuntimeError("truncated collector response")
+        result += part
+    return result
+
+
+class Collector:
+    def __init__(self, endpoint, token):
+        host, port = endpoint.rsplit(":", 1)
+        self.address = (host, int(port))
+        self.token = token
+
+    def request(self, kind, operation=b""):
+        payload = field(self.token) + operation
+        frame = b"TCOL" + struct.pack("!HHI", 1, kind, len(payload)) + payload
+        with socket.create_connection(self.address, timeout=10) as sock:
+            sock.settimeout(60)
+            sock.sendall(frame)
+            header = recv_exact(sock, 12)
+            data = recv_exact(sock, struct.unpack("!I", header[8:])[0])
+        status = struct.unpack_from("!H", data)[0]
+        message, offset = take_field(data, 2)
+        if status:
+            raise RuntimeError(f"collector request {kind} failed ({status}): {message}")
+        return data[offset:]
+
+    def acquire(self, run_id):
+        data = self.request(1, field(run_id))
+        return take_field(data, 0)[0]
+
+    def decide(self, session, save, source):
+        self.request(5, field(session) + struct.pack("!H", 1 if save else 2) + field(source))
+
+    def finalize(self, lease):
+        self.request(6, field(lease))
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def free_range(count=16):
+    for _ in range(100):
+        first = free_port()
+        sockets = []
+        try:
+            for port in range(first, first + count):
+                sock = socket.socket()
+                sock.bind(("127.0.0.1", port))
+                sockets.append(sock)
+            return first, first + count - 1
+        except OSError:
+            pass
+        finally:
+            for sock in sockets:
+                sock.close()
+    raise RuntimeError("no free collector port range")
+
+
+def wait_ready(process, ready):
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        if ready.exists():
+            return json.loads(ready.read_text())
+        if process.poll() is not None:
+            raise RuntimeError("collector exited before ready")
+        time.sleep(0.02)
+    raise RuntimeError("collector ready timeout")
+
+
+def junit_outcomes(path):
+    outcomes = {}
+    for case in ET.parse(path).getroot().iter("testcase"):
+        tags = {child.tag.rsplit("}", 1)[-1] for child in case}
+        name = case.attrib.get("name", "")
+        outcomes[name] = "failure" if tags & {"failure", "error"} else "success"
+    return outcomes
+
+
+def query_marker(query, trace, marker):
+    subprocess.run([str(query), "check", str(trace)], check=True)
+    subprocess.run([str(query), "range", str(trace)], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run([str(query), "info", str(trace)], check=True, stdout=subprocess.DEVNULL)
+    result = subprocess.run(
+        [str(query), "query", "--kind", "message", "--filter",
+         f"message.text=^{re.escape(marker)}$", "--count", str(trace)],
+        check=True, capture_output=True, text=True)
+    count = sum(json.loads(line)["count"] for line in result.stdout.splitlines() if line)
+    if count < 1:
+        raise RuntimeError(f"identity marker missing from {trace}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--collector", type=Path, required=True)
+    parser.add_argument("--query", type=Path, required=True)
+    parser.add_argument("--nextest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("artifacts/tracy-nextest"))
+    parser.add_argument("--expect-controlled-failures", action="store_true")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    output = (root / args.output).resolve()
+    shutil.rmtree(output, ignore_errors=True)
+    output.mkdir(parents=True)
+
+    baseline_start = time.monotonic()
+    baseline = subprocess.run(
+        ["cargo", "test", "--locked", "-p", "shoop_engine", "--test",
+         "tracy_collector_contract", "--", "--test-threads=1"], cwd=root)
+    baseline_seconds = time.monotonic() - baseline_start
+    if baseline.returncode:
+        raise RuntimeError("ordinary cargo test lane failed")
+
+    ready = output / "ready.json"
+    traces = output / "traces"
+    control_port = free_port()
+    first, last = free_range()
+    daemon_log = open(output / "collector.log", "w", encoding="utf-8")
+    daemon = subprocess.Popen(
+        [str(args.collector.resolve()), "--output-root", str(traces),
+         "--ready-file", str(ready), "--control-port", str(control_port),
+         "--data-port-first", str(first), "--data-port-last", str(last),
+         "--owner-timeout-ms", "60000", "--connect-timeout-ms", "15000"],
+        stdout=daemon_log, stderr=subprocess.STDOUT, text=True)
+    nextest_code = 1
+    try:
+        descriptor = wait_ready(daemon, ready)
+        token = Path(descriptor["secret_file"]).read_text().strip()
+        client = Collector(descriptor["endpoint"], token)
+        lease = client.acquire(descriptor["run_id"])
+        env = os.environ.copy()
+        env.update({
+            "SHOOP_TRACY_NEXTEST": "1",
+            "SHOOP_TRACY_DETAIL": "0",
+            "TRACY_COLLECTOR_ENDPOINT": descriptor["endpoint"],
+            "TRACY_COLLECTOR_TOKEN": token,
+            "TRACY_COLLECTOR_RUN_ID": descriptor["run_id"],
+            "RUST_BACKTRACE": "0",
+        })
+        traced_start = time.monotonic()
+        nextest = subprocess.run(
+            [str(args.nextest.resolve()), "nextest", "run", "--profile",
+             "tracy-collector", "--no-fail-fast", "-p", "shoop_engine",
+             "--test", "tracy_collector_contract"],
+            cwd=root, env=env, capture_output=True, text=True, timeout=180)
+        traced_seconds = time.monotonic() - traced_start
+        nextest_code = nextest.returncode
+        (output / "nextest.stdout.log").write_text(nextest.stdout)
+        (output / "nextest.stderr.log").write_text(nextest.stderr)
+        if nextest_code not in (100, 101):
+            raise RuntimeError(f"unexpected nextest status {nextest_code}")
+
+        junit = root / "target/nextest/tracy-collector/junit.xml"
+        if not junit.exists():
+            raise RuntimeError("nextest JUnit report missing")
+        shutil.copy2(junit, output / "junit.xml")
+        outcomes = junit_outcomes(junit)
+        # Allow Tracy network threads to observe abrupt exits before decisions.
+        time.sleep(0.5)
+        manifest = json.loads((traces / "manifest.json").read_text())
+        records = manifest["sessions"]
+        if len(records) != 4:
+            raise RuntimeError(f"expected four registered attempts, got {len(records)}")
+        for record in records:
+            outcome = outcomes.get(record["test_name"], "unknown")
+            client.decide(record["session_id"], outcome != "success", f"junit:{outcome}")
+        client.finalize(lease)
+        if daemon.wait(timeout=60) != 0:
+            raise RuntimeError("collector finalization failed")
+        daemon_log.flush()
+
+        manifest = json.loads((traces / "manifest.json").read_text())
+        records = manifest["sessions"]
+        passing = [r for r in records if r["test_name"].endswith("traced_passes")]
+        failures = [r for r in records if not r["test_name"].endswith("traced_passes")]
+        if len(passing) != 1 or passing[0]["state"] != "discarded" or passing[0]["output_name"]:
+            raise RuntimeError("passing trace was not discarded")
+        if len(failures) != 3 or any(r["state"] != "saved" for r in failures):
+            raise RuntimeError("failure/abort/timeout traces were not all saved")
+        if list(traces.glob("*.partial")):
+            raise RuntimeError("partial traces leaked")
+        for record in failures:
+            marker = (f"shoop-nextest:{record['test_name']}:attempt:{record['retry'] + 1}:"
+                      f"id:{record['attempt_id']}")
+            query_marker(args.query.resolve(), traces / record["output_name"], marker)
+
+        metrics = {
+            "baseline_wall_seconds": baseline_seconds,
+            "traced_wall_seconds": traced_seconds,
+            "wall_overhead_seconds": traced_seconds - baseline_seconds,
+            "peak_rss_kib": resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss,
+            "trace_count": len(list(traces.glob("*.tracy"))),
+            "trace_bytes": sum(path.stat().st_size for path in traces.glob("*.tracy")),
+            "nextest_status": nextest_code,
+            "traced_concurrency": 1,
+            "detail_tracing": False,
+        }
+        (output / "metrics.json").write_text(json.dumps(metrics, indent=2) + "\n")
+        print(json.dumps(metrics, indent=2))
+    finally:
+        if daemon.poll() is None:
+            daemon.kill()
+            daemon.wait()
+        daemon_log.close()
+
+    if not args.expect_controlled_failures:
+        raise SystemExit(nextest_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tracy_nextest.py
+++ b/scripts/run_tracy_nextest.py
@@ -173,7 +173,8 @@ def main():
         })
         traced_start = time.monotonic()
         nextest = subprocess.run(
-            [str(args.nextest.resolve()), "nextest", "run", "--profile",
+            [str(args.nextest.resolve()), "nextest", "run", "--config-file",
+             str(root / ".config/tracy-nextest.toml"), "--profile",
              "tracy-collector", "--no-fail-fast", "-p", "shoop_engine",
              "--test", "tracy_collector_contract"],
             cwd=root, env=env, capture_output=True, text=True, timeout=180)

--- a/src/rust/shoop_engine/tests/support/mod.rs
+++ b/src/rust/shoop_engine/tests/support/mod.rs
@@ -1,0 +1,124 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
+
+pub struct TraceAttempt {
+    client: tracy_client::Client,
+}
+
+impl TraceAttempt {
+    pub fn active(&self) -> bool {
+        let _ = &self.client;
+        true
+    }
+}
+
+fn field(out: &mut Vec<u8>, value: &str) {
+    let bytes = value.as_bytes();
+    assert!(bytes.len() <= 4096);
+    out.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn take_field(data: &[u8], offset: &mut usize) -> String {
+    let length = u16::from_be_bytes(data[*offset..*offset + 2].try_into().unwrap()) as usize;
+    *offset += 2;
+    let value = std::str::from_utf8(&data[*offset..*offset + length])
+        .unwrap()
+        .to_owned();
+    *offset += length;
+    value
+}
+
+fn request(kind: u16, operation: &[u8]) -> Vec<u8> {
+    let endpoint = std::env::var("TRACY_COLLECTOR_ENDPOINT").unwrap();
+    let token = std::env::var("TRACY_COLLECTOR_TOKEN").unwrap();
+    let mut payload = Vec::new();
+    field(&mut payload, &token);
+    payload.extend_from_slice(operation);
+    let mut frame = b"TCOL".to_vec();
+    frame.extend_from_slice(&1_u16.to_be_bytes());
+    frame.extend_from_slice(&kind.to_be_bytes());
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    let mut stream = TcpStream::connect(endpoint).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    stream.write_all(&frame).unwrap();
+    let mut header = [0_u8; 12];
+    stream.read_exact(&mut header).unwrap();
+    assert_eq!(&header[..4], b"TCOL");
+    let length = u32::from_be_bytes(header[8..12].try_into().unwrap()) as usize;
+    let mut response = vec![0; length];
+    stream.read_exact(&mut response).unwrap();
+    let status = u16::from_be_bytes(response[..2].try_into().unwrap());
+    let mut offset = 2;
+    let message = take_field(&response, &mut offset);
+    assert_eq!(status, 0, "collector error {status}: {message}");
+    response[offset..].to_vec()
+}
+
+/// Activates only in the dedicated nextest trace lane. Discovery and ordinary
+/// cargo tests never contact the collector or initialize Tracy.
+pub fn startup() -> Option<TraceAttempt> {
+    if std::env::var("SHOOP_TRACY_NEXTEST").as_deref() != Ok("1") {
+        return None;
+    }
+    let attempt_id = std::env::var("NEXTEST_ATTEMPT_ID").ok()?;
+    let run_id = std::env::var("TRACY_COLLECTOR_RUN_ID").unwrap();
+    let binary_id = std::env::var("NEXTEST_BINARY_ID").unwrap();
+    let test_name = std::env::var("NEXTEST_TEST_NAME").unwrap();
+    let attempt = std::env::var("NEXTEST_ATTEMPT")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(1);
+    let stress = format!(
+        "{}/{}",
+        std::env::var("NEXTEST_STRESS_CURRENT").unwrap_or_default(),
+        std::env::var("NEXTEST_STRESS_TOTAL").unwrap_or_default()
+    );
+    let mut registration = Vec::new();
+    field(&mut registration, &run_id);
+    field(&mut registration, &attempt_id);
+    field(&mut registration, &binary_id);
+    field(&mut registration, &test_name);
+    registration.extend_from_slice(&attempt.saturating_sub(1).to_be_bytes());
+    field(&mut registration, &stress);
+    let response = request(3, &registration);
+    let mut offset = 0;
+    let session_id = take_field(&response, &mut offset);
+    let port = u16::from_be_bytes(response[offset..offset + 2].try_into().unwrap());
+
+    std::env::set_var("TRACY_PORT", port.to_string());
+    let client = tracy_client::Client::start();
+    client.message("ShoopDaLoop collector startup", 0);
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let mut status = Vec::new();
+        field(&mut status, &session_id);
+        let response = request(4, &status);
+        let mut offset = 0;
+        let state = take_field(&response, &mut offset);
+        let handshake = take_field(&response, &mut offset);
+        if state == "capturing" {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "collector state={state}, handshake={handshake}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    shoop_tracing::set_tracing_enabled(true);
+    shoop_tracing::set_engine_detail_enabled(
+        std::env::var("SHOOP_TRACY_DETAIL").as_deref() == Ok("1"),
+    );
+    let marker = format!("shoop-nextest:{test_name}:attempt:{attempt}:id:{attempt_id}");
+    for _ in 0..50 {
+        client.message(&marker, 0);
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    Some(TraceAttempt { client })
+}

--- a/src/rust/shoop_engine/tests/tracy_collector_contract.rs
+++ b/src/rust/shoop_engine/tests/tracy_collector_contract.rs
@@ -1,0 +1,49 @@
+mod support;
+
+use shoop_engine::basic_loop::BasicLoop;
+use shoop_engine::loop_mode::LoopMode;
+use std::time::Duration;
+
+fn exercise_engine() {
+    let mut engine_loop = BasicLoop::default();
+    engine_loop.set_mode(LoopMode::Recording);
+    engine_loop.update_poi();
+    for _ in 0..8 {
+        let _span = shoop_tracing::realtime_span!("collector.fixture.engine_cycle");
+        engine_loop.process(64);
+    }
+    assert_eq!(engine_loop.length(), 512);
+}
+
+#[test]
+fn traced_passes() {
+    let _trace = support::startup();
+    exercise_engine();
+}
+
+#[test]
+fn traced_failure() {
+    let trace = support::startup();
+    exercise_engine();
+    if trace.as_ref().is_some_and(support::TraceAttempt::active) {
+        panic!("controlled traced failure");
+    }
+}
+
+#[test]
+fn traced_abort() {
+    let trace = support::startup();
+    exercise_engine();
+    if trace.as_ref().is_some_and(support::TraceAttempt::active) {
+        std::process::abort();
+    }
+}
+
+#[test]
+fn traced_timeout() {
+    let trace = support::startup();
+    exercise_engine();
+    if trace.as_ref().is_some_and(support::TraceAttempt::active) {
+        std::thread::sleep(Duration::from_secs(30));
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in in-process nextest startup hook that registers attempt identity before manually starting Tracy, while leaving ordinary cargo tests and discovery inert
- add a concurrency-one pass/panic/abort/timeout engine subset and a conservative JUnit adapter that saves only failures through `tracy-collector`
- validate every retained trace, upload only finalized failure evidence, and record traced/untraced wall time, RSS, and artifact sizes

## Verification
- `RUSTFLAGS='-D warnings' cargo test --locked -p shoop_engine --test tracy_collector_contract -- --test-threads=1`
- `cargo fmt --all -- --check`
- local traced adapter run against `tracy-query#1`: controlled pass discarded; panic, abort, and nextest timeout saved as three valid queryable captures; no partials

This pins the collector implementation commit from https://github.com/SanderVocke/tracy-query/pull/1 until the first collector release asset is available.
