### PR TITLE
Enable track removal and resource recreation

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -3389,12 +3389,64 @@ impl ApplicationModel {
         Ok(())
     }
 
+    fn remove_track(&mut self, backend: &mut dyn Backend, track_id: TrackId) -> Result<(), String> {
+        let index = self
+            .tracks
+            .iter()
+            .position(|track| track.id == track_id && !track.is_sync)
+            .ok_or_else(|| format!("stale, unknown, or sync track {track_id}"))?;
+        let loop_ids = self.tracks[index]
+            .loops
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let referenced = self.loops.values().any(|model| {
+            !loop_ids.contains(&model.id)
+                && model.composite.as_ref().is_some_and(|composite| {
+                    composite
+                        .playlists
+                        .iter()
+                        .flatten()
+                        .flatten()
+                        .any(|event| loop_ids.contains(&LoopId::from_raw(event.loop_id)))
+                })
+        });
+        if referenced {
+            return Err(format!(
+                "cannot remove track {track_id} while its loops are used by a composite"
+            ));
+        }
+        for loop_id in &loop_ids {
+            if let Some(composite_id) = self.loops[loop_id].backend_composite {
+                backend
+                    .remove_composite_loop(composite_id)
+                    .map_err(|error| format!("could not remove track composite: {error}"))?;
+            }
+        }
+        let track = &self.tracks[index];
+        backend
+            .remove_track(track.backend_id)
+            .map_err(|error| format!("could not remove track {track_id}: {error}"))?;
+        for loop_id in &loop_ids {
+            self.script_composition_playback.remove(loop_id);
+            self.loops.remove(loop_id);
+        }
+        for port_id in track.port_ids.iter() {
+            self.connection_ports.remove(port_id);
+        }
+        self.tracks.remove(index);
+        self.refresh_selected_media(backend)
+    }
+
     fn handle_track_action(
         &mut self,
         backend: &mut dyn Backend,
         track_id: TrackId,
         action: TrackAction,
     ) -> Result<(), String> {
+        if action == TrackAction::Remove {
+            return self.remove_track(backend, track_id);
+        }
         if let TrackAction::InputMonitoringChanged {
             enabled,
             respect_auto_mute,
@@ -3417,6 +3469,7 @@ impl ApplicationModel {
             return Ok(());
         }
         let backend_action = match action {
+            TrackAction::Remove => unreachable!(),
             TrackAction::NameChanged(name) => {
                 track.name = name;
                 return Ok(());
@@ -7483,6 +7536,74 @@ mod tests {
         assert!(snapshot.tracks[0].loops[0].sync);
         assert!(snapshot.tracks[0].id.is_valid());
         assert!(snapshot.tracks[0].loops[0].id.is_valid());
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn removing_and_recreating_a_track_reuses_its_port_names_without_stale_resources() {
+        let mut backend = EngineBackend::new_dummy(48_000, 128).unwrap();
+        let mut model = ApplicationModel::initialize(
+            &mut backend,
+            Arc::new(Mutex::new(VecDeque::new())),
+            Arc::new(Mutex::new(VecDeque::new())),
+            false,
+        )
+        .unwrap();
+        let spec = DirectTrackSpec {
+            name: "Reusable Track".to_owned(),
+            audio_channels: 2,
+            midi: true,
+        };
+        model.add_track(&mut backend, spec.clone()).unwrap();
+        let track = model.tracks.last().unwrap();
+        let track_id = track.id;
+        let backend_track_id = track.backend_id;
+        let port_name_base = track.port_name_base.clone();
+        let old_loop_ids = track
+            .loops
+            .iter()
+            .map(|id| model.loops[id].backend_id)
+            .collect::<Vec<_>>();
+        let old_port_ids = track
+            .port_ids
+            .iter()
+            .map(|id| model.connection_ports[id].backend_id)
+            .collect::<Vec<_>>();
+        let before = backend.poll().unwrap();
+        let old_port_names = old_port_ids
+            .iter()
+            .map(|id| before.connections.application_ports[id].name.clone())
+            .collect::<Vec<_>>();
+
+        model
+            .handle_track_action(&mut backend, track_id, TrackAction::Remove)
+            .unwrap();
+        let removed = backend.poll().unwrap();
+        assert!(!removed.tracks.contains_key(&backend_track_id));
+        assert!(old_loop_ids
+            .iter()
+            .all(|loop_id| !removed.loops.contains_key(loop_id)));
+        assert!(old_port_ids
+            .iter()
+            .all(|port_id| !removed.connections.application_ports.contains_key(port_id)));
+        assert!(!model.tracks.iter().any(|track| track.id == track_id));
+
+        model.add_track(&mut backend, spec).unwrap();
+        let recreated = model.tracks.last().unwrap();
+        assert_eq!(recreated.port_name_base, port_name_base);
+        let new_port_ids = recreated
+            .port_ids
+            .iter()
+            .map(|id| model.connection_ports[id].backend_id)
+            .collect::<Vec<_>>();
+        assert!(new_port_ids
+            .iter()
+            .all(|port_id| !old_port_ids.contains(port_id)));
+        let snapshot = backend.poll().unwrap();
+        let new_port_names = new_port_ids
+            .iter()
+            .map(|id| snapshot.connections.application_ports[id].name.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(new_port_names, old_port_names);
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1455,6 +1455,7 @@ pub enum TinySynthFxControl {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum TrackAction {
+    Remove,
     NameChanged(String),
     OutputGainChanged(f32),
     OutputBalanceChanged(f32),
@@ -1706,6 +1707,7 @@ impl TinySynthFxControl {
 impl TrackAction {
     pub const fn kind(&self) -> &'static str {
         match self {
+            Self::Remove => "track.remove",
             Self::NameChanged(_) => "track.name",
             Self::OutputGainChanged(_) => "track.output_gain",
             Self::OutputBalanceChanged(_) => "track.output_balance",

--- a/src/rust/shoop_audio_protocol/src/lib.rs
+++ b/src/rust/shoop_audio_protocol/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u16 = 11;
+pub const PROTOCOL_VERSION: u16 = 12;
 pub const COMMAND_CAPACITY: usize = 256;
 pub const COMMAND_MAX_BYTES: usize = 64 * 1024;
 pub const SESSION_TRANSFER_CHUNK_BYTES: usize = 2 * 1024;
@@ -56,6 +56,9 @@ pub enum Command {
         expected_loop_ids: Vec<u64>,
         port_name_base: String,
         topology: WireTrackTopology,
+    },
+    RemoveTrack {
+        track_id: u64,
     },
     AddLoop {
         track_id: u64,

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -270,6 +270,12 @@ impl WorkletHost {
                 }
                 Ok(Event::Ack)
             }
+            Command::RemoveTrack { track_id } => {
+                self.backend
+                    .remove_track(BackendTrackId::from_raw(track_id))
+                    .map_err(|error| error.to_string())?;
+                Ok(Event::Ack)
+            }
             Command::AddLoop {
                 track_id,
                 expected_loop_id,
@@ -1203,6 +1209,77 @@ mod tests {
     fn command(host: &mut WorkletHost, sequence: u64, command: Command) -> EventEnvelope {
         let json = serde_json::to_vec(&CommandEnvelope::new(sequence, command)).unwrap();
         serde_json::from_str(host.handle_json(&json)).unwrap()
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn worklet_removes_and_recreates_same_named_track_ports() {
+        let mut host = WorkletHost::new(48_000, 128).unwrap();
+        let create = |expected_track_id, expected_loop_id| Command::CreateTrack {
+            expected_track_id,
+            expected_loop_ids: vec![expected_loop_id],
+            port_name_base: "reusable".to_owned(),
+            topology: WireTrackTopology::Direct {
+                audio_channels: 1,
+                midi: true,
+            },
+        };
+        assert!(matches!(
+            command(&mut host, 1, create(1, 1)).event,
+            Event::Ack
+        ));
+        let Event::Snapshot(first) = command(&mut host, 2, Command::Poll).event else {
+            panic!("expected first snapshot");
+        };
+        let first_ports = first
+            .application_ports
+            .iter()
+            .filter(|port| matches!(port.owner, WireApplicationPortOwner::Track))
+            .map(|port| (port.id, port.name.clone()))
+            .collect::<Vec<_>>();
+
+        assert!(matches!(
+            command(&mut host, 3, Command::RemoveTrack { track_id: 1 }).event,
+            Event::Ack
+        ));
+        assert!(matches!(
+            command(&mut host, 4, create(2, 2)).event,
+            Event::Ack
+        ));
+        let Event::Snapshot(recreated) = command(&mut host, 5, Command::Poll).event else {
+            panic!("expected recreated snapshot");
+        };
+        assert_eq!(
+            recreated
+                .tracks
+                .iter()
+                .map(|track| track.id)
+                .collect::<Vec<_>>(),
+            [2]
+        );
+        assert_eq!(
+            recreated
+                .loops
+                .iter()
+                .map(|loop_| loop_.id)
+                .collect::<Vec<_>>(),
+            [2]
+        );
+        let recreated_ports = recreated
+            .application_ports
+            .iter()
+            .filter(|port| matches!(port.owner, WireApplicationPortOwner::Track))
+            .map(|port| (port.id, port.name.clone()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            recreated_ports
+                .iter()
+                .map(|(_, name)| name)
+                .collect::<Vec<_>>(),
+            first_ports.iter().map(|(_, name)| name).collect::<Vec<_>>()
+        );
+        assert!(recreated_ports
+            .iter()
+            .all(|(id, _)| first_ports.iter().all(|(old_id, _)| old_id != id)));
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -742,6 +742,7 @@ pub trait Backend {
         }
     }
     fn create_direct_track(&mut self, request: DirectTrackRequest) -> Result<BackendTrackCreation>;
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()>;
     fn add_loop_to_track(&mut self, track_id: BackendTrackId) -> Result<BackendLoopId>;
     fn set_track_control(
         &mut self,
@@ -3445,6 +3446,49 @@ impl Backend for EngineBackend {
         })
     }
 
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()> {
+        let Some(track) = self.tracks.remove(&track_id) else {
+            return Ok(());
+        };
+        for loop_id in &track.loops {
+            if let Some(engine_loop) = self.loops.remove(loop_id) {
+                self.session.remove_loop(engine_loop)?;
+            }
+            self.loop_channels.remove(loop_id);
+        }
+        for port in track
+            .audio_inputs
+            .iter()
+            .chain(&track.audio_outputs)
+            .chain(&track.audio_sends)
+            .chain(&track.audio_returns)
+            .copied()
+            .chain(track.midi_input)
+            .chain(track.midi_output)
+        {
+            self.session.remove_port(port)?;
+        }
+        self.session.remove_processor(&track.port_name_base);
+        for port_id in &track.ports {
+            self.desired_web_midi_connections
+                .retain(|(candidate, _)| candidate != port_id);
+            if let Some(port) = self.connection_ports.remove(port_id) {
+                for endpoint in self
+                    .external_connections
+                    .connection_status_of(port.registry_id)
+                    .keys()
+                {
+                    let _ = self
+                        .external_connections
+                        .disconnect(port.registry_id, endpoint);
+                }
+            }
+        }
+        self.connection_revision = self.connection_revision.wrapping_add(1);
+        self.apply_graph_changes()?;
+        Ok(())
+    }
+
     fn add_loop_to_track(&mut self, track_id: BackendTrackId) -> Result<BackendLoopId> {
         let loop_id = self.create_track_loop(track_id)?;
         self.apply_graph_changes()?;
@@ -4698,6 +4742,7 @@ pub enum FakeOperation {
     ),
     RemoveComposite(BackendCompositeId),
     CreateTrack(BackendTrackId),
+    RemoveTrack(BackendTrackId),
     AddTrackLoop(BackendTrackId, BackendLoopId),
     SetTrackControl(BackendTrackId, BackendTrackControl),
     SetLoopGain(BackendLoopId, f32),
@@ -5498,6 +5543,38 @@ impl Backend for FakeBackend {
             loops,
             ports,
         })
+    }
+
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()> {
+        let Some(track) = self.tracks.remove(&track_id) else {
+            return Ok(());
+        };
+        for loop_id in track.loops {
+            self.loops.remove(&loop_id);
+            self.loop_content.remove(&loop_id);
+            self.sync_sources.remove(&loop_id);
+            for source in self.sync_sources.values_mut() {
+                if *source == Some(loop_id) {
+                    *source = None;
+                }
+            }
+        }
+        self.failed_midi_input_tracks.remove(&track_id);
+        self.connections.with_state(|state| {
+            for port_id in track.ports {
+                state.ports.remove(&port_id);
+                state
+                    .connected
+                    .retain(|(candidate, _)| *candidate != port_id);
+                state
+                    .pending
+                    .retain(|(candidate, _, _)| *candidate != port_id);
+                state.failures.retain(|failure| failure.port_id != port_id);
+            }
+            state.revision = state.revision.wrapping_add(1);
+        });
+        self.operations.push(FakeOperation::RemoveTrack(track_id));
+        Ok(())
     }
 
     fn add_loop_to_track(&mut self, track_id: BackendTrackId) -> Result<BackendLoopId> {

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -353,6 +353,42 @@ impl NativeRuntime {
         self.driver.wait_process();
     }
 
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()> {
+        let Some(track) = self.tracks.remove(&track_id) else {
+            return Ok(());
+        };
+        for loop_id in &track.loops {
+            if let Some(loop_) = self.loops.remove(loop_id) {
+                self.session.remove_loop(&loop_.handle)?;
+            }
+        }
+        if let Some(fx) = &track.fx {
+            self.session.remove_fx_chain(&fx.chain)?;
+        } else {
+            self.session.remove_processor(&track.port_name_base)?;
+        }
+        for port_id in &track.ports {
+            let Some(port) = self.ports.remove(port_id) else {
+                continue;
+            };
+            match port.handle {
+                NativePortHandle::Audio(port) => {
+                    self.driver.unregister_audio_port(&port)?;
+                    self.session.remove_audio_port(&port)?;
+                }
+                NativePortHandle::Midi(port) => {
+                    self.driver.unregister_midi_port(&port)?;
+                    self.session.remove_midi_port(&port)?;
+                }
+            }
+        }
+        self.connection_failures
+            .retain(|failure| !track.ports.contains(&failure.port_id));
+        self.connection_revision = self.connection_revision.wrapping_add(1);
+        self.wait();
+        Ok(())
+    }
+
     fn composite_target_identity(
         &self,
         target: BackendCompositeTarget,
@@ -2063,6 +2099,10 @@ impl Backend for NativeBackend {
 
     fn create_direct_track(&mut self, request: DirectTrackRequest) -> Result<BackendTrackCreation> {
         self.runtime_mut()?.create_direct_track(request)
+    }
+
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()> {
+        self.runtime_mut()?.remove_track(track_id)
     }
 
     fn add_loop_to_track(&mut self, track_id: BackendTrackId) -> Result<BackendLoopId> {
@@ -3996,6 +4036,52 @@ mod tests {
         assert!(restored.capture_session().unwrap().tracks[0]
             .tiny_synth_midi_cc_assignments
             .is_empty());
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn native_track_removal_releases_ports_for_same_name_recreation() {
+        let config = AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: 128,
+        });
+        let mut backend = NativeBackend::new(config).unwrap();
+        let request = DirectTrackRequest {
+            port_name_base: "reusable_native".to_owned(),
+            audio_channels: 2,
+            midi: true,
+            initial_loops: 2,
+        };
+        let first = backend.create_direct_track(request.clone()).unwrap();
+        let first_names = first
+            .ports
+            .iter()
+            .map(|port| port.name.clone())
+            .collect::<Vec<_>>();
+        backend.remove_track(first.track_id).unwrap();
+        let removed = backend.poll().unwrap();
+        assert!(!removed.tracks.contains_key(&first.track_id));
+        assert!(first
+            .loops
+            .iter()
+            .all(|loop_id| !removed.loops.contains_key(loop_id)));
+        assert!(first
+            .ports
+            .iter()
+            .all(|port| !removed.connections.application_ports.contains_key(&port.id)));
+
+        let recreated = backend.create_direct_track(request).unwrap();
+        assert_eq!(
+            recreated
+                .ports
+                .iter()
+                .map(|port| port.name.clone())
+                .collect::<Vec<_>>(),
+            first_names
+        );
+        assert!(recreated
+            .ports
+            .iter()
+            .all(|port| first.ports.iter().all(|old| old.id != port.id)));
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoop_egui/src/track_widget.rs
+++ b/src/rust/shoop_egui/src/track_widget.rs
@@ -52,6 +52,8 @@ pub struct TrackWidget {
     #[cfg(test)]
     test_connections_rect: Option<egui::Rect>,
     #[cfg(test)]
+    test_delete_rect: Option<egui::Rect>,
+    #[cfg(test)]
     test_fx_rect: Option<egui::Rect>,
 }
 
@@ -81,6 +83,8 @@ impl Default for TrackWidget {
             test_options_rect: None,
             #[cfg(test)]
             test_connections_rect: None,
+            #[cfg(test)]
+            test_delete_rect: None,
             #[cfg(test)]
             test_fx_rect: None,
         }
@@ -466,7 +470,15 @@ impl TrackWidget {
                         ui.close();
                     }
                     if !state.is_sync {
-                        ui.add_enabled(false, egui::Button::new("Delete Track"));
+                        let delete = ui.button("Delete Track");
+                        #[cfg(test)]
+                        {
+                            self.test_delete_rect = Some(delete.rect);
+                        }
+                        if delete.clicked() {
+                            result.actions.push(TrackWidgetAction::Remove);
+                            ui.close();
+                        }
                     }
                 });
                 #[cfg(test)]
@@ -819,6 +831,42 @@ mod tests {
         let mut direct_widget = TrackWidget::default();
         let _ = frame(&context, &mut direct_widget, &direct, Vec::new());
         assert!(direct_widget.test_fx_rect.is_none());
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn track_options_menu_requests_deletion_for_main_tracks_only() {
+        let context = egui::Context::default();
+        crate::initialize(&context);
+        let state = TrackState {
+            id: TrackId::from_raw(2),
+            name: "Track".to_owned(),
+            ..Default::default()
+        };
+        let mut widget = TrackWidget::default();
+        let _ = frame(&context, &mut widget, &state, Vec::new());
+        let options = widget.test_options_rect.unwrap().center();
+        assert!(click(&context, &mut widget, &state, options)
+            .actions
+            .is_empty());
+        let _ = frame(&context, &mut widget, &state, Vec::new());
+        let delete = widget.test_delete_rect.unwrap().center();
+        assert_eq!(
+            click(&context, &mut widget, &state, delete).actions,
+            [TrackWidgetAction::Remove]
+        );
+
+        let sync = TrackState {
+            id: TrackId::from_raw(1),
+            name: "Sync".to_owned(),
+            is_sync: true,
+            ..Default::default()
+        };
+        let mut sync_widget = TrackWidget::default();
+        let _ = frame(&context, &mut sync_widget, &sync, Vec::new());
+        let options = sync_widget.test_options_rect.unwrap().center();
+        let _ = click(&context, &mut sync_widget, &sync, options);
+        let _ = frame(&context, &mut sync_widget, &sync, Vec::new());
+        assert!(sync_widget.test_delete_rect.is_none());
     }
 
     #[tracy_nextest_capture::tracy_capture_test]

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -2187,6 +2187,86 @@ impl BackendSession {
             desired_play_after_record: Arc::new(AtomicBool::new(false)),
         })
     }
+    pub fn remove_loop(&self, loop_: &Loop) -> Result<CommandSequence> {
+        if !Arc::ptr_eq(&self.shared, &loop_.shared) {
+            return Err(anyhow!("loop belongs to another session"));
+        }
+        let control = Arc::clone(&loop_.control);
+        Ok(self.shared.send_topology(move |session| {
+            if let Some(index) = control.ready_id().map(ObjectIdentity::index) {
+                let _ = session.remove_loop(index);
+            }
+            control.mark_closed();
+        })?)
+    }
+
+    pub fn remove_audio_port(&self, port: &AudioPort) -> Result<CommandSequence> {
+        if !Arc::ptr_eq(&self.shared, &port.shared) {
+            return Err(anyhow!("audio port belongs to another session"));
+        }
+        let control = Arc::clone(&port.control);
+        Ok(self.shared.send_topology(move |session| {
+            if let Some(index) = control.ready_id().map(ObjectIdentity::index) {
+                let _ = session.remove_port(index);
+            }
+            control.mark_closed();
+        })?)
+    }
+
+    pub fn remove_midi_port(&self, port: &MidiPort) -> Result<CommandSequence> {
+        if !Arc::ptr_eq(&self.shared, &port.shared) {
+            return Err(anyhow!("MIDI port belongs to another session"));
+        }
+        let control = Arc::clone(&port.control);
+        Ok(self.shared.send_topology(move |session| {
+            if let Some(index) = control.ready_id().map(ObjectIdentity::index) {
+                let _ = session.remove_port(index);
+            }
+            control.mark_closed();
+        })?)
+    }
+
+    pub fn remove_processor(&self, title: &str) -> Result<CommandSequence> {
+        let title = title.to_owned();
+        Ok(self.shared.send_topology(move |session| {
+            session.remove_processor(&title);
+        })?)
+    }
+
+    pub fn remove_fx_chain(&self, chain: &FXChain) -> Result<CommandSequence> {
+        if !Arc::ptr_eq(&self.shared, &chain.shared) {
+            return Err(anyhow!("FX chain belongs to another session"));
+        }
+        let title = chain.title.clone();
+        let audio = chain
+            .audio_inputs
+            .iter()
+            .chain(&chain.audio_outputs)
+            .map(|port| Arc::clone(&port.control))
+            .collect::<Vec<_>>();
+        let midi = chain
+            .midi_inputs
+            .iter()
+            .chain(&chain.midi_outputs)
+            .map(|port| Arc::clone(&port.control))
+            .collect::<Vec<_>>();
+        Ok(self.shared.send_topology(move |session| {
+            session.remove_processor(&title);
+            for control in &audio {
+                if let Some(index) = control.ready_id().map(ObjectIdentity::index) {
+                    let _ = session.remove_port(index);
+                }
+                control.mark_closed();
+            }
+            for control in &midi {
+                if let Some(index) = control.ready_id().map(ObjectIdentity::index) {
+                    let _ = session.remove_port(index);
+                }
+                control.mark_closed();
+            }
+        })?)
+    }
+
     pub fn primitive_sync_sources(&self) -> Vec<Option<usize>> {
         self.primitive_sync_sources_if_ready().unwrap_or_else(|| {
             self.shared
@@ -3343,6 +3423,66 @@ impl AudioDriver {
         }
         Ok(())
     }
+    pub fn unregister_audio_port(&self, port: &AudioPort) -> Result<()> {
+        let Some(jack) = self.jack() else {
+            return Ok(());
+        };
+        let jack = jack.lock().unwrap_or_else(|error| error.into_inner());
+        let registered = {
+            let mut ports = jack.ports.lock().unwrap_or_else(|error| error.into_inner());
+            ports
+                .iter()
+                .position(|registered| match registered {
+                    JackRegisteredPort::AudioIn { control, .. }
+                    | JackRegisteredPort::AudioOut { control, .. } => {
+                        Arc::ptr_eq(control, &port.control)
+                    }
+                    _ => false,
+                })
+                .map(|index| ports.remove(index))
+        };
+        match registered {
+            Some(JackRegisteredPort::AudioIn { jack: port, .. }) => {
+                jack.client().unregister_port(port)?;
+            }
+            Some(JackRegisteredPort::AudioOut { jack: port, .. }) => {
+                jack.client().unregister_port(port)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub fn unregister_midi_port(&self, port: &MidiPort) -> Result<()> {
+        let Some(jack) = self.jack() else {
+            return Ok(());
+        };
+        let jack = jack.lock().unwrap_or_else(|error| error.into_inner());
+        let registered = {
+            let mut ports = jack.ports.lock().unwrap_or_else(|error| error.into_inner());
+            ports
+                .iter()
+                .position(|registered| match registered {
+                    JackRegisteredPort::MidiIn { control, .. }
+                    | JackRegisteredPort::MidiOut { control, .. } => {
+                        Arc::ptr_eq(control, &port.control)
+                    }
+                    _ => false,
+                })
+                .map(|index| ports.remove(index))
+        };
+        match registered {
+            Some(JackRegisteredPort::MidiIn { jack: port, .. }) => {
+                jack.client().unregister_port(port)?;
+            }
+            Some(JackRegisteredPort::MidiOut { jack: port, .. }) => {
+                jack.client().unregister_port(port)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     fn register_midi_port(
         &self,
         name: &str,

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1625,6 +1625,11 @@ impl Session {
         }
     }
 
+    pub fn remove_processor(&mut self, title: &str) {
+        self.processors.retain(|route| route.title != title);
+        self.note_graph_change();
+    }
+
     pub fn tiny_synth_fx_processor_mut(
         &mut self,
         title: &str,

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1006,9 +1006,19 @@ struct LoopContentReplaceAssembly {
     complete: bool,
 }
 
+#[derive(Default)]
+struct BrowserTrackResources {
+    loops: Vec<BackendLoopId>,
+    ports: Vec<BackendPortId>,
+}
+
 pub struct WebAudioBackend {
     transport: Rc<RefCell<Transport>>,
     snapshot: BackendSnapshot,
+    track_resources: BTreeMap<BackendTrackId, BrowserTrackResources>,
+    removed_tracks: BTreeSet<BackendTrackId>,
+    removed_loops: BTreeSet<BackendLoopId>,
+    removed_ports: BTreeSet<BackendPortId>,
     next_track_id: u64,
     next_loop_id: u64,
     next_composite_id: u64,
@@ -1055,6 +1065,10 @@ impl WebAudioBackend {
                     },
                     ..Default::default()
                 },
+                track_resources: BTreeMap::new(),
+                removed_tracks: BTreeSet::new(),
+                removed_loops: BTreeSet::new(),
+                removed_ports: BTreeSet::new(),
                 next_track_id: 1,
                 next_loop_id: 1,
                 next_composite_id: 1,
@@ -1465,6 +1479,10 @@ impl WebAudioBackend {
         self.next_composite_id = 1;
         self.snapshot.connections.application_ports.clear();
         self.snapshot.connections.confirmed_links.clear();
+        self.track_resources.clear();
+        self.removed_tracks.clear();
+        self.removed_loops.clear();
+        self.removed_ports.clear();
         self.waveforms.clear();
         self.midi_data.clear();
         for source_track in &session.tracks {
@@ -1474,6 +1492,13 @@ impl WebAudioBackend {
             self.snapshot
                 .tracks
                 .insert(created.track_id, source_track.state.clone());
+            self.track_resources.insert(
+                created.track_id,
+                BrowserTrackResources {
+                    loops: created.loops.clone(),
+                    ports: created.ports.iter().map(|port| port.id).collect(),
+                },
+            );
             for (source_loop, loop_id) in source_track.loops.iter().zip(&created.loops) {
                 self.snapshot.loops.insert(
                     *loop_id,
@@ -1559,6 +1584,11 @@ impl WebAudioBackend {
         self.snapshot.connections.application_ports = wire
             .application_ports
             .into_iter()
+            .filter(|port| {
+                !self
+                    .removed_ports
+                    .contains(&BackendPortId::from_raw(port.id))
+            })
             .map(|port| {
                 let id = BackendPortId::from_raw(port.id);
                 (
@@ -1597,6 +1627,11 @@ impl WebAudioBackend {
         self.snapshot.connections.confirmed_links = wire
             .confirmed_links
             .into_iter()
+            .filter(|link| {
+                !self
+                    .removed_ports
+                    .contains(&BackendPortId::from_raw(link.application_port_id))
+            })
             .map(|link| BackendConfirmedLink {
                 application_port_id: BackendPortId::from_raw(link.application_port_id),
                 host_port_id: link.host_port_id,
@@ -1606,6 +1641,11 @@ impl WebAudioBackend {
         self.snapshot.tracks.extend(
             wire.tracks
                 .into_iter()
+                .filter(|track| {
+                    !self
+                        .removed_tracks
+                        .contains(&BackendTrackId::from_raw(track.id))
+                })
                 .map(|track| {
                     (
                         BackendTrackId::from_raw(track.id),
@@ -1693,6 +1733,11 @@ impl WebAudioBackend {
         self.snapshot.loops.extend(
             wire.loops
                 .into_iter()
+                .filter(|loop_| {
+                    !self
+                        .removed_loops
+                        .contains(&BackendLoopId::from_raw(loop_.id))
+                })
                 .map(|loop_| {
                     (
                         BackendLoopId::from_raw(loop_.id),
@@ -1967,6 +2012,13 @@ impl Backend for WebAudioBackend {
                 }
                 self.snapshot.connections.revision =
                     self.snapshot.connections.revision.wrapping_add(1);
+                self.track_resources.insert(
+                    track_id,
+                    BrowserTrackResources {
+                        loops: loops.clone(),
+                        ports: ports.iter().map(|port| port.id).collect(),
+                    },
+                );
                 for loop_id in &loops {
                     self.snapshot.loops.insert(
                         *loop_id,
@@ -2127,6 +2179,13 @@ impl Backend for WebAudioBackend {
                 .insert(port.id, port.clone());
         }
         self.snapshot.connections.revision = self.snapshot.connections.revision.wrapping_add(1);
+        self.track_resources.insert(
+            track_id,
+            BrowserTrackResources {
+                loops: loops.clone(),
+                ports: ports.iter().map(|port| port.id).collect(),
+            },
+        );
         for loop_id in &loops {
             self.snapshot.loops.insert(
                 *loop_id,
@@ -2146,6 +2205,37 @@ impl Backend for WebAudioBackend {
         })
     }
 
+    fn remove_track(&mut self, track_id: BackendTrackId) -> Result<()> {
+        if !self.snapshot.tracks.contains_key(&track_id) {
+            return Ok(());
+        }
+        self.submit(Command::RemoveTrack {
+            track_id: track_id.raw(),
+        })?;
+        self.snapshot.tracks.remove(&track_id);
+        self.removed_tracks.insert(track_id);
+        if let Some(resources) = self.track_resources.remove(&track_id) {
+            for loop_id in resources.loops {
+                self.removed_loops.insert(loop_id);
+                self.snapshot.loops.remove(&loop_id);
+                self.waveform_revisions.remove(&loop_id);
+                self.waveforms.remove(&loop_id);
+                self.midi_data_generations.remove(&loop_id);
+                self.midi_data.remove(&loop_id);
+            }
+            for port_id in resources.ports {
+                self.removed_ports.insert(port_id);
+                self.snapshot.connections.application_ports.remove(&port_id);
+                self.snapshot
+                    .connections
+                    .confirmed_links
+                    .retain(|link| link.application_port_id != port_id);
+            }
+            self.snapshot.connections.revision = self.snapshot.connections.revision.wrapping_add(1);
+        }
+        Ok(())
+    }
+
     fn add_loop_to_track(&mut self, track_id: BackendTrackId) -> Result<BackendLoopId> {
         if !self.snapshot.tracks.contains_key(&track_id) {
             return Err(anyhow!("unknown browser backend track {track_id:?}"));
@@ -2156,6 +2246,11 @@ impl Backend for WebAudioBackend {
             expected_loop_id: loop_id.raw(),
         })?;
         self.next_loop_id = self.next_loop_id.saturating_add(1);
+        self.track_resources
+            .get_mut(&track_id)
+            .ok_or_else(|| anyhow!("browser track resources are missing"))?
+            .loops
+            .push(loop_id);
         let track = &self.snapshot.tracks[&track_id];
         self.snapshot.loops.insert(
             loop_id,


### PR DESCRIPTION
## Summary
- enable the Delete Track action for non-sync tracks
- remove track loops, processors, connection state, and ports across native, engine, fake, and Web Audio backends
- explicitly unregister JACK ports and prevent stale browser snapshots from resurrecting removed resources
- support removing and recreating a track with the same name and port names

## Tests
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1377 passed, 1 skipped)
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `cargo fmt --all -- --check`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `cargo check -p shoopdaloop --no-default-features --target wasm32-unknown-unknown`
- targeted UI, application, native backend, and AudioWorklet remove/recreate tests

The release AudioWorklet Wasm link could not be completed locally because `lld` is unavailable in the environment.
