### PR TITLE
Add reusable in-app Tracy captures

### DIFF
--- a/.agents/skills/tracy/SKILL.md
+++ b/.agents/skills/tracy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tracy
 description: Capture and investigate native ShoopDaLoop Tracy profiles, including GUI/application intent flow, engine control and graph work, realtime audio timing, Tiny Synth/FX processing, queues, scheduling, and state publication from .tracy files.
-compatibility: The native application emits Tracy 0.13.1-compatible captures through the tracy-extensions 0.5.0 embedded backend. Querying requires the matching static tracy-query 0.5.0 release binary.
+compatibility: The native application emits Tracy 0.13.1-compatible captures through the tracy-extensions 0.6.0 embedded backend. Querying requires the matching static tracy-query 0.6.0 release binary.
 ---
 
 # Debug ShoopDaLoop with Tracy
@@ -12,10 +12,10 @@ Use the versioned `tracy-query` skill distributed with `tracy-extensions` for co
 
 ## Obtain `tracy-query` and its skill
 
-Use the `tracy-extensions` v0.5.0 release and the matching tagged query skill:
+Use the `tracy-extensions` v0.6.0 release and the matching tagged query skill:
 
-- Release page: <https://github.com/SanderVocke/tracy-extensions/releases/tag/v0.5.0>
-- Query skill: <https://raw.githubusercontent.com/SanderVocke/tracy-extensions/v0.5.0/tracy-query/SKILL.md>
+- Release page: <https://github.com/SanderVocke/tracy-extensions/releases/tag/v0.6.0>
+- Query skill: <https://raw.githubusercontent.com/SanderVocke/tracy-extensions/v0.6.0/tracy-query/SKILL.md>
 
 Choose the static binary for the current platform:
 
@@ -33,13 +33,13 @@ TRACE_DIR=traces/investigation
 ASSET=tracy-query-linux-x86_64 # select for the current OS and architecture
 
 mkdir -p "$TRACE_DIR"
-gh release download v0.5.0 \
+gh release download v0.6.0 \
   --repo SanderVocke/tracy-extensions \
   --pattern "$ASSET" \
   --dir "$TRACE_DIR" \
   --clobber
 curl --fail --location \
-  https://raw.githubusercontent.com/SanderVocke/tracy-extensions/v0.5.0/tracy-query/SKILL.md \
+  https://raw.githubusercontent.com/SanderVocke/tracy-extensions/v0.6.0/tracy-query/SKILL.md \
   --output "$TRACE_DIR/tracy-query-SKILL.md"
 chmod +x "$TRACE_DIR/$ASSET"
 ```
@@ -91,7 +91,7 @@ gh run download "$RUN_ID" \
 find "traces/ci-$RUN_ID" -type f -name '*.tracy' -print
 ```
 
-Match the artifact's target, architecture, and profile to the failing job. Preserve the trace filename: it identifies the nextest binary, test, attempt, and unique attempt digest. Then obtain the matching v0.5.0 `tracy-query` binary as described above, validate each trace with `check`, `range`, `info`, and `sources`, and follow the investigation workflow below. Detailed `engine.rt.*` zones may be absent when the failing test never starts or advances an engine even though the CI tracing gate is enabled.
+Match the artifact's target, architecture, and profile to the failing job. Preserve the trace filename: it identifies the nextest binary, test, attempt, and unique attempt digest. Then obtain the matching v0.6.0 `tracy-query` binary as described above, validate each trace with `check`, `range`, `info`, and `sources`, and follow the investigation workflow below. Detailed `engine.rt.*` zones may be absent when the failing test never starts or advances an engine even though the CI tracing gate is enabled.
 
 For general workflow status and log investigation before trace analysis, read `.agents/info/ci-debug.md`.
 
@@ -111,6 +111,8 @@ The application executable has two tracing options:
 ```
 
 Tracing uses the embedded in-process backend. There is no live TCP profiler mode, external `tracy-capture` executable, capture-tool environment variable, or CLI output-directory option. The output directory is `traces` relative to the application's working directory.
+
+Tracing can also be started after launch from **Settings > Developer**, optionally with detailed engine events. While active, the bottom bar reports event-storage memory usage and offers **Save** and **Discard**. Either action stops the current capture; another capture can then be started in the same process. Application captures begin after runtime initialization so that long-lived worker guards predate reusable capture cycles.
 
 The audio backend is selected through persisted application settings, not a `--backend` argument. Reproduce with the configured JACK, CPAL+midir, or dummy backend that matters to the issue.
 
@@ -150,8 +152,6 @@ ShoopDaLoop uses fixed, bounded zone names. User labels, paths, processor state,
 
 Expected native GUI zones include:
 
-- `app.egui.run`: native eframe lifetime.
-- `frontend.egui.initialize`: settings, widget, backend, and runtime initialization.
 - `frontend.egui.update`: one top-level GUI update.
 - `frontend.egui.frame`: widget rendering, with revision and bounded state counts.
 - `frontend.egui.tracks` and `frontend.egui.track`: track collection and per-track rendering.
@@ -161,7 +161,7 @@ Expected native GUI zones include:
 - `frontend.app.intent_handle`: actor-side handling with the same `intent_id` and intent kind.
 - `frontend.app.intent_apply`: model mutation, revision, and success/error outcome.
 - `frontend.app.update`, `frontend.app.backend_advance`, `frontend.app.backend_snapshot_apply`, and `frontend.app.snapshot_publish`: polling, state application, and publication.
-- `frontend.app.runtime_start`, `frontend.app.runtime_shutdown`, and `worker.application`: actor lifecycle.
+- `frontend.app.runtime_shutdown`: actor shutdown. Startup and long-lived worker zones normally predate application captures.
 
 A UI intent normally nests `frontend.app.intent_dispatch` inside `frontend.egui.intent_dispatch` on the GUI thread. Join only the app dispatch zone to `frontend.app.intent_handle` by `intent_id`; the egui zone itself does not carry that ID. `frontend.app.intent_apply` then contains the resulting backend and `engine.control.*` work when it is synchronous.
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -178,7 +178,7 @@ jobs:
             *) exit 1 ;;
           esac
           root="$RUNNER_TEMP/tracy-embedded-native"
-          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.5.0
+          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0
           rm -rf "$root"
           mkdir -p "$root/download" "$root/extracted"
           curl -L --fail --retry 3 "$base/$asset" -o "$root/download/$asset"
@@ -213,7 +213,7 @@ jobs:
           $Root = Join-Path $env:RUNNER_TEMP "tracy-embedded-native"
           $Download = Join-Path $Root "download"
           $Extracted = Join-Path $Root "extracted"
-          $Base = "https://github.com/SanderVocke/tracy-extensions/releases/download/v0.5.0"
+          $Base = "https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0"
           Remove-Item $Root -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force $Download, $Extracted | Out-Null
           curl.exe --fail --location --retry 3 "$Base/$Asset" --output (Join-Path $Download $Asset)
@@ -662,7 +662,7 @@ jobs:
           ! find "$TRACY_NEXTEST_OUTPUT_DIR" -name '*.partial' -print -quit | grep -q .
           curl -L --fail --retry 3 \
             -o "$RUNNER_TEMP/tracy-query" \
-            https://github.com/SanderVocke/tracy-extensions/releases/download/v0.5.0/tracy-query-linux-x86_64
+            https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0/tracy-query-linux-x86_64
           chmod +x "$RUNNER_TEMP/tracy-query"
           "$RUNNER_TEMP/tracy-query" check "${traces[0]}"
           "$RUNNER_TEMP/tracy-query" range "${traces[0]}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,15 +4544,15 @@ dependencies = [
 [[package]]
 name = "tracy-client-sys"
 version = "0.28.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.5.0#e5e49ffa0f212690eeb8e35fddc603b50978a8e1"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
 dependencies = [
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "tracy-nextest-capture"
-version = "0.5.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.5.0#e5e49ffa0f212690eeb8e35fddc603b50978a8e1"
+version = "0.6.0"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
 dependencies = [
  "sha2 0.10.9",
  "tracy-client",
@@ -4562,8 +4562,8 @@ dependencies = [
 
 [[package]]
 name = "tracy-nextest-capture-macros"
-version = "0.5.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.5.0#e5e49ffa0f212690eeb8e35fddc603b50978a8e1"
+version = "0.6.0"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "=0.11.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client-sys = { version = "=0.28.0", default-features = false, features = ["embedded-capture"] }
-tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.5.0" }
+tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.6.0" }
 shoop_tracing = { path = "src/rust/shoop_tracing", default-features = false }
 tinyviolin = "=0.3.0"
 
 [patch.crates-io]
-tracy-client-sys = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.5.0" }
+tracy-client-sys = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.6.0" }
 
 [profile.release-with-debug]
 inherits = "release"

--- a/src/rust/shoop_common/src/tracing_capture.rs
+++ b/src/rust/shoop_common/src/tracing_capture.rs
@@ -32,6 +32,39 @@ pub enum CaptureError {
     MissingOutput(PathBuf),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureDisposition {
+    Save,
+    Discard,
+}
+
+impl CaptureDisposition {
+    const fn as_ffi(self) -> i32 {
+        match self {
+            Self::Save => tracy_client_sys::TRACY_EMBEDDED_CAPTURE_SAVE,
+            Self::Discard => tracy_client_sys::TRACY_EMBEDDED_CAPTURE_DISCARD,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CaptureStatus {
+    pub active: bool,
+    pub event_storage_bytes: u64,
+}
+
+impl CaptureStatus {
+    pub fn current() -> Self {
+        let state = unsafe { tracy_client_sys::___tracy_embedded_capture_get_state() };
+        let event_storage_bytes =
+            unsafe { tracy_client_sys::___tracy_embedded_capture_get_event_storage_bytes() };
+        Self {
+            active: state == tracy_client_sys::TRACY_EMBEDDED_CAPTURE_CAPTURING,
+            event_storage_bytes: event_storage_bytes.max(0) as u64,
+        }
+    }
+}
+
 pub struct CaptureSession {
     path: PathBuf,
     finished: bool,
@@ -66,24 +99,7 @@ impl CaptureSession {
     }
 
     pub fn wait_until_capturing(&self) -> Result<(), CaptureError> {
-        let deadline = Instant::now() + START_TIMEOUT;
-        loop {
-            let state = unsafe { tracy_client_sys::___tracy_embedded_capture_get_state() };
-            if state == tracy_client_sys::TRACY_EMBEDDED_CAPTURE_CAPTURING {
-                info!("Embedded Tracy capture started: {}", self.path.display());
-                return Ok(());
-            }
-            if state == tracy_client_sys::TRACY_EMBEDDED_CAPTURE_FAILED {
-                return Err(embedded_error(state));
-            }
-            if Instant::now() >= deadline {
-                return Err(CaptureError::StartTimeout {
-                    timeout: START_TIMEOUT,
-                    state,
-                });
-            }
-            std::thread::sleep(POLL_INTERVAL);
-        }
+        wait_until_capturing(&self.path)
     }
 
     pub fn finish(&mut self) -> Result<(), CaptureError> {
@@ -126,6 +142,85 @@ impl CaptureSession {
     }
 }
 
+pub struct ReusableCaptureSession {
+    path: PathBuf,
+    stopped: bool,
+}
+
+impl ReusableCaptureSession {
+    pub fn start(output_dir: &Path, label: &str) -> Result<Self, CaptureError> {
+        verify_abi()?;
+        std::fs::create_dir_all(output_dir)
+            .map_err(|source| io_error("create capture output directory", output_dir, source))?;
+        let output_dir = output_dir.canonicalize().map_err(|source| {
+            io_error("canonicalize capture output directory", output_dir, source)
+        })?;
+        let path = next_capture_path(&output_dir, label);
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| CaptureError::NonUtf8Path(path.clone()))?;
+        let status = unsafe {
+            tracy_client_sys::___tracy_embedded_capture_start(
+                path_str.as_ptr().cast(),
+                path_str.len(),
+                CHANNEL_CAPACITY,
+                WORKER_MEMORY_LIMIT,
+            )
+        };
+        check_status(status)?;
+        info!(
+            "Starting reusable embedded Tracy capture {}",
+            path.display()
+        );
+        Ok(Self {
+            path,
+            stopped: false,
+        })
+    }
+
+    pub fn wait_until_capturing(&self) -> Result<(), CaptureError> {
+        wait_until_capturing(&self.path)
+    }
+
+    pub fn stop(&mut self, disposition: CaptureDisposition) -> Result<(), CaptureError> {
+        if self.stopped {
+            return Ok(());
+        }
+        let status = unsafe {
+            tracy_client_sys::___tracy_embedded_capture_stop_with_disposition(disposition.as_ffi())
+        };
+        check_status(status)?;
+        self.stopped = true;
+
+        if disposition == CaptureDisposition::Save {
+            let metadata = self
+                .path
+                .metadata()
+                .map_err(|_| CaptureError::MissingOutput(self.path.clone()))?;
+            if metadata.len() == 0 {
+                return Err(CaptureError::MissingOutput(self.path.clone()));
+            }
+            info!(
+                "Finalized reusable embedded Tracy capture {} ({} bytes)",
+                self.path.display(),
+                metadata.len()
+            );
+        } else {
+            info!("Discarded reusable embedded Tracy capture");
+        }
+        Ok(())
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub fn shutdown_reusable_profiler() -> Result<(), CaptureError> {
+    let status = unsafe { tracy_client_sys::___tracy_embedded_capture_shutdown() };
+    check_status(status)
+}
+
 fn verify_abi() -> Result<(), CaptureError> {
     let actual = unsafe { tracy_client_sys::___tracy_embedded_capture_abi_version() };
     let expected = tracy_client_sys::TRACY_EMBEDDED_CAPTURE_ABI_VERSION;
@@ -133,6 +228,27 @@ fn verify_abi() -> Result<(), CaptureError> {
         Ok(())
     } else {
         Err(CaptureError::AbiMismatch { expected, actual })
+    }
+}
+
+fn wait_until_capturing(path: &Path) -> Result<(), CaptureError> {
+    let deadline = Instant::now() + START_TIMEOUT;
+    loop {
+        let state = unsafe { tracy_client_sys::___tracy_embedded_capture_get_state() };
+        if state == tracy_client_sys::TRACY_EMBEDDED_CAPTURE_CAPTURING {
+            info!("Embedded Tracy capture started: {}", path.display());
+            return Ok(());
+        }
+        if state == tracy_client_sys::TRACY_EMBEDDED_CAPTURE_FAILED {
+            return Err(embedded_error(state));
+        }
+        if Instant::now() >= deadline {
+            return Err(CaptureError::StartTimeout {
+                timeout: START_TIMEOUT,
+                state,
+            });
+        }
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 

--- a/src/rust/shoop_common/tests/embedded_capture_repeated.rs
+++ b/src/rust/shoop_common/tests/embedded_capture_repeated.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+use shoop_common::tracing_capture::{
+    shutdown_reusable_profiler, CaptureDisposition, CaptureStatus, ReusableCaptureSession,
+};
+
+#[test]
+fn embedded_capture_supports_save_then_discard() {
+    let temporary_dir = std::env::var_os("SHOOP_TRACY_TEST_OUTPUT_DIR")
+        .map(PathBuf::from)
+        .map(TemporaryOutput::External)
+        .unwrap_or_else(|| {
+            TemporaryOutput::Owned(tempfile::tempdir().expect("create capture output directory"))
+        });
+    let output_dir = temporary_dir.path();
+    std::fs::create_dir_all(output_dir).expect("create external capture output directory");
+
+    let mut first = ReusableCaptureSession::start(output_dir, "repeated-save")
+        .expect("start first reusable capture");
+    let client = tracy_client::Client::start();
+    first
+        .wait_until_capturing()
+        .expect("wait for first reusable capture");
+    let first_status = CaptureStatus::current();
+    assert!(first_status.active);
+    assert!(first_status.event_storage_bytes > 0);
+    client.message("shoop.embedded_capture.repeated.first", 0);
+    first
+        .stop(CaptureDisposition::Save)
+        .expect("save first reusable capture");
+    let idle_status = CaptureStatus::current();
+    assert!(!idle_status.active);
+    assert_eq!(idle_status.event_storage_bytes, 0);
+    assert!(first.path().metadata().unwrap().len() > 0);
+
+    let mut second = ReusableCaptureSession::start(output_dir, "repeated-discard")
+        .expect("start second reusable capture");
+    second
+        .wait_until_capturing()
+        .expect("wait for second reusable capture");
+    let second_status = CaptureStatus::current();
+    assert!(second_status.active);
+    assert!(second_status.event_storage_bytes > 0);
+    client.message("shoop.embedded_capture.repeated.second", 0);
+    second
+        .stop(CaptureDisposition::Discard)
+        .expect("discard second reusable capture");
+    let idle_status = CaptureStatus::current();
+    assert!(!idle_status.active);
+    assert_eq!(idle_status.event_storage_bytes, 0);
+    assert!(!second.path().exists());
+
+    shutdown_reusable_profiler().expect("shut down reusable profiler");
+}
+
+enum TemporaryOutput {
+    External(PathBuf),
+    Owned(tempfile::TempDir),
+}
+
+impl TemporaryOutput {
+    fn path(&self) -> &Path {
+        match self {
+            Self::External(path) => path,
+            Self::Owned(directory) => directory.path(),
+        }
+    }
+}

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -5,8 +5,8 @@ use crate::{
     is_ephemeral_script_version, script_dialogs::ScriptDialogs, AppAction, AppState,
     AudioDriverConfig, AudioDriverKind, ConnectionDialog, ConnectionScope, CpalAudioDriverConfig,
     DetailsPane, DummyAudioDriverConfig, GlobalControls, JackAudioDriverConfig, PianoPane,
-    SettingsAction, SettingsDialog, TrackProcessorDescriptor, TrackProcessorTypeId, TrackSpec,
-    TrackSpecTopology, TrackWidget, TracksWidget,
+    SettingsAction, SettingsDialog, TracingStatus, TracingStopped, TrackProcessorDescriptor,
+    TrackProcessorTypeId, TrackSpec, TrackSpecTopology, TrackWidget, TracksWidget,
 };
 use shoop_settings::{
     SettingDefinition, SettingEditor, SettingEffect, SettingKey, SettingsDraft, SettingsRegistry,
@@ -517,8 +517,14 @@ pub struct AppWidget {
     io_channel_selections: BTreeMap<crate::TaskId, Vec<u32>>,
     pressed_script_keys: BTreeMap<egui::Key, (i64, i64)>,
     pending_ephemeral_scripts: VecDeque<PendingEphemeralScript>,
+    tracing_status: TracingStatus,
+    tracing_stopped: Option<TracingStopped>,
     last_callback_count: u64,
     callbacks_active_until: f64,
+    #[cfg(test)]
+    tracing_save_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    tracing_discard_rect: Option<egui::Rect>,
     #[cfg(test)]
     ephemeral_script_accept_rect: Option<egui::Rect>,
     #[cfg(test)]
@@ -574,8 +580,14 @@ impl AppWidget {
             io_channel_selections: BTreeMap::new(),
             pressed_script_keys: BTreeMap::new(),
             pending_ephemeral_scripts: VecDeque::new(),
+            tracing_status: TracingStatus::default(),
+            tracing_stopped: None,
             last_callback_count: 0,
             callbacks_active_until: 0.0,
+            #[cfg(test)]
+            tracing_save_rect: None,
+            #[cfg(test)]
+            tracing_discard_rect: None,
             #[cfg(test)]
             ephemeral_script_accept_rect: None,
             #[cfg(test)]
@@ -612,6 +624,15 @@ impl AppWidget {
 
     pub fn set_click_track_preview_available(&mut self, available: bool) {
         self.click_track.set_preview_available(available);
+    }
+
+    pub fn set_tracing_status(&mut self, status: TracingStatus) {
+        self.tracing_status = status;
+        self.settings.set_tracing_status(status);
+    }
+
+    pub fn notify_tracing_stopped(&mut self, stopped: TracingStopped) {
+        self.tracing_stopped = Some(stopped);
     }
 
     pub fn add_user_script_path(&mut self, path: String) -> Result<(), &'static str> {
@@ -718,7 +739,7 @@ impl AppWidget {
                         }
                     }
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        self.show_bottom_status(ui, state, &mut actions)
+                        self.show_bottom_status(ui, state, &mut actions, &mut settings_actions)
                     });
                 });
             });
@@ -864,6 +885,7 @@ impl AppWidget {
         actions.extend(settings_response.app_actions);
         settings_actions.extend(settings_response.settings_actions);
         self.show_ephemeral_script_confirmation(ui.ctx(), state, &mut actions);
+        self.show_tracing_stopped(ui.ctx());
         if !actions.is_empty() || !settings_actions.is_empty() {
             tracing::debug!(
                 target: "Frontend.Egui",
@@ -1562,6 +1584,7 @@ impl AppWidget {
         ui: &mut egui::Ui,
         state: &AppState,
         actions: &mut Vec<AppAction>,
+        settings_actions: &mut Vec<SettingsAction>,
     ) {
         #[cfg(test)]
         {
@@ -1604,6 +1627,64 @@ impl AppWidget {
             state.status.buffer_size
         ));
         self.show_backend_status(ui, state);
+        if self.tracing_status.active {
+            ui.separator();
+            ui.horizontal(|ui| {
+                ui.label(format!(
+                    "Tracing active ({})",
+                    format_memory_usage(self.tracing_status.memory_usage_bytes)
+                ));
+                let save = ui.small_button("Save");
+                let discard = ui.small_button("Discard");
+                #[cfg(test)]
+                {
+                    self.tracing_save_rect = Some(save.rect);
+                    self.tracing_discard_rect = Some(discard.rect);
+                }
+                if save.clicked() {
+                    settings_actions.push(SettingsAction::StopTracing { save: true });
+                }
+                if discard.clicked() {
+                    settings_actions.push(SettingsAction::StopTracing { save: false });
+                }
+            });
+        } else {
+            #[cfg(test)]
+            {
+                self.tracing_save_rect = None;
+                self.tracing_discard_rect = None;
+            }
+        }
+    }
+
+    fn show_tracing_stopped(&mut self, context: &egui::Context) {
+        let Some(stopped) = self.tracing_stopped.clone() else {
+            return;
+        };
+        let mut open = true;
+        let mut acknowledged = false;
+        egui::Window::new("Tracing stopped")
+            .id(egui::Id::new("tracing_stopped"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .show(context, |ui| {
+                match &stopped {
+                    TracingStopped::Saved(path) => {
+                        ui.label("The trace was stopped and saved to:");
+                        ui.monospace(path);
+                    }
+                    TracingStopped::Discarded => {
+                        ui.label("The trace was stopped and discarded.");
+                    }
+                }
+                if ui.button("OK").clicked() {
+                    acknowledged = true;
+                }
+            });
+        if acknowledged || !open {
+            self.tracing_stopped = None;
+        }
     }
 
     fn show_backend_status(&mut self, ui: &mut egui::Ui, state: &AppState) {
@@ -1708,6 +1789,21 @@ impl BackendHealth {
     }
 }
 
+fn format_memory_usage(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
 fn backend_health(driver: crate::AudioDriverState, callbacks_active: bool) -> BackendHealth {
     use crate::AudioDriverState;
     match driver {
@@ -1809,6 +1905,70 @@ mod tests {
             backend_health(crate::AudioDriverState::Failed, false),
             BackendHealth::Failed
         );
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn tracing_memory_usage_uses_readable_binary_units() {
+        assert_eq!(format_memory_usage(0), "0 B");
+        assert_eq!(format_memory_usage(1536), "1.5 KiB");
+        assert_eq!(format_memory_usage(3 * 1024 * 1024), "3.0 MiB");
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn active_tracing_status_offers_save_action() {
+        let context = egui::Context::default();
+        let mut widget = AppWidget::default();
+        widget.set_tracing_status(TracingStatus {
+            available: true,
+            active: true,
+            memory_usage_bytes: 3 * 1024 * 1024,
+        });
+        let state = AppState::default();
+        let frame = |widget: &mut AppWidget, events: Vec<egui::Event>| {
+            let mut settings_actions = Vec::new();
+            let _ = context.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(1000.0, 100.0),
+                    )),
+                    events,
+                    ..Default::default()
+                },
+                |ui| widget.show_bottom_status(ui, &state, &mut Vec::new(), &mut settings_actions),
+            );
+            settings_actions
+        };
+
+        frame(&mut widget, Vec::new());
+        let save = widget.tracing_save_rect.unwrap().center();
+        frame(
+            &mut widget,
+            vec![
+                egui::Event::PointerMoved(save),
+                egui::Event::PointerButton {
+                    pos: save,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        let actions = frame(
+            &mut widget,
+            vec![
+                egui::Event::PointerMoved(save),
+                egui::Event::PointerButton {
+                    pos: save,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        assert!(actions
+            .iter()
+            .any(|action| matches!(action, SettingsAction::StopTracing { save: true })));
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoop_egui/src/lib.rs
+++ b/src/rust/shoop_egui/src/lib.rs
@@ -42,7 +42,9 @@ pub use global_controls::GlobalControls;
 pub use loop_widget::{LoopWidget, LoopWidgetResponse};
 pub use midi_sequence_widget::MidiSequenceWidget;
 pub use piano_pane::{c_label, is_black, PianoLayout, PianoPane, MIDDLE_C, MIDI_NOTE_COUNT};
-pub use settings_dialog::{SettingsAction, SettingsDialog, SettingsDialogResponse};
+pub use settings_dialog::{
+    SettingsAction, SettingsDialog, SettingsDialogResponse, TracingStatus, TracingStopped,
+};
 pub use shoop_app_api::*;
 pub use shoop_settings::*;
 pub use track_controls::TrackControls;

--- a/src/rust/shoop_egui/src/settings_dialog.rs
+++ b/src/rust/shoop_egui/src/settings_dialog.rs
@@ -22,6 +22,19 @@ use crate::{
     APC_MINI_SCRIPT_ENABLED, KEYBOARD_SCRIPT_ENABLED, UI_SCALE_FACTOR, USER_SCRIPTS,
 };
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TracingStatus {
+    pub available: bool,
+    pub active: bool,
+    pub memory_usage_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TracingStopped {
+    Saved(String),
+    Discarded,
+}
+
 #[derive(Clone, Debug)]
 pub enum SettingsAction {
     Save(SettingsDraft),
@@ -39,6 +52,12 @@ pub enum SettingsAction {
     RequestReloadUserScript {
         script_id: ScriptId,
     },
+    StartTracing {
+        engine_detail: bool,
+    },
+    StopTracing {
+        save: bool,
+    },
 }
 
 impl SettingsAction {
@@ -52,6 +71,9 @@ impl SettingsAction {
             Self::RequestAddUserScript => "settings.add_user_script",
             Self::RequestEphemeralScriptPicker => "settings.pick_ephemeral_script",
             Self::RequestReloadUserScript { .. } => "settings.reload_user_script",
+            Self::StartTracing { .. } => "developer.tracing.start",
+            Self::StopTracing { save: true } => "developer.tracing.save",
+            Self::StopTracing { save: false } => "developer.tracing.discard",
         }
     }
 }
@@ -73,6 +95,10 @@ pub struct SettingsDialog {
     script_documentation_windows: BTreeSet<ScriptId>,
     script_status_windows: BTreeSet<ScriptId>,
     markdown_cache: CommonMarkCache,
+    tracing_status: TracingStatus,
+    tracing_engine_detail: bool,
+    #[cfg(test)]
+    tracing_start_rect: Option<egui::Rect>,
     #[cfg(test)]
     setting_card_rects: Vec<egui::Rect>,
     #[cfg(test)]
@@ -108,6 +134,10 @@ impl SettingsDialog {
             script_documentation_windows: BTreeSet::new(),
             script_status_windows: BTreeSet::new(),
             markdown_cache: CommonMarkCache::default(),
+            tracing_status: TracingStatus::default(),
+            tracing_engine_detail: false,
+            #[cfg(test)]
+            tracing_start_rect: None,
             #[cfg(test)]
             setting_card_rects: Vec::new(),
             #[cfg(test)]
@@ -139,6 +169,10 @@ impl SettingsDialog {
 
     pub const fn is_open(&self) -> bool {
         self.open
+    }
+
+    pub fn set_tracing_status(&mut self, status: TracingStatus) {
+        self.tracing_status = status;
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -274,6 +308,8 @@ impl SettingsDialog {
                                                     script_paths,
                                                     &mut response,
                                                 );
+                                            } else if active_category == "Developer" {
+                                                self.show_developer(ui, &mut response);
                                             } else {
                                                 self.show_definitions(ui, &active_category);
                                             }
@@ -349,6 +385,9 @@ impl SettingsDialog {
         if !categories.iter().any(|category| category == "Audio") {
             categories.insert(0, "Audio".to_owned());
         }
+        if !categories.iter().any(|category| category == "Developer") {
+            categories.push("Developer".to_owned());
+        }
         categories
     }
 
@@ -408,6 +447,40 @@ impl SettingsDialog {
         }
         for diagnostic in state.diagnostics.iter() {
             ui.colored_label(colors::WARNING, &diagnostic.message);
+        }
+    }
+
+    fn show_developer(&mut self, ui: &mut egui::Ui, response: &mut SettingsDialogResponse) {
+        ui.label(
+            "Capture performance data or investigate UI/audio bugs. Tracing can be stopped again, but capturing may degrade performance.",
+        );
+        ui.add_space(8.0);
+        ui.checkbox(
+            &mut self.tracing_engine_detail,
+            "include detailed engine events",
+        );
+        let start = ui.add_enabled(
+            self.tracing_status.available && !self.tracing_status.active,
+            egui::Button::new("Start tracing"),
+        );
+        #[cfg(test)]
+        {
+            self.tracing_start_rect = Some(start.rect);
+        }
+        if start.clicked() {
+            response
+                .settings_actions
+                .push(SettingsAction::StartTracing {
+                    engine_detail: self.tracing_engine_detail,
+                });
+        }
+        if self.tracing_status.active {
+            ui.colored_label(colors::WARNING, "Tracing is already active");
+        } else if !self.tracing_status.available {
+            ui.colored_label(
+                colors::MUTED_FOREGROUND,
+                "Tracing is unavailable in this build.",
+            );
         }
     }
 
@@ -1423,7 +1496,71 @@ mod tests {
             assert!(!output.shapes.is_empty());
             assert!(dialog.is_open());
         }
-        assert_eq!(dialog.categories(), ["Other", "Track defaults"]);
+        assert_eq!(
+            dialog.categories(),
+            ["Other", "Track defaults", "Developer"]
+        );
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn developer_category_starts_tracing_with_engine_detail() {
+        let (registry, _) = fixture();
+        let context = egui::Context::default();
+        let mut dialog = SettingsDialog::new(registry);
+        dialog.set_tracing_status(TracingStatus {
+            available: true,
+            active: false,
+            memory_usage_bytes: 0,
+        });
+        dialog.tracing_engine_detail = true;
+        let frame = |dialog: &mut SettingsDialog, events: Vec<egui::Event>| {
+            let mut response = SettingsDialogResponse::default();
+            let _ = context.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(500.0, 300.0),
+                    )),
+                    events,
+                    ..Default::default()
+                },
+                |ui| dialog.show_developer(ui, &mut response),
+            );
+            response
+        };
+
+        frame(&mut dialog, Vec::new());
+        let start = dialog.tracing_start_rect.unwrap().center();
+        frame(
+            &mut dialog,
+            vec![
+                egui::Event::PointerMoved(start),
+                egui::Event::PointerButton {
+                    pos: start,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        let response = frame(
+            &mut dialog,
+            vec![
+                egui::Event::PointerMoved(start),
+                egui::Event::PointerButton {
+                    pos: start,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        assert!(response.settings_actions.iter().any(|action| matches!(
+            action,
+            SettingsAction::StartTracing {
+                engine_detail: true
+            }
+        )));
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -13,7 +13,10 @@ use clap::Parser;
 use std::{
     io::Write,
     path::Path,
-    sync::mpsc::{self, Receiver, Sender},
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        Arc, Mutex,
+    },
     time::Instant,
 };
 #[cfg(target_arch = "wasm32")]
@@ -37,6 +40,8 @@ use shoop_egui::{
     register_settings, AppIntent, AppSnapshot, AppWidget, ScriptKind, SettingsAction,
     SettingsRegistryBuilder, UI_SCALE_FACTOR,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use shoop_egui::{TracingStatus, TracingStopped};
 
 #[cfg(target_arch = "wasm32")]
 use shoop_app::CooperativeApplicationRuntime;
@@ -97,42 +102,119 @@ struct NativeCli {
 
 #[cfg(not(target_arch = "wasm32"))]
 struct NativeTracing {
-    capture: Option<shoop_common::tracing_capture::CaptureSession>,
+    capture: Option<shoop_common::tracing_capture::ReusableCaptureSession>,
+    start_on_app_init: Option<bool>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl NativeTracing {
-    fn start(cli: &NativeCli) -> anyhow::Result<Self> {
-        shoop_common::tracing_helpers::set_tracing_enabled(cli.tracing);
-        shoop_common::tracing_helpers::set_engine_detail_enabled(cli.tracing_engine_detail);
-        let capture = cli
-            .tracing
-            .then(|| {
-                shoop_common::tracing_capture::CaptureSession::configure(
-                    Path::new("traces"),
-                    "application",
-                )
-            })
-            .transpose()?;
+    fn initialize(cli: &NativeCli) -> anyhow::Result<Self> {
+        use shoop_common::tracing_capture::{CaptureDisposition, ReusableCaptureSession};
+
+        shoop_common::tracing_helpers::set_engine_detail_enabled(false);
+        shoop_common::tracing_helpers::set_tracing_enabled(true);
+        shoop_common::tracing_helpers::set_tracing_output_enabled(true);
+        let mut bootstrap =
+            ReusableCaptureSession::start(&std::env::temp_dir(), "shoopdaloop-initialization")?;
         shoop_common::init()?;
-        if let Some(capture) = &capture {
-            capture.wait_until_capturing()?;
-        }
-        tracing::info!(
-            target: "Frontend.Egui",
-            capture = cli.tracing,
-            engine_detail = cli.tracing_engine_detail,
-            "frontend.egui.tracing_started"
-        );
-        Ok(Self { capture })
+        bootstrap.wait_until_capturing()?;
+        shoop_common::tracing_helpers::set_tracing_output_enabled(false);
+        shoop_common::tracing_helpers::set_tracing_enabled(false);
+        bootstrap.stop(CaptureDisposition::Discard)?;
+        Ok(Self {
+            capture: None,
+            start_on_app_init: cli.tracing.then_some(cli.tracing_engine_detail),
+        })
     }
 
-    fn shutdown(&mut self) -> anyhow::Result<()> {
-        if let Some(mut capture) = self.capture.take() {
-            capture.finish()?;
+    fn start_requested_capture(&mut self) -> anyhow::Result<()> {
+        if let Some(engine_detail) = self.start_on_app_init.take() {
+            self.start_capture(engine_detail)?;
         }
         Ok(())
     }
+
+    fn start_capture(&mut self, engine_detail: bool) -> anyhow::Result<()> {
+        if self.capture.is_some() {
+            return Ok(());
+        }
+        let capture = shoop_common::tracing_capture::ReusableCaptureSession::start(
+            Path::new("traces"),
+            "application",
+        )?;
+        capture.wait_until_capturing()?;
+        shoop_common::tracing_helpers::set_engine_detail_enabled(engine_detail);
+        shoop_common::tracing_helpers::set_tracing_output_enabled(true);
+        shoop_common::tracing_helpers::set_tracing_enabled(true);
+        tracing::info!(
+            target: "Frontend.Egui",
+            capture = true,
+            engine_detail,
+            "frontend.egui.tracing_started"
+        );
+        self.capture = Some(capture);
+        Ok(())
+    }
+
+    fn quiesce_capture(&self) -> anyhow::Result<()> {
+        if self.capture.is_none() {
+            anyhow::bail!("tracing is not active");
+        }
+        shoop_common::tracing_helpers::set_tracing_output_enabled(false);
+        shoop_common::tracing_helpers::set_tracing_enabled(false);
+        Ok(())
+    }
+
+    fn stop_capture(&mut self, save: bool) -> anyhow::Result<TracingStopped> {
+        use shoop_common::tracing_capture::CaptureDisposition;
+
+        let Some(capture) = self.capture.as_mut() else {
+            anyhow::bail!("tracing is not active");
+        };
+        shoop_common::tracing_helpers::set_engine_detail_enabled(false);
+        let disposition = if save {
+            CaptureDisposition::Save
+        } else {
+            CaptureDisposition::Discard
+        };
+        capture.stop(disposition)?;
+        let stopped = if save {
+            TracingStopped::Saved(capture.path().display().to_string())
+        } else {
+            TracingStopped::Discarded
+        };
+        self.capture = None;
+        Ok(stopped)
+    }
+
+    fn status(&self) -> TracingStatus {
+        let status = shoop_common::tracing_capture::CaptureStatus::current();
+        TracingStatus {
+            available: true,
+            active: status.active,
+            memory_usage_bytes: status.event_storage_bytes,
+        }
+    }
+
+    fn shutdown(&mut self) -> anyhow::Result<()> {
+        if self.capture.is_some() {
+            self.quiesce_capture()?;
+            self.stop_capture(true)?;
+        }
+        shoop_common::tracing_capture::shutdown_reusable_profiler()?;
+        Ok(())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type SharedNativeTracing = Arc<Mutex<NativeTracing>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy)]
+enum PendingTracingAction {
+    Start { engine_detail: bool },
+    Stop { save: bool },
+    FinishStop { save: bool },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -156,6 +238,10 @@ struct UnifiedApp {
     settings: SettingsManager,
     #[cfg(not(target_arch = "wasm32"))]
     pending_audio_settings: Option<PendingAudioSettings>,
+    #[cfg(not(target_arch = "wasm32"))]
+    tracing: Option<SharedNativeTracing>,
+    #[cfg(not(target_arch = "wasm32"))]
+    pending_tracing_action: Option<PendingTracingAction>,
     last_update: Instant,
     #[cfg(target_arch = "wasm32")]
     browser_self_test: BrowserSelfTest,
@@ -223,6 +309,10 @@ impl UnifiedApp {
             settings,
             #[cfg(not(target_arch = "wasm32"))]
             pending_audio_settings: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            tracing: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            pending_tracing_action: None,
             last_update: Instant::now(),
             #[cfg(target_arch = "wasm32")]
             browser_self_test: BrowserSelfTest::from_location(),
@@ -242,7 +332,67 @@ impl UnifiedApp {
 
 impl UnifiedApp {
     #[cfg(not(target_arch = "wasm32"))]
+    fn process_tracing(&mut self) {
+        let Some(tracing) = self.tracing.as_ref().cloned() else {
+            self.widget.set_tracing_status(TracingStatus::default());
+            self.pending_tracing_action = None;
+            return;
+        };
+        if let Some(action) = self.pending_tracing_action.take() {
+            let result = tracing
+                .lock()
+                .map_err(|_| anyhow::anyhow!("tracing controller lock is poisoned"))
+                .and_then(|mut tracing| match action {
+                    PendingTracingAction::Start { engine_detail } => {
+                        tracing.start_capture(engine_detail).map(|()| None)
+                    }
+                    PendingTracingAction::Stop { save } => {
+                        tracing.quiesce_capture()?;
+                        self.pending_tracing_action =
+                            Some(PendingTracingAction::FinishStop { save });
+                        Ok(None)
+                    }
+                    PendingTracingAction::FinishStop { save } => {
+                        tracing.stop_capture(save).map(Some)
+                    }
+                });
+            match result {
+                Ok(Some(stopped)) => self.widget.notify_tracing_stopped(stopped),
+                Ok(None) => {}
+                Err(error) => self.settings.report_action_error(error.to_string()),
+            }
+        }
+        let status = tracing
+            .lock()
+            .map(|tracing| tracing.status())
+            .unwrap_or_default();
+        self.widget.set_tracing_status(status);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     fn handle_settings_action(&mut self, action: SettingsAction) {
+        let action = match action {
+            SettingsAction::StartTracing { engine_detail } => {
+                if self.tracing.is_some() {
+                    self.pending_tracing_action =
+                        Some(PendingTracingAction::Start { engine_detail });
+                } else {
+                    self.settings
+                        .report_action_error("Tracing is unavailable in this build");
+                }
+                return;
+            }
+            SettingsAction::StopTracing { save } => {
+                if self.tracing.is_some() {
+                    self.pending_tracing_action = Some(PendingTracingAction::Stop { save });
+                } else {
+                    self.settings
+                        .report_action_error("Tracing is unavailable in this build");
+                }
+                return;
+            }
+            action => action,
+        };
         let kind = action.kind();
         let _span = tracing::debug_span!("frontend.egui.settings_action", action = kind).entered();
         let result = match action {
@@ -310,6 +460,9 @@ impl UnifiedApp {
             SettingsAction::RequestReloadUserScript { script_id } => {
                 self.runtime.reload_user_script(script_id)
             }
+            SettingsAction::StartTracing { .. } | SettingsAction::StopTracing { .. } => {
+                unreachable!("tracing actions are handled before traced settings actions")
+            }
         };
         if let Err(error) = result {
             self.settings.report_action_error(error.to_string());
@@ -357,6 +510,11 @@ impl UnifiedApp {
                 self.settings.report_action_error(
                     "Path-based user scripts are unavailable in browser builds",
                 );
+                return;
+            }
+            SettingsAction::StartTracing { .. } | SettingsAction::StopTracing { .. } => {
+                self.settings
+                    .report_action_error("Tracing is unavailable in browser builds");
                 return;
             }
         };
@@ -881,6 +1039,8 @@ fn save_file_output(
 
 impl eframe::App for UnifiedApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        #[cfg(not(target_arch = "wasm32"))]
+        self.process_tracing();
         self.show(ui);
     }
 }
@@ -1361,16 +1521,24 @@ impl Runtime {
 
 fn create_app(
     context: &eframe::CreationContext<'_>,
+    #[cfg(not(target_arch = "wasm32"))] tracing: Option<SharedNativeTracing>,
 ) -> Result<Box<dyn eframe::App>, Box<dyn std::error::Error + Send + Sync>> {
     shoop_egui::initialize(&context.egui_ctx);
-    UnifiedApp::new()
-        .map(|app| {
-            if let Ok(scale) = app.settings.active().get(UI_SCALE_FACTOR) {
-                context.egui_ctx.set_zoom_factor(scale as f32);
-            }
-            Box::new(app) as Box<dyn eframe::App>
-        })
-        .map_err(|error| error.into())
+    let app = UnifiedApp::new()?;
+    #[cfg(not(target_arch = "wasm32"))]
+    let mut app = app;
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(tracing) = tracing {
+        tracing
+            .lock()
+            .map_err(|_| anyhow::anyhow!("tracing controller lock is poisoned"))?
+            .start_requested_capture()?;
+        app.tracing = Some(tracing);
+    }
+    if let Ok(scale) = app.settings.active().get(UI_SCALE_FACTOR) {
+        context.egui_ctx.set_zoom_factor(scale as f32);
+    }
+    Ok(Box::new(app) as Box<dyn eframe::App>)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -1407,17 +1575,24 @@ fn main() {
             }
         }
     }
-    let mut tracing_runtime = match NativeTracing::start(&cli) {
-        Ok(tracing) => tracing,
+    let tracing_runtime = match NativeTracing::initialize(&cli) {
+        Ok(tracing) => Arc::new(Mutex::new(tracing)),
         Err(error) => {
             eprintln!("Could not initialize tracing: {error:#}");
             std::process::exit(1);
         }
     };
     if cli.tracing_smoke_test {
-        tracing::info!(target: "Frontend.Egui", "frontend.egui.tracing_smoke_test");
-        if let Err(error) = tracing_runtime.shutdown() {
-            eprintln!("Failed to shut down Tracy capture: {error:#}");
+        let result = tracing_runtime
+            .lock()
+            .map_err(|_| anyhow::anyhow!("tracing controller lock is poisoned"))
+            .and_then(|mut tracing| {
+                tracing.start_requested_capture()?;
+                tracing::info!(target: "Frontend.Egui", "frontend.egui.tracing_smoke_test");
+                tracing.shutdown()
+            });
+        if let Err(error) = result {
+            eprintln!("Failed to run Tracy capture smoke test: {error:#}");
             std::process::exit(1);
         }
         return;
@@ -1430,11 +1605,17 @@ fn main() {
             .with_min_inner_size([360.0, 200.0]),
         ..Default::default()
     };
-    let result = {
-        let _span = tracing::info_span!("app.egui.run").entered();
-        eframe::run_native("ShoopDaLoop", options, Box::new(create_app))
-    };
-    if let Err(error) = tracing_runtime.shutdown() {
+    let app_tracing = Arc::clone(&tracing_runtime);
+    let result = eframe::run_native(
+        "ShoopDaLoop",
+        options,
+        Box::new(move |context| create_app(context, Some(Arc::clone(&app_tracing)))),
+    );
+    let shutdown = tracing_runtime
+        .lock()
+        .map_err(|_| anyhow::anyhow!("tracing controller lock is poisoned"))
+        .and_then(|mut tracing| tracing.shutdown());
+    if let Err(error) = shutdown {
         eprintln!("Failed to shut down Tracy capture: {error:#}");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary
- upgrade tracy-extensions integrations and CI prebuilt downloads to v0.6.0
- add reusable in-process Tracy capture start/save/discard lifecycle with status and event-storage memory reporting
- add a Developer settings category and active tracing controls in the bottom status bar
- show saved/discarded completion dialogs and keep browser/non-Tracy builds supported
- update Tracy guidance and add reusable lifecycle/UI tests

## Verification
- warning-denying workspace build using the v0.6.0 Linux prebuilt with CMake disabled
- warning-denying wasm build without tracing support
- `shoop_egui` library suite: 148 passed
- `shoop_common` suite, including repeated save/discard capture: passed
- `shoopdaloop --no-default-features` suite: 29 passed
- v0.6.0 smoke capture validated with `tracy-query check` and `tracy-query info`
- formatting and tracing coverage inventory passed

## Local note
The released Windows bundle was built with MSVC 19.51, while the local machine has 19.50, so local Windows linking reports the expected newer-toolset STL symbol mismatch. The released Linux prebuilt linked and ran successfully without invoking CMake.