### PR TITLE
Fix graph scheduler race and complete nextest Tracy captures

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -764,6 +764,12 @@ jobs:
           "$RUNNER_TEMP/tracy-query" info "${traces[0]}"
           "$RUNNER_TEMP/tracy-query" query --kind message \
             --filter 'message.text=shoop\.nextest_capture\.smoke\.failure' "${traces[0]}"
+          "$RUNNER_TEMP/tracy-query" query --kind cpu-zone \
+            --filter 'cpu-zone.name=^shoop\.nextest_capture\.smoke\.tracing_span$' "${traces[0]}"
+          "$RUNNER_TEMP/tracy-query" query --kind message \
+            --filter 'message.text=shoop\.nextest_capture\.smoke\.tracing_event' "${traces[0]}"
+          "$RUNNER_TEMP/tracy-query" query --kind message \
+            --filter 'message.text=shoop\.nextest_capture\.smoke\.log_event' "${traces[0]}"
 
       - name: Check formatting and tracing inventory
         if: matrix.target == 'linux' && matrix.profile == 'debug'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,9 +4552,13 @@ dependencies = [
 [[package]]
 name = "tracy-nextest-capture"
 version = "0.6.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
+source = "git+https://github.com/SanderVocke/tracy-extensions?rev=8589c41352c41ff3fe5e9c44075f61bd1e63a72d#8589c41352c41ff3fe5e9c44075f61bd1e63a72d"
 dependencies = [
  "sha2 0.10.9",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "tracing-tracy",
  "tracy-client",
  "tracy-client-sys",
  "tracy-nextest-capture-macros",
@@ -4563,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "tracy-nextest-capture-macros"
 version = "0.6.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
+source = "git+https://github.com/SanderVocke/tracy-extensions?rev=8589c41352c41ff3fe5e9c44075f61bd1e63a72d#8589c41352c41ff3fe5e9c44075f61bd1e63a72d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "=0.11.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client-sys = { version = "=0.28.0", default-features = false, features = ["embedded-capture"] }
-tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.6.0" }
+tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", rev = "8589c41352c41ff3fe5e9c44075f61bd1e63a72d" }
 shoop_tracing = { path = "src/rust/shoop_tracing", default-features = false }
 tinyviolin = "=0.3.0"
 

--- a/src/rust/shoop_common/tests/nextest_capture_smoke.rs
+++ b/src/rust/shoop_common/tests/nextest_capture_smoke.rs
@@ -7,6 +7,10 @@ fn emit_shoop_marker(marker: &str) {
     shoop_tracing::set_tracing_enabled(true);
     let span = shoop_tracing::realtime_span!("shoop.nextest_capture.smoke.zone");
     assert!(span.entered_tracy());
+    let tracing_span = tracing::info_span!("shoop.nextest_capture.smoke.tracing_span");
+    let _entered = tracing_span.enter();
+    tracing::info!(message = "shoop.nextest_capture.smoke.tracing_event");
+    log::info!("shoop.nextest_capture.smoke.log_event");
     client.message(marker, 0);
     drop(span);
     shoop_tracing::set_tracing_enabled(false);

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -1596,24 +1596,24 @@ impl SharedSession {
     /// ~90 times a second kept the command queue permanently busy with questions whose answer
     /// was almost always "nothing to do" -- which starved every other control operation.
     ///
-    /// A published `true` is trusted at once. A published `false` is only trusted when the
-    /// queue is empty as well: a mutation that is queued but not yet applied has not dirtied
-    /// the graph *yet*, and taking `false` at face value there would drop the rebuild on the
-    /// floor with nothing left to arm another window. So a non-empty queue re-arms and looks
-    /// again, which is bounded by the queue draining.
+    /// A published `true` is trusted at once. A published `false` is only trusted when no
+    /// command is queued or being applied: a mutation does not publish graph staleness until
+    /// its complete command batch has finished. Pending work re-arms another bounded window.
     fn graph_may_need_rebuild(&self) -> bool {
         let handle = self.handle.lock().unwrap_or_else(|e| e.into_inner());
-        if handle.stats().graph_stale.load(Ordering::Relaxed) {
-            return true;
-        }
-        if handle.n_pending() > 0 {
+        let pending = handle.n_pending() > 0;
+        let command_batch_in_flight = handle
+            .stats()
+            .command_batch_in_flight
+            .load(Ordering::Acquire);
+        if pending || command_batch_in_flight {
             drop(handle);
             if let Some(s) = self.scheduler.get() {
                 s.arm();
             }
             return false;
         }
-        false
+        handle.stats().graph_stale.load(Ordering::Relaxed)
     }
 
     /// Hands the engine to a driver that is about to start cycling it.
@@ -6741,6 +6741,29 @@ mod tests {
             .expect("engine answered")
     }
 
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn a_command_batch_removed_from_the_queue_keeps_the_graph_scheduler_armed() {
+        let sess = BackendSession::new().expect("session");
+        let scheduler = sess.shared.scheduler.get().expect("scheduler");
+        let before = scheduler.n_arms();
+        {
+            let handle = sess.shared.handle.lock().unwrap_or_else(|e| e.into_inner());
+            handle
+                .stats()
+                .command_batch_in_flight
+                .store(true, Ordering::Release);
+        }
+
+        assert!(!sess.shared.graph_may_need_rebuild());
+        assert!(scheduler.n_arms() > before);
+
+        let handle = sess.shared.handle.lock().unwrap_or_else(|e| e.into_inner());
+        handle
+            .stats()
+            .command_batch_in_flight
+            .store(false, Ordering::Release);
+    }
+
     /// The invariant `ControlGuard` exists to enforce.
     ///
     /// Connecting a channel to a port used to leave the graph dirty with nothing scheduled
@@ -7231,8 +7254,17 @@ mod tests {
             )
             .unwrap();
 
-        std::thread::sleep(Duration::from_millis(10));
-        let actual = midi.get_all_midi_data();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let actual = loop {
+            if let Ok(snapshot) = midi.try_get_current_data_snapshot() {
+                break snapshot.contiguous();
+            }
+            assert!(
+                Instant::now() < deadline,
+                "MIDI snapshot publication timed out"
+            );
+            std::thread::yield_now();
+        };
         assert_eq!(actual.len(), 2);
         assert_eq!(actual[0], MidiEvent::new(0, vec![0x90, 64, 100]));
         assert_eq!(actual[1], MidiEvent::new(3, vec![0x80, 64, 0]));

--- a/src/rust/shoop_engine/src/engine.rs
+++ b/src/rust/shoop_engine/src/engine.rs
@@ -106,6 +106,8 @@ pub struct Stats {
     pub stuck_cycles: AtomicU32,
     /// Commands that arrived and were applied.
     pub commands_applied: AtomicU32,
+    /// Whether the engine is applying a batch removed from the visible command queue.
+    pub command_batch_in_flight: AtomicBool,
     /// Diagnostic trace publications skipped because every preallocated box was in use.
     pub trace_snapshots_dropped: AtomicU32,
     /// The newest command sequence that finished executing.
@@ -142,8 +144,8 @@ pub struct Stats {
     /// pay for one on every window whether or not anything had changed.
     ///
     /// A `true` reading can be trusted at once. A `false` reading only means the graph was
-    /// current when this was last written, so a caller must also satisfy itself that nothing
-    /// is still queued that could dirty it -- see [`EngineHandle::n_pending`].
+    /// current when this was last written, so a caller must also satisfy itself that no
+    /// topology command is queued or being applied.
     pub graph_stale: AtomicBool,
     /// Backend DSP load, as a percentage scaled by 100 so it fits an integer.
     ///
@@ -342,14 +344,7 @@ impl Engine {
     }
 
     fn process_inner(&mut self, n_frames: usize) {
-        {
-            let _span = shoop_tracing::realtime_span!("engine.rt.commands");
-            self.apply_commands();
-        }
-        {
-            let _span = shoop_tracing::realtime_span!("engine.rt.graph_state");
-            self.publish_graph_staleness();
-        }
+        self.apply_commands_and_publish_graph_staleness();
         self.cycle_inner(n_frames);
     }
 
@@ -424,16 +419,25 @@ impl Engine {
         let _span = shoop_tracing::realtime_span!("engine.rt.pump");
         crate::realtime_alloc_guard::forbid_alloc_if_enabled(|| {
             crate::realtime_lock_guard::forbid_locks_if_enabled(|| {
-                {
-                    let _commands_span = shoop_tracing::realtime_span!("engine.rt.commands");
-                    self.apply_commands();
-                }
-                {
-                    let _graph_span = shoop_tracing::realtime_span!("engine.rt.graph_state");
-                    self.publish_graph_staleness();
-                }
+                self.apply_commands_and_publish_graph_staleness();
             });
         });
+    }
+
+    fn apply_commands_and_publish_graph_staleness(&mut self) {
+        let batch_in_flight = {
+            let _span = shoop_tracing::realtime_span!("engine.rt.commands");
+            self.apply_commands()
+        };
+        {
+            let _span = shoop_tracing::realtime_span!("engine.rt.graph_state");
+            self.publish_graph_staleness();
+        }
+        if batch_in_flight {
+            self.stats
+                .command_batch_in_flight
+                .store(false, Ordering::Release);
+        }
     }
 
     /// Publishes whether the schedule has fallen behind the topology.
@@ -446,8 +450,14 @@ impl Engine {
             .store(!self.session.graph_up_to_date(), Ordering::Relaxed);
     }
 
-    fn apply_commands(&mut self) {
+    fn apply_commands(&mut self) -> bool {
         let accepted = self.commands.slots();
+        if accepted == 0 {
+            return false;
+        }
+        self.stats
+            .command_batch_in_flight
+            .store(true, Ordering::Release);
         let mut applied = 0u32;
         for _ in 0..accepted {
             let Ok(mut queued) = self.commands.pop() else {
@@ -469,6 +479,7 @@ impl Engine {
                 .commands_applied
                 .fetch_add(applied, Ordering::Relaxed);
         }
+        true
     }
 }
 
@@ -943,6 +954,23 @@ mod tests {
         check!(e.session().loop_(0).expect("loop").position() == 0);
         // And the box came back to be freed on this side, as after a cycle.
         check!(h.reclaim() == 1);
+    }
+
+    #[tracy_nextest_capture::tracy_capture_test]
+    fn command_batch_visibility_covers_execution_through_staleness_publication() {
+        let (mut e, mut h) = engine();
+        let stats = Arc::clone(h.stats());
+        let observed = Arc::clone(&stats);
+        h.send(Box::new(move |s: &mut Session| {
+            assert!(observed.command_batch_in_flight.load(Ordering::Acquire));
+            s.create_loop();
+        }))
+        .expect("queue command");
+
+        e.pump();
+
+        assert!(!stats.command_batch_in_flight.load(Ordering::Acquire));
+        assert!(stats.graph_stale.load(Ordering::Relaxed));
     }
 
     #[tracy_nextest_capture::tracy_capture_test]


### PR DESCRIPTION
## Summary
- keep graph rebuilds armed while an engine command batch is executing outside the visible queue
- publish graph staleness before clearing the in-flight batch marker
- capture ordinary `tracing` spans/events and bridged `log` records in nextest Tracy profiles
- extend the intentional capture canary to verify direct, tracing, and log instrumentation

## Root cause
The graph scheduler could inspect an empty command queue while the engine was still executing a removed topology batch. Because graph staleness was only published after that batch, the scheduler could treat the dirty generation as applied without building a schedule. The requested dummy callback then ran the prior empty schedule.

Fixes the failure in master run https://github.com/SanderVocke/shoopdaloop/actions/runs/31887824886.

The nextest subscriber support is supplied by https://github.com/SanderVocke/tracy-extensions/pull/3 and pinned to its tested commit.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --locked --workspace`
- complete native suite: 1396 passed, 1 skipped
- failing release test repeated 20 times: 20/20 passed
- nextest `always` capture of the formerly failing test validated with `tracy-query 0.6.0`; it contains 39 `engine.graph.*` zones and 80 detailed scheduled-node zones
- intentional failure capture contains the direct zone, ordinary tracing span/event, and bridged log event
- `python3 scripts/check_tracing_coverage.py --require-closed`
- upstream nextest off/failure/always capture contract