### PR TITLE
Fix native connection capture race

### DIFF
--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -189,6 +189,38 @@ impl NativePortHandle {
         }
     }
 
+    fn connections_now(&self) -> std::collections::HashMap<String, bool> {
+        match self {
+            Self::Audio(port) => port.get_connections_state_now(),
+            Self::Midi(port) => port.get_connections_state_now(),
+        }
+    }
+
+    fn wait_ready(&self, session: &BackendSession) -> Result<()> {
+        let sequence = match self {
+            Self::Audio(port) => port.creation_sequence(),
+            Self::Midi(port) => port.creation_sequence(),
+        };
+        session.wait_for_command(sequence, shoop_engine::DEFAULT_WAIT_TIMEOUT)?;
+        let (lifecycle, error, kind) = match self {
+            Self::Audio(port) => (port.lifecycle(), port.creation_error(), "audio"),
+            Self::Midi(port) => (port.lifecycle(), port.creation_error(), "MIDI"),
+        };
+        match lifecycle {
+            shoop_engine::app_backend::ObjectLifecycle::Ready => Ok(()),
+            shoop_engine::app_backend::ObjectLifecycle::Failed => Err(anyhow!(
+                "{kind} port creation failed: {}",
+                error.unwrap_or_else(|| "unknown error".to_owned())
+            )),
+            shoop_engine::app_backend::ObjectLifecycle::Pending => {
+                Err(anyhow!("{kind} port is still pending creation"))
+            }
+            shoop_engine::app_backend::ObjectLifecycle::Closed => {
+                Err(anyhow!("{kind} port is closed"))
+            }
+        }
+    }
+
     fn connect(&self, endpoint: &str) {
         match self {
             Self::Audio(port) => port.connect_external_port(endpoint),
@@ -629,6 +661,14 @@ impl NativeRuntime {
     }
 
     fn connection_snapshot(&self) -> BackendConnectionSnapshot {
+        self.connection_snapshot_with(false)
+    }
+
+    fn connection_snapshot_now(&self) -> BackendConnectionSnapshot {
+        self.connection_snapshot_with(true)
+    }
+
+    fn connection_snapshot_with(&self, authoritative: bool) -> BackendConnectionSnapshot {
         let mut host_ports = self
             .driver
             .find_external_ports(
@@ -661,7 +701,12 @@ impl NativeRuntime {
             .collect::<BTreeMap<_, _>>();
         let mut confirmed_links = BTreeSet::new();
         for (id, port) in &self.ports {
-            for (endpoint, connected) in port.handle.connections() {
+            let connections = if authoritative {
+                port.handle.connections_now()
+            } else {
+                port.handle.connections()
+            };
+            for (endpoint, connected) in connections {
                 host_ports
                     .entry(endpoint.clone())
                     .or_insert_with(|| BackendHostPortDescriptor {
@@ -700,7 +745,7 @@ impl NativeRuntime {
 
     fn capture_session(&mut self) -> Result<BackendSessionData> {
         self.wait();
-        let connections = self.connection_snapshot();
+        let connections = self.connection_snapshot_now();
         let mut tracks = Vec::with_capacity(self.tracks.len());
         for (track_id, track) in &mut self.tracks {
             let mut loops = Vec::with_capacity(track.loops.len());
@@ -1757,23 +1802,28 @@ impl NativeRuntime {
         if !self.connection_snapshot().host_ports.contains_key(endpoint) {
             return Err(anyhow!("external port disappeared: {endpoint}"));
         }
-        // Session restoration can request the global link immediately after its
-        // driver port was queued for creation. Make the port identity visible
-        // before asking the adapter to mutate its external connections; otherwise
-        // the deferred mutation may run before creation and be silently dropped.
-        self.wait();
         let port = self
             .ports
             .get(&port_id)
             .ok_or_else(|| anyhow!("unknown native port {port_id:?}"))?;
+        port.handle.wait_ready(&self.session)?;
         if connected {
             port.handle.connect(endpoint);
         } else {
             port.handle.disconnect(endpoint);
         }
-        // JACK applies links synchronously, while dummy/CPAL adapters may queue the
-        // mutation until the next driver turn. Do not publish or capture stale truth.
         self.wait();
+        let observed = port
+            .handle
+            .connections_now()
+            .get(endpoint)
+            .copied()
+            .unwrap_or(false);
+        if observed != connected {
+            return Err(anyhow!(
+                "external port {endpoint} did not reach requested connection state {connected}"
+            ));
+        }
         self.connection_revision = self.connection_revision.wrapping_add(1);
         Ok(())
     }

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -1734,6 +1734,41 @@ impl SharedSession {
         cached
     }
 
+    fn connections_state_now(
+        &self,
+        name: &str,
+        direction: PortDirection,
+        data_type: PortDataType,
+        session_index: Option<usize>,
+    ) -> HashMap<String, bool> {
+        let key = (name.to_string(), direction as u32, data_type as u32);
+        let request = ConnectionCacheRequest {
+            name: name.to_string(),
+            direction,
+            data_type,
+            session_index,
+        };
+        let state = if let Some(jack) = self.jack() {
+            let jack = jack.lock().unwrap_or_else(|e| e.into_inner());
+            jack_connections_state_locked(&jack, name, direction, data_type)
+        } else if let Some(external) = self.external() {
+            let external = external.lock().unwrap_or_else(|e| e.into_inner());
+            dummy_connections_state_locked(&external, &request)
+        } else {
+            HashMap::new()
+        };
+        let mut cache = self
+            .connection_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        cache.requests.insert(key.clone(), request);
+        cache.states.insert(key, state.clone());
+        cache.last_refresh = Instant::now();
+        cache.refresh_in_flight = false;
+        cache.generation = cache.generation.wrapping_add(1);
+        state
+    }
+
     fn invalidate_connection_cache(&self) {
         let mut cache = self
             .connection_cache
@@ -1829,6 +1864,30 @@ fn jack_connections_state_locked(
         .collect()
 }
 
+fn dummy_connections_state_locked(
+    external: &engine::DummyExternalConnections,
+    request: &ConnectionCacheRequest,
+) -> HashMap<String, bool> {
+    let connected = request
+        .session_index
+        .map(|idx| external.connection_status_of(compat_port_id(idx)))
+        .unwrap_or_default();
+    let mut state = HashMap::new();
+    if let Ok(ports) = external.find_external_ports(
+        None,
+        opposite_direction(request.direction).into(),
+        request.data_type.into(),
+    ) {
+        for port in ports {
+            state.insert(
+                port.name.clone(),
+                *connected.get(&port.name).unwrap_or(&false),
+            );
+        }
+    }
+    state
+}
+
 fn refresh_connection_cache(
     cache: Arc<Mutex<ConnectionCache>>,
     jack: Option<Arc<Mutex<JackBackend>>>,
@@ -1865,24 +1924,10 @@ fn refresh_connection_cache(
     } else if let Some(external) = external {
         let external = external.lock().unwrap_or_else(|e| e.into_inner());
         for (key, request) in &requests {
-            let connected = request
-                .session_index
-                .map(|idx| external.connection_status_of(compat_port_id(idx)))
-                .unwrap_or_default();
-            let mut state = HashMap::new();
-            if let Ok(ports) = external.find_external_ports(
-                None,
-                opposite_direction(request.direction).into(),
-                request.data_type.into(),
-            ) {
-                for port in ports {
-                    state.insert(
-                        port.name.clone(),
-                        *connected.get(&port.name).unwrap_or(&false),
-                    );
-                }
-            }
-            states.insert(key.clone(), state);
+            states.insert(
+                key.clone(),
+                dummy_connections_state_locked(&external, request),
+            );
         }
     }
     let mut cache = cache.lock().unwrap_or_else(|e| e.into_inner());
@@ -5433,6 +5478,14 @@ impl AudioPort {
             self.control.ready_id().map(ObjectIdentity::index),
         )
     }
+    pub fn get_connections_state_now(&self) -> HashMap<String, bool> {
+        self.shared.connections_state_now(
+            &self.name,
+            self.direction,
+            PortDataType::Audio,
+            self.control.ready_id().map(ObjectIdentity::index),
+        )
+    }
     pub fn connect_external_port(&self, name: &str) {
         self.shared.invalidate_connection_cache();
         if let Some(j) = self.shared.jack() {
@@ -5756,6 +5809,14 @@ impl MidiPort {
     }
     pub fn get_connections_state(&self) -> HashMap<String, bool> {
         self.shared.connections_state(
+            &self.name,
+            self.direction,
+            PortDataType::Midi,
+            self.control.ready_id().map(ObjectIdentity::index),
+        )
+    }
+    pub fn get_connections_state_now(&self) -> HashMap<String, bool> {
+        self.shared.connections_state_now(
             &self.name,
             self.direction,
             PortDataType::Midi,
@@ -7290,6 +7351,56 @@ mod tests {
             commands_before
         );
         sess.shared.return_engine(engine);
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn authoritative_connection_state_bypasses_and_replaces_stale_cache() {
+        let driver = AudioDriver::new(AudioDriverType::Dummy, None).expect("driver");
+        driver
+            .start(&AudioDriverSettings::Dummy(DummyAudioDriverSettings {
+                client_name: "authoritative-connections".to_string(),
+                sample_rate: 48_000,
+                buffer_size: 128,
+            }))
+            .expect("start driver");
+        driver.dummy_add_external_mock_port(
+            "system:playback",
+            PortDirection::Input as u32,
+            PortDataType::Audio as u32,
+        );
+        let sess = BackendSession::new().expect("session");
+        sess.set_audio_driver(&driver).expect("attach driver");
+        let port = AudioPort::new_driver_port(
+            &sess,
+            &driver,
+            "authoritative-output",
+            &PortDirection::Output,
+            0,
+        )
+        .expect("port");
+        sess.wait_for_command(port.creation_sequence(), engine::DEFAULT_WAIT_TIMEOUT)
+            .expect("port creation");
+        port.connect_external_port("system:playback");
+        port.shared.set_cached_connection(
+            &port.name,
+            port.direction,
+            PortDataType::Audio,
+            "system:playback",
+            false,
+        );
+
+        assert_eq!(
+            port.get_connections_state().get("system:playback"),
+            Some(&false)
+        );
+        assert_eq!(
+            port.get_connections_state_now().get("system:playback"),
+            Some(&true)
+        );
+        assert_eq!(
+            port.get_connections_state().get("system:playback"),
+            Some(&true)
+        );
     }
 
     #[tracy_nextest_capture::tracy_capture_test]


### PR DESCRIPTION
## Summary
- wait for native audio and MIDI ports to reach their exact creation sequence before restoring external links
- verify restored links against synchronous authoritative JACK/dummy connection state
- use authoritative state for session capture while retaining asynchronous cached polling for routine snapshots
- add coverage proving authoritative reads replace stale cache entries

## Context
The macOS debug job in run 31867623581 intermittently captured an empty restored global MIDI connection. Its Tracy capture showed that the replacement dummy runtime and graph remained healthy through the assertion, pointing to the asynchronous connection cache rather than an engine failure.

The old implementation could defer a connection while a port was pending and then immediately serialize cache-only state. Under contention, the deferred mutation and cache refresh were not synchronized.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1381 passed, 1 skipped)
- `python3 scripts/check_tracing_coverage.py --require-closed`
- 96 concurrent repetitions of `native_dummy_satisfies_topology_capture_and_same_driver_switch` (0 failures; the prior binary reproduced 6 failures in 96)
