### PR TITLE
Fix remote loop duplication and peak meter decay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,8 +4097,14 @@ dependencies = [
 name = "shoop_wasm_runtime_tests"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
+ "js-sys",
+ "shoop_app",
+ "shoop_app_api",
  "shoop_audio_protocol",
+ "shoop_backend",
  "shoop_wasm_test_support",
+ "shoop_worklet_client",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/SITUATION_REPORT.md
+++ b/SITUATION_REPORT.md
@@ -1,0 +1,290 @@
+# Situation Report: Fix WASM Loop Duplication and Peak Meter Decay
+
+## Current branch and PR
+
+- Branch: `test/node-remote-app-harness`
+- PR: https://github.com/SanderVocke/shoopdaloop/pull/756
+- Current CI: fully green on commit `a56e8ac`
+- The branch is pushed and the working tree was clean before this report was added.
+
+## What PR 756 adds
+
+A reusable remote application test harness was added under:
+
+- `src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs`
+- `src/rust/shoop_wasm_runtime_tests/js/worker_fixture.js`
+
+The harness runs this complete stack:
+
+```text
+AppIntent
+  -> CooperativeApplicationRuntime
+  -> RemoteWorkletBackend
+  -> MessageEndpoint / MessagePort
+  -> production audio_worker.js
+  -> production shoop_audio_worklet.wasm
+  -> protocol responses
+  -> RemoteBackendControl
+  -> application snapshots
+```
+
+It works in the required Node WASM setup and also passed in Chromium.
+
+Three tests use it:
+
+1. `remote_application_stack_processes_intents_and_engine_quanta`
+2. `remote_loop_duplication_reproduces_async_capture_error`
+3. `remote_peak_publication_reproduces_accumulated_maximum`
+
+The latter two are **characterization tests**. They currently pass by asserting the bugs occur. They must be converted into correct-behavior regression tests as part of fixing the bugs.
+
+## Bug 1: dragging a loop to clone/duplicate fails in WASM
+
+### Reproduction now covered
+
+The remote test:
+
+```rust
+remote_loop_duplication_reproduces_async_capture_error
+```
+
+- creates a real remote audio track;
+- generates real click content in a source loop;
+- dispatches `AppIntent::Loop` with `LoopAction::DuplicateTo(target)`;
+- observes the application notification:
+  `asynchronous session capture is not complete`;
+- verifies the target remains empty.
+
+This is the same class of error shown at the top of the browser application.
+
+### Likely root cause
+
+`ApplicationModel::duplicate_loop_into()` in `src/rust/shoop_app/src/lib.rs` uses synchronous backend methods for primitive loops:
+
+```rust
+backend.capture_session()
+backend.replace_loop_content(...)
+```
+
+The in-process `EngineBackend` and `FakeBackend` complete these synchronously, which is why existing tests pass.
+
+`RemoteWorkletBackend` implements these operations using multi-message asynchronous transfers:
+
+- `capture_session()` delegates to `capture_session_async()` and returns an error while pending:
+  `asynchronous session capture is not complete`
+- `replace_loop_content()` delegates to `replace_loop_content_async()` and similarly returns an error while pending.
+
+The application already has asynchronous I/O state machinery in `PendingIo` and repeatedly advances operations such as:
+
+- session capture/load;
+- generated click content replacement;
+- loop import/export.
+
+Duplication needs an equivalent asynchronous application operation. Do not hide the problem by blocking or spinning in `RemoteWorkletBackend`; Node/browser message delivery requires yielding to the event loop.
+
+### Suggested implementation direction
+
+Add a pending duplication state machine to `ApplicationModel`. It should:
+
+1. Validate source/target and capture source metadata.
+2. Call `capture_session_async()` repeatedly until ready.
+3. Extract the source loop content.
+4. Call `replace_loop_content_async()` repeatedly until ready, or clear the target if appropriate.
+5. Apply gain and balance.
+6. Remove/replace any previous target composite as needed.
+7. Commit target model metadata only after backend success.
+8. Report errors without partially committing application state.
+
+Preserve the immediate path for synchronous backends where `BackendAsyncResult::Ready` is returned on the first call.
+
+Be careful about:
+
+- composite duplication, which follows a different path;
+- stale source/target IDs while an operation is pending;
+- only one backend transfer being active at a time;
+- interaction with existing `pending_io` operations;
+- committing name, length, media flags, cached audio/MIDI details, repeat-sync, recorded FX state, and composite fields exactly as the existing synchronous implementation does;
+- cleanup/rollback after failures.
+
+### Required test conversion
+
+Rename and invert:
+
+```rust
+remote_loop_duplication_reproduces_async_capture_error
+```
+
+The final test should assert:
+
+- no error notification;
+- the operation settles asynchronously;
+- target is non-empty;
+- target content is equivalent to source;
+- target gain and balance match source;
+- stable source and target identities are preserved.
+
+Keep the existing GUI drag tests. They already cover synthetic egui drag/drop producing `DuplicateTo`; the remote test starts at the `AppIntent` boundary.
+
+## Bug 2: WASM audio peak meters rise and never decay
+
+### Reproduction now covered
+
+The remote test:
+
+```rust
+remote_peak_publication_reproduces_accumulated_maximum
+```
+
+- creates a real remote track;
+- generates click content;
+- plays it through the production Worker/worklet WASM;
+- observes a loud loop peak in the application snapshot;
+- stops the loop and processes silent quanta;
+- verifies the published peak remains exactly at the previous maximum.
+
+This means the failure is upstream of the egui decay algorithm: egui never receives a lower target value, so it correctly has nothing to decay toward.
+
+### Likely root cause
+
+Engine audio-port/channel peaks are running maxima until explicitly reset. Existing low-level tests document this behavior.
+
+`EngineBackend::poll()` in `src/rust/shoop_backend/src/lib.rs` reads:
+
+- track input port peaks;
+- track output port peaks;
+- loop audio-channel output peaks;
+
+but does not appear to reset those accumulators after publishing the snapshot.
+
+Relevant APIs exist in the engine:
+
+- audio port `reset_input_peak()`
+- audio port `reset_output_peak()`
+- audio channel `reset_output_peak()`
+
+Global backend `input_peak` and `output_peak` are already reset during processing, but track/loop port and channel accumulators need explicit publication-window handling.
+
+### Suggested implementation direction
+
+Treat `EngineBackend::poll()` as the end of a peak measurement window:
+
+1. Read all track and loop peaks into the returned snapshot.
+2. Reset each corresponding accumulator after reading it.
+3. Ensure shared ports/channels are reset once after all required snapshot values have been collected.
+4. Avoid borrow conflicts by collecting port/channel IDs and resetting in a separate pass if necessary.
+
+Confirm desired semantics for repeated polls without processing:
+
+- first poll after loud processing publishes the loud peak;
+- a later processing window containing silence should publish silence;
+- polling twice without any processing should not accidentally retain a lifetime maximum.
+
+Consider both:
+
+- local `EngineBackend::new_dummy()` / `new_web_audio()` behavior;
+- production worklet behavior, since the worklet serializes `EngineBackend::poll()` snapshots.
+
+### Required test conversion
+
+Rename and invert:
+
+```rust
+remote_peak_publication_reproduces_accumulated_maximum
+```
+
+The final test should assert that after stopping and processing silent quanta, the application snapshot peak falls to the silence floor rather than remaining at the loud maximum.
+
+Also add a focused in-process backend regression test:
+
+```text
+process loud quantum
+-> poll reports loud peak
+-> process silent quantum
+-> poll reports silence
+```
+
+The existing egui tests in `src/rust/shoop_egui/src/meter_ballistics.rs` already verify hold/release arithmetic with explicit timestamps. A later improvement could test repaint scheduling and painted geometry over successive egui frames, but fixing backend publication is the primary issue.
+
+## Harness notes
+
+`RemoteAppHarness` owns:
+
+- production fixture JS object;
+- `CooperativeApplicationRuntime`;
+- `RemoteBackendControl`;
+- a persistent Rust closure receiving Worker protocol messages;
+- callback error collection.
+
+Important behavior:
+
+- tests run concurrently under `wasm-bindgen-test`;
+- fixture shutdown must not assert global Worker counts are zero because peer tests can still own Workers;
+- the harness waits for a published 48 kHz sample rate before tests generate click content;
+- `drive_step()` ticks the app, yields to the JS event loop, ticks again to consume responses, and yields again;
+- explicit engine processing uses 128-frame quanta.
+
+Do not replace the Node fixture with browser-only `web_sys::Worker`; Node compatibility is a requirement.
+
+## Existing coverage distinction
+
+There is extensive real-backend coverage already:
+
+- application tests against in-process `EngineBackend::new_dummy()`;
+- backend contract tests against the real engine;
+- native full-application dummy workflow tests;
+- remote backend tests against mock endpoints;
+- production Worker tests using raw protocol commands.
+
+The new harness fills the previously missing combination:
+
+```text
+application intents + RemoteWorkletBackend + real MessagePort + real Worker/worklet engine
+```
+
+## Validation and CI
+
+Before committing Rust changes, project instructions require:
+
+```sh
+cargo fmt --all
+RUSTFLAGS="-D warnings" cargo build --workspace
+```
+
+If Rust tests change:
+
+```sh
+python3 scripts/check_shoop_test_usage.py
+```
+
+This phone cannot perform the full build. Push updates to PR 756 and monitor with:
+
+```sh
+gh pr checks 756 --watch --interval 30
+```
+
+Useful CI commands and evidence:
+
+```sh
+gh run list --branch test/node-remote-app-harness
+gh run view <run-id> --job <job-id> --log-failed
+gh run download <run-id> -n wasm-test-reports-debug-<run-id> -D <dir>
+```
+
+The authoritative successful run for the current harness was:
+
+- Build/test run: `31958522271`
+- All matrix jobs passed.
+- Both Node and Chromium reports showed all three remote tests passing as characterization tests.
+
+## Project instructions already identified
+
+Read before continuing:
+
+- `AGENTS.md`
+- `.agents/index.md`
+- `.agents/rules/mandates.md`
+- `.agents/rules/style.md`
+- `.agents/info/test.md`
+- `.agents/info/ci-debug.md`
+
+The current PR is open, non-draft, and mergeable, but the bug tests still encode broken behavior. The next objective is to fix both implementations and turn those two tests into correct-behavior regression tests while keeping Node WASM CI green.

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -833,6 +833,7 @@ struct RecordedFxState {
     state: String,
 }
 
+#[derive(Clone)]
 struct LoopModel {
     id: LoopId,
     backend_id: BackendLoopId,
@@ -1034,6 +1035,17 @@ enum PendingIo {
         loop_id: LoopId,
         update: BackendLoopContentUpdate,
         message: String,
+    },
+    CaptureLoopDuplicate {
+        source: LoopModel,
+        target: LoopId,
+    },
+    CommitLoopDuplicate {
+        source: LoopModel,
+        target: LoopId,
+        update: BackendLoopContentUpdate,
+        gain: f32,
+        balance: f32,
     },
 }
 
@@ -3510,6 +3522,125 @@ impl ApplicationModel {
                     Err(error) => self.fail_io(format!("could not commit loop import: {error}")),
                 }
             }
+            PendingIo::CaptureLoopDuplicate { source, target } => {
+                match backend.capture_session_async() {
+                    Ok(BackendAsyncResult::Ready(capture)) => {
+                        let content = capture
+                            .tracks
+                            .into_iter()
+                            .flat_map(|track| track.loops)
+                            .find(|content| content.source_id == source.backend_id.raw());
+                        match content {
+                            Some(content) => {
+                                let gain = content.gain;
+                                let balance = content.balance;
+                                let update = BackendLoopContentUpdate {
+                                    audio: content
+                                        .audio
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(channel, content)| BackendAudioChannelUpdate {
+                                            channel,
+                                            samples: content.samples,
+                                            start_offset: Some(content.start_offset),
+                                            preplay: Some(content.preplay),
+                                        })
+                                        .collect(),
+                                    midi: content
+                                        .midi
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(channel, content)| BackendMidiChannelUpdate {
+                                            channel,
+                                            length: content.length,
+                                            start_state: content.start_state,
+                                            events: content.events,
+                                            start_offset: Some(content.start_offset),
+                                            preplay: Some(content.preplay),
+                                        })
+                                        .collect(),
+                                    length: Some(content.length),
+                                };
+                                if update.audio.is_empty() && update.midi.is_empty() {
+                                    let result = self
+                                        .loops
+                                        .get(&target)
+                                        .ok_or_else(|| format!("stale loop {target}"))
+                                        .and_then(|model| {
+                                            backend.clear_loop(model.backend_id).map_err(|error| {
+                                                format!(
+                                                    "could not clear duplicate target {target}: {error}"
+                                                )
+                                            })
+                                        })
+                                        .and_then(|()| {
+                                            self.finish_primitive_loop_duplicate(
+                                                backend, source, target, gain, balance,
+                                            )
+                                        });
+                                    if let Err(error) = result {
+                                        self.notify_error(error);
+                                    }
+                                } else {
+                                    self.pending_io = Some(PendingIo::CommitLoopDuplicate {
+                                        source,
+                                        target,
+                                        update,
+                                        gain,
+                                        balance,
+                                    });
+                                }
+                            }
+                            None => self.notify_error(format!(
+                                "backend content for loop {} is unavailable",
+                                source.id
+                            )),
+                        }
+                    }
+                    Ok(BackendAsyncResult::Pending(_)) => {
+                        self.pending_io = Some(PendingIo::CaptureLoopDuplicate { source, target });
+                    }
+                    Err(error) => {
+                        self.notify_error(format!("could not capture loop {}: {error}", source.id))
+                    }
+                }
+            }
+            PendingIo::CommitLoopDuplicate {
+                source,
+                target,
+                update,
+                gain,
+                balance,
+            } => {
+                let target_backend = self.loops.get(&target).map(|model| model.backend_id);
+                let result = target_backend
+                    .ok_or_else(|| anyhow!("stale loop {target}"))
+                    .and_then(|target_backend| {
+                        backend.replace_loop_content_async(target_backend, &update)
+                    });
+                match result {
+                    Ok(BackendAsyncResult::Ready(())) => {
+                        match self
+                            .finish_primitive_loop_duplicate(backend, source, target, gain, balance)
+                        {
+                            Ok(()) => {}
+                            Err(error) => self.notify_error(error),
+                        }
+                    }
+                    Ok(BackendAsyncResult::Pending(_)) => {
+                        self.pending_io = Some(PendingIo::CommitLoopDuplicate {
+                            source,
+                            target,
+                            update,
+                            gain,
+                            balance,
+                        });
+                    }
+                    Err(error) => {
+                        self.notify_error(format!("could not duplicate loop content: {error}"))
+                    }
+                }
+            }
         }
     }
 
@@ -4221,7 +4352,7 @@ impl ApplicationModel {
             ));
         }
 
-        let source_backend = self.loops[&source].backend_id;
+        let source_model = self.loops[&source].clone();
         let target_backend = self.loops[&target].backend_id;
         let source_name = self.loops[&source].name.clone();
         let source_state = self.loops[&source].state.clone();
@@ -4246,59 +4377,16 @@ impl ApplicationModel {
             }
             created
         } else {
-            let content = backend
-                .capture_session()
-                .map_err(|error| format!("could not capture loop {source}: {error}"))?
-                .tracks
-                .into_iter()
-                .flat_map(|track| track.loops)
-                .find(|content| content.source_id == source_backend.raw())
-                .ok_or_else(|| format!("backend content for loop {source} is unavailable"))?;
-            let gain = content.gain;
-            let balance = content.balance;
-            let update = BackendLoopContentUpdate {
-                audio: content
-                    .audio
-                    .into_iter()
-                    .enumerate()
-                    .map(|(channel, content)| BackendAudioChannelUpdate {
-                        channel,
-                        samples: content.samples,
-                        start_offset: Some(content.start_offset),
-                        preplay: Some(content.preplay),
-                    })
-                    .collect(),
-                midi: content
-                    .midi
-                    .into_iter()
-                    .enumerate()
-                    .map(|(channel, content)| BackendMidiChannelUpdate {
-                        channel,
-                        length: content.length,
-                        start_state: content.start_state,
-                        events: content.events,
-                        start_offset: Some(content.start_offset),
-                        preplay: Some(content.preplay),
-                    })
-                    .collect(),
-                length: Some(content.length),
-            };
-            if update.audio.is_empty() && update.midi.is_empty() {
-                backend.clear_loop(target_backend).map_err(|error| {
-                    format!("could not clear duplicate target {target}: {error}")
-                })?;
-            } else {
-                backend
-                    .replace_loop_content(target_backend, &update)
-                    .map_err(|error| format!("could not duplicate loop content: {error}"))?;
-            }
-            backend
-                .set_loop_gain(target_backend, gain)
-                .map_err(|error| format!("could not duplicate loop gain: {error}"))?;
-            backend
-                .set_loop_balance(target_backend, balance)
-                .map_err(|error| format!("could not duplicate loop balance: {error}"))?;
-            None
+            self.ensure_io_idle()?;
+            self.pending_io = Some(PendingIo::CaptureLoopDuplicate {
+                source: source_model,
+                target,
+            });
+            // Preserve immediate completion for in-process backends while remote
+            // backends retain the operation and continue it on later ticks.
+            self.advance_io(backend);
+            self.advance_io(backend);
+            return Ok(());
         };
         if let Some(id) = previous_backend_composite {
             backend
@@ -4332,6 +4420,57 @@ impl ApplicationModel {
         model.backend_composite_signature = signature;
         model.repeat_sync = source_repeat_sync;
         model.recorded_fx_state = source_recorded_fx_state;
+        Ok(())
+    }
+
+    fn finish_primitive_loop_duplicate(
+        &mut self,
+        backend: &mut dyn Backend,
+        source: LoopModel,
+        target: LoopId,
+        gain: f32,
+        balance: f32,
+    ) -> Result<(), String> {
+        let target_model = self
+            .loops
+            .get(&target)
+            .ok_or_else(|| format!("stale loop {target}"))?;
+        let target_backend = target_model.backend_id;
+        let previous_backend_composite = target_model.backend_composite;
+        backend
+            .set_loop_gain(target_backend, gain)
+            .map_err(|error| format!("could not duplicate loop gain: {error}"))?;
+        backend
+            .set_loop_balance(target_backend, balance)
+            .map_err(|error| format!("could not duplicate loop balance: {error}"))?;
+        if let Some(id) = previous_backend_composite {
+            backend
+                .remove_composite_loop(id)
+                .map_err(|error| format!("could not replace duplicate target: {error}"))?;
+        }
+
+        self.script_composition_playback.remove(&target);
+        let model = self.loops.get_mut(&target).expect("target was checked");
+        model.name = source.name.clone();
+        model.state = source.state;
+        model.state.id = target;
+        model.state.name = source.name;
+        model.state.mode = LoopMode::Stopped;
+        model.state.position = 0.0;
+        model.state.next_mode = LoopMode::Unknown;
+        model.state.next_transition_delay = None;
+        model.state.selected = false;
+        model.state.targeted = false;
+        model.length = source.length;
+        model.position = 0;
+        model.audio_data = source.audio_data;
+        model.midi_data = source.midi_data;
+        model.script_composition = source.script_composition;
+        model.composite = None;
+        model.backend_composite = None;
+        model.backend_composite_signature.clear();
+        model.repeat_sync = source.repeat_sync;
+        model.recorded_fx_state = source.recorded_fx_state;
         Ok(())
     }
 

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -9133,9 +9133,12 @@ mod tests {
             )
             .unwrap();
 
+        backend.delay_next_async_loop_copy();
         model
             .handle_loop_action(&mut backend, track_id, source, LoopAction::Duplicate)
             .unwrap();
+        model.advance_io(&mut backend);
+        model.advance_io(&mut backend);
         assert!(model.loops[&model.tracks[1].loops[0]].state.empty);
         assert_eq!(model.loops[&occupied].length, 2);
         assert_eq!(model.loops[&duplicate_target].name, "Source");

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -4441,11 +4441,11 @@ impl Backend for EngineBackend {
             let audio_peaks = channels
                 .into_iter()
                 .flat_map(|channels| &channels.audio)
-                .filter_map(|channel| self.session.audio_channel_mut(*channel))
-                .map(|channel| {
+                .filter_map(|channel| {
+                    let channel = self.session.audio_channel_mut(*channel)?;
                     let peak = amplitude_db(channel.output_peak());
                     channel.reset_output_peak();
-                    peak
+                    Some(peak)
                 })
                 .collect();
             let midi_activity = channels

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -8929,18 +8929,6 @@ mod tests {
         assert!(loud.tracks[&track.track_id].output_peaks[0] > -100.0);
         assert!(loud.loops[&track.loops[0]].audio_peaks[0] > -100.0);
 
-        backend
-            .transition_loop(track.loops[0], BackendLoopMode::Stopped, None)
-            .unwrap();
-        output.fill(0.0);
-        backend
-            .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
-            .unwrap();
-        let _ = backend.poll().unwrap();
-        output.fill(0.0);
-        backend
-            .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
-            .unwrap();
         let silent = backend.poll().unwrap();
         assert!(silent.tracks[&track.track_id].output_peaks[0] <= -100.0);
         assert!(silent.loops[&track.loops[0]].audio_peaks[0] <= -100.0);

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -5079,6 +5079,8 @@ pub struct FakeBackend {
     fail_track_creation_after: Option<usize>,
     fail_next_session_replace: Option<String>,
     fail_next_loop_content_replace: Option<String>,
+    pending_session_captures: usize,
+    pending_loop_content_replacements: usize,
     failed_midi_input_tracks: BTreeSet<BackendTrackId>,
     processor_catalog: Arc<[TrackProcessorDescriptor]>,
     default_fx_state_string: String,
@@ -5168,6 +5170,8 @@ impl Default for FakeBackend {
             fail_track_creation_after: None,
             fail_next_session_replace: None,
             fail_next_loop_content_replace: None,
+            pending_session_captures: 0,
+            pending_loop_content_replacements: 0,
             failed_midi_input_tracks: BTreeSet::new(),
             processor_catalog: Arc::from([]),
             default_fx_state_string: "{}".to_owned(),
@@ -5242,6 +5246,11 @@ impl FakeBackend {
 
     pub fn fail_next_loop_content_replace(&mut self, message: impl Into<String>) {
         self.fail_next_loop_content_replace = Some(message.into());
+    }
+
+    pub fn delay_next_async_loop_copy(&mut self) {
+        self.pending_session_captures = 1;
+        self.pending_loop_content_replacements = 1;
     }
 
     pub fn set_preflight_sample_rate_override(&mut self, sample_rate: Option<u32>) {
@@ -6357,6 +6366,24 @@ impl Backend for FakeBackend {
         Ok(())
     }
 
+    fn replace_loop_content_async(
+        &mut self,
+        loop_id: BackendLoopId,
+        update: &BackendLoopContentUpdate,
+    ) -> Result<BackendAsyncResult<()>> {
+        if self.pending_loop_content_replacements > 0 {
+            self.pending_loop_content_replacements -= 1;
+            return Ok(BackendAsyncResult::Pending(BackendOperationProgress {
+                key: 1,
+                kind: BackendOperationKind::LoopContentReplacement,
+                completed: 0,
+                total: Some(1),
+            }));
+        }
+        self.replace_loop_content(loop_id, update)
+            .map(BackendAsyncResult::Ready)
+    }
+
     fn set_loop_length(&mut self, loop_id: BackendLoopId, length: u32) -> Result<()> {
         let state = self
             .loops
@@ -6459,6 +6486,19 @@ impl Backend for FakeBackend {
             global_ports,
             use_legacy_browser_default_routes: false,
         })
+    }
+
+    fn capture_session_async(&mut self) -> Result<BackendAsyncResult<BackendSessionData>> {
+        if self.pending_session_captures > 0 {
+            self.pending_session_captures -= 1;
+            return Ok(BackendAsyncResult::Pending(BackendOperationProgress {
+                key: 1,
+                kind: BackendOperationKind::SessionCapture,
+                completed: 0,
+                total: Some(1),
+            }));
+        }
+        self.capture_session().map(BackendAsyncResult::Ready)
     }
 
     fn replace_session(

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -8936,6 +8936,11 @@ mod tests {
         backend
             .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
             .unwrap();
+        let _ = backend.poll().unwrap();
+        output.fill(0.0);
+        backend
+            .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
+            .unwrap();
         let silent = backend.poll().unwrap();
         assert!(silent.tracks[&track.track_id].output_peaks[0] <= -100.0);
         assert!(silent.loops[&track.loops[0]].audio_peaks[0] <= -100.0);

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -4357,9 +4357,13 @@ impl Backend for EngineBackend {
                 .iter()
                 .map(|port| {
                     self.session
-                        .port(*port)
-                        .and_then(Port::audio)
-                        .map(|port| amplitude_db(port.input_peak()))
+                        .port_mut(*port)
+                        .and_then(Port::audio_mut)
+                        .map(|port| {
+                            let peak = amplitude_db(port.input_peak());
+                            port.reset_input_peak();
+                            peak
+                        })
                         .unwrap_or(-200.0)
                 })
                 .collect();
@@ -4368,9 +4372,13 @@ impl Backend for EngineBackend {
                 .iter()
                 .map(|port| {
                     self.session
-                        .port(*port)
-                        .and_then(Port::audio)
-                        .map(|port| amplitude_db(port.output_peak()))
+                        .port_mut(*port)
+                        .and_then(Port::audio_mut)
+                        .map(|port| {
+                            let peak = amplitude_db(port.output_peak());
+                            port.reset_output_peak();
+                            peak
+                        })
                         .unwrap_or(-200.0)
                 })
                 .collect();
@@ -4414,14 +4422,31 @@ impl Backend for EngineBackend {
         }
         let mut loops = BTreeMap::new();
         for (id, engine_loop) in &self.loops {
-            let Some(state) = self.session.loop_(*engine_loop) else {
+            let Some((mode, length, position, next_mode, next_transition_delay)) =
+                self.session.loop_(*engine_loop).map(|state| {
+                    (
+                        from_engine_mode(state.mode()),
+                        state.length(),
+                        state.position(),
+                        state
+                            .first_planned_transition()
+                            .map(|(mode, _)| from_engine_mode(mode)),
+                        state.first_planned_transition().map(|(_, delay)| delay),
+                    )
+                })
+            else {
                 continue;
             };
             let channels = self.loop_channels.get(id);
-            let audio: Vec<_> = channels
+            let audio_peaks = channels
                 .into_iter()
                 .flat_map(|channels| &channels.audio)
-                .filter_map(|channel| self.session.audio_channel(*channel))
+                .filter_map(|channel| self.session.audio_channel_mut(*channel))
+                .map(|channel| {
+                    let peak = amplitude_db(channel.output_peak());
+                    channel.reset_output_peak();
+                    peak
+                })
                 .collect();
             let midi_activity = channels
                 .into_iter()
@@ -4431,13 +4456,11 @@ impl Backend for EngineBackend {
             loops.insert(
                 *id,
                 BackendLoopState {
-                    mode: from_engine_mode(state.mode()),
-                    length: state.length(),
-                    position: state.position(),
-                    next_mode: state
-                        .first_planned_transition()
-                        .map(|(mode, _)| from_engine_mode(mode)),
-                    next_transition_delay: state.first_planned_transition().map(|(_, delay)| delay),
+                    mode,
+                    length,
+                    position,
+                    next_mode,
+                    next_transition_delay,
                     stereo: channels.is_some_and(|channels| {
                         channels
                             .audio_modes
@@ -4450,10 +4473,7 @@ impl Backend for EngineBackend {
                     }),
                     gain: channels.map(|channels| channels.gain).unwrap_or(1.0),
                     balance: channels.map(|channels| channels.balance).unwrap_or(0.0),
-                    audio_peaks: audio
-                        .iter()
-                        .map(|channel| amplitude_db(channel.output_peak()))
-                        .collect(),
+                    audio_peaks,
                     midi_activity,
                 },
             );
@@ -8872,6 +8892,53 @@ mod tests {
         assert_eq!(status.processed_frames, 256);
         assert!(status.input_peak == 0.0);
         assert!(status.output_peak > 0.0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn engine_peak_publication_resets_measurement_window() {
+        let mut backend = EngineBackend::new_web_audio(48_000, 128).unwrap();
+        backend.configure_web_audio_channels(1, 1).unwrap();
+        let track = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "peak_window".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 1,
+            })
+            .unwrap();
+        backend
+            .transition_loop(track.loops[0], BackendLoopMode::Recording, None)
+            .unwrap();
+        let mut output = vec![0.0; 128];
+        backend
+            .process_audio_quantum(&vec![0.5; 128], 1, &mut output, 1, 128)
+            .unwrap();
+        backend
+            .transition_loop(track.loops[0], BackendLoopMode::Stopped, None)
+            .unwrap();
+        let _ = backend.poll().unwrap();
+
+        backend
+            .transition_loop(track.loops[0], BackendLoopMode::Playing, None)
+            .unwrap();
+        output.fill(0.0);
+        backend
+            .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
+            .unwrap();
+        let loud = backend.poll().unwrap();
+        assert!(loud.tracks[&track.track_id].output_peaks[0] > -100.0);
+        assert!(loud.loops[&track.loops[0]].audio_peaks[0] > -100.0);
+
+        backend
+            .transition_loop(track.loops[0], BackendLoopMode::Stopped, None)
+            .unwrap();
+        output.fill(0.0);
+        backend
+            .process_audio_quantum(&vec![0.0; 128], 1, &mut output, 1, 128)
+            .unwrap();
+        let silent = backend.poll().unwrap();
+        assert!(silent.tracks[&track.track_id].output_peaks[0] <= -100.0);
+        assert!(silent.loops[&track.loops[0]].audio_peaks[0] <= -100.0);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_wasm_runtime_tests/Cargo.toml
+++ b/src/rust/shoop_wasm_runtime_tests/Cargo.toml
@@ -13,10 +13,16 @@ default = []
 wasm-test-browser = []
 
 [dependencies]
+anyhow = { workspace = true }
+shoop_app = { path = "../shoop_app" }
+shoop_app_api = { path = "../shoop_app_api" }
 shoop_audio_protocol = { path = "../shoop_audio_protocol" }
+shoop_backend = { path = "../shoop_backend" }
 shoop_wasm_test_support = { path = "../shoop_wasm_test_support" }
+shoop_worklet_client = { path = "../shoop_worklet_client" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
 wasm-bindgen = "=0.2.127"
 wasm-bindgen-futures = "=0.4.77"
 wasm-bindgen-test = "=0.3.77"

--- a/src/rust/shoop_wasm_runtime_tests/js/worker_fixture.js
+++ b/src/rust/shoop_wasm_runtime_tests/js/worker_fixture.js
@@ -298,7 +298,6 @@ export async function shutdownRemoteApplicationFixture(fixture) {
     await stop(fixture.api, fixture.instance);
   } finally {
     fixture.api.cleanup();
-    assertNoLeaks();
   }
 }
 

--- a/src/rust/shoop_wasm_runtime_tests/js/worker_fixture.js
+++ b/src/rust/shoop_wasm_runtime_tests/js/worker_fixture.js
@@ -237,6 +237,71 @@ async function productionStop(api, instance, protocolVersion, sequence) {
   }
 }
 
+function subscribeMessages(target, callback) {
+  if (typeof target.addEventListener === 'function') {
+    const handler = event => callback(event.data);
+    target.addEventListener('message', handler);
+    target.start?.();
+    return () => target.removeEventListener('message', handler);
+  }
+  const handler = value => callback(value);
+  target.on('message', handler);
+  return () => target.off('message', handler);
+}
+
+export async function spawnRemoteApplicationFixture(
+  runtime,
+  assetLocation,
+  protocolVersion,
+  commandMaxBytes,
+  onMessage,
+) {
+  const api = await runtimeApi(runtime, assetLocation);
+  try {
+    const instance = await boot(api, protocolVersion, commandMaxBytes, 'explicit');
+    return {
+      api,
+      instance,
+      unsubscribe: subscribeMessages(instance.application, onMessage),
+      closed: false,
+    };
+  } catch (error) {
+    api.cleanup();
+    throw error;
+  }
+}
+
+export function remoteApplicationPostMessage(fixture, message) {
+  if (fixture.closed) throw new Error('remote application fixture is closed');
+  fixture.instance.application.postMessage(message);
+}
+
+export async function remoteApplicationProcessQuantum(fixture, inputs, outputChannels) {
+  if (fixture.closed) throw new Error('remote application fixture is closed');
+  return fixtureCommand(fixture.instance, {
+    kind: 'process',
+    frames: 128,
+    inputs,
+    outputChannels,
+  });
+}
+
+export async function remoteApplicationTurn() {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+export async function shutdownRemoteApplicationFixture(fixture) {
+  if (fixture.closed) return;
+  fixture.closed = true;
+  fixture.unsubscribe();
+  try {
+    await stop(fixture.api, fixture.instance);
+  } finally {
+    fixture.api.cleanup();
+    assertNoLeaks();
+  }
+}
+
 export class MultiWorkerFixture {
   static async spawn(runtime, assetLocation, protocolVersion, commandMaxBytes, modes) {
     const api = await runtimeApi(runtime, assetLocation);

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -131,7 +131,11 @@ impl RemoteAppHarness {
             callback_errors,
             _on_message: on_message,
         };
-        harness.drive_steps(4).await;
+        harness
+            .drive_until("published engine sample rate", |snapshot| {
+                snapshot.status.sample_rate == 48_000
+            })
+            .await;
         harness
     }
 

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -1,0 +1,353 @@
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use js_sys::{Array, Function, Promise};
+use shoop_app::CooperativeApplicationRuntime;
+use shoop_app_api::{
+    AppIntent, AppSnapshot, ClickTrackRequest, DirectTrackSpec, GlobalControlAction, IoTaskStatus,
+    LoopAction, LoopMode,
+};
+use shoop_backend::BackendDriverState;
+use shoop_worklet_client::{MessageEndpoint, NullHostMidiBridge, RemoteBackendControl};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+#[cfg(feature = "wasm-test-browser")]
+shoop_wasm_test_support::wasm_bindgen_test_configure!(run_in_browser);
+
+const GENERATION: u64 = 1;
+const QUANTUM: usize = 128;
+const MAX_DRIVE_STEPS: usize = 200;
+
+#[wasm_bindgen(module = "/js/worker_fixture.js")]
+extern "C" {
+    #[wasm_bindgen(catch, js_name = spawnRemoteApplicationFixture)]
+    async fn spawn_remote_application_fixture(
+        runtime: &str,
+        asset_location: &str,
+        protocol_version: u16,
+        command_max_bytes: u32,
+        on_message: &Function,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch, js_name = remoteApplicationPostMessage)]
+    fn remote_application_post_message(fixture: &JsValue, message: &str) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(catch, js_name = remoteApplicationProcessQuantum)]
+    fn remote_application_process_quantum(
+        fixture: &JsValue,
+        inputs: &Array,
+        output_channels: u32,
+    ) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(js_name = remoteApplicationTurn)]
+    fn remote_application_turn() -> Promise;
+
+    #[wasm_bindgen(catch, js_name = shutdownRemoteApplicationFixture)]
+    fn shutdown_remote_application_fixture(fixture: &JsValue) -> Result<Promise, JsValue>;
+}
+
+fn runtime_and_assets() -> (&'static str, &'static str) {
+    let browser = cfg!(feature = "wasm-test-browser");
+    let runtime = if browser { "chrome" } else { "node" };
+    let asset_location = if browser {
+        option_env!("SHOOP_WASM_TEST_ASSET_BASE")
+    } else {
+        option_env!("SHOOP_WASM_TEST_ASSET_DIR")
+    }
+    .expect("run_wasm_tests.py must provide the staged asset location");
+    (runtime, asset_location)
+}
+
+#[derive(Clone)]
+struct FixtureEndpoint {
+    fixture: JsValue,
+}
+
+impl MessageEndpoint for FixtureEndpoint {
+    fn post_message(&self, message: &str) -> anyhow::Result<()> {
+        remote_application_post_message(&self.fixture, message)
+            .map_err(|error| anyhow::anyhow!("could not post fixture message: {error:?}"))
+    }
+}
+
+struct RemoteAppHarness {
+    fixture: JsValue,
+    runtime: Option<CooperativeApplicationRuntime>,
+    control: RemoteBackendControl,
+    callback_errors: Rc<RefCell<Vec<String>>>,
+    _on_message: Closure<dyn FnMut(JsValue)>,
+}
+
+impl RemoteAppHarness {
+    async fn start() -> Self {
+        let (backend, control) =
+            shoop_worklet_client::RemoteWorkletBackend::new(NullHostMidiBridge);
+        let callback_errors = Rc::new(RefCell::new(Vec::new()));
+        let callback_control = control.clone();
+        let callback_error_sink = Rc::clone(&callback_errors);
+        let on_message = Closure::wrap(Box::new(move |message: JsValue| {
+            let Some(message) = message.as_string() else {
+                callback_error_sink.borrow_mut().push(format!(
+                    "fixture returned a non-string message: {message:?}"
+                ));
+                return;
+            };
+            if let Err(error) = callback_control.receive(GENERATION, &message) {
+                callback_error_sink.borrow_mut().push(error.to_string());
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+        let (runtime_name, assets) = runtime_and_assets();
+        let fixture = spawn_remote_application_fixture(
+            runtime_name,
+            assets,
+            shoop_audio_protocol::PROTOCOL_VERSION,
+            shoop_audio_protocol::COMMAND_MAX_BYTES as u32,
+            on_message.as_ref().unchecked_ref(),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("could not start remote application fixture: {error:?}"));
+        control
+            .attach(
+                Box::new(FixtureEndpoint {
+                    fixture: fixture.clone(),
+                }),
+                GENERATION,
+                2,
+                2,
+            )
+            .expect("attach remote application endpoint");
+        control.set_driver_state(BackendDriverState::Dummy);
+        let runtime = CooperativeApplicationRuntime::start(Box::new(backend))
+            .expect("start cooperative application runtime");
+        let mut harness = Self {
+            fixture,
+            runtime: Some(runtime),
+            control,
+            callback_errors,
+            _on_message: on_message,
+        };
+        harness.drive_steps(4).await;
+        harness
+    }
+
+    fn runtime(&self) -> &CooperativeApplicationRuntime {
+        self.runtime.as_ref().expect("remote runtime is active")
+    }
+
+    fn runtime_mut(&mut self) -> &mut CooperativeApplicationRuntime {
+        self.runtime.as_mut().expect("remote runtime is active")
+    }
+
+    fn snapshot(&self) -> Arc<AppSnapshot> {
+        self.runtime().snapshot()
+    }
+
+    fn dispatch(&mut self, intent: AppIntent) {
+        self.runtime_mut()
+            .dispatch(intent)
+            .expect("dispatch remote application intent");
+    }
+
+    fn check_callback_errors(&self) {
+        let errors = self.callback_errors.borrow();
+        assert!(errors.is_empty(), "remote callback errors: {errors:?}");
+    }
+
+    async fn turn(&self) {
+        JsFuture::from(remote_application_turn())
+            .await
+            .expect("wait for remote Worker turn");
+        self.check_callback_errors();
+    }
+
+    async fn drive_step(&mut self) {
+        self.runtime_mut().tick(Duration::from_millis(16));
+        self.turn().await;
+        self.runtime_mut().tick(Duration::ZERO);
+        self.turn().await;
+    }
+
+    async fn drive_steps(&mut self, count: usize) {
+        for _ in 0..count {
+            self.drive_step().await;
+        }
+    }
+
+    async fn drive_until(&mut self, description: &str, predicate: impl Fn(&AppSnapshot) -> bool) {
+        for _ in 0..MAX_DRIVE_STEPS {
+            if predicate(&self.snapshot()) {
+                return;
+            }
+            self.drive_step().await;
+        }
+        panic!(
+            "remote application did not reach {description}; readiness={:?}, notifications={:?}",
+            self.control.readiness(),
+            self.snapshot().notifications
+        );
+    }
+
+    async fn process_quantum(&mut self, inputs: &[Vec<f32>], output_channels: u32) {
+        let js_inputs = Array::new();
+        for input in inputs {
+            let channel = Array::new();
+            for sample in input {
+                channel.push(&JsValue::from_f64(f64::from(*sample)));
+            }
+            js_inputs.push(&channel);
+        }
+        let promise =
+            remote_application_process_quantum(&self.fixture, &js_inputs, output_channels)
+                .expect("request explicit remote quantum");
+        JsFuture::from(promise)
+            .await
+            .expect("process explicit remote quantum");
+        self.drive_steps(2).await;
+    }
+
+    async fn shutdown(mut self) {
+        self.runtime.take();
+        self.control.detach(false);
+        let promise = shutdown_remote_application_fixture(&self.fixture)
+            .expect("request remote application fixture shutdown");
+        JsFuture::from(promise)
+            .await
+            .expect("shutdown remote application fixture");
+        self.check_callback_errors();
+    }
+}
+
+fn has_notification(snapshot: &AppSnapshot, needle: &str) -> bool {
+    snapshot
+        .notifications
+        .iter()
+        .any(|notification| notification.message.contains(needle))
+}
+
+async fn add_audio_track(harness: &mut RemoteAppHarness) -> shoop_app_api::TrackState {
+    harness.dispatch(AppIntent::AddTrack(DirectTrackSpec {
+        name: "Remote fixture".to_owned(),
+        audio_channels: 2,
+        midi: false,
+    }));
+    harness
+        .drive_until("created audio track", |snapshot| snapshot.tracks.len() == 2)
+        .await;
+    harness.snapshot().tracks[1].clone()
+}
+
+async fn generate_click(harness: &mut RemoteAppHarness, loop_id: shoop_app_api::LoopId) {
+    harness.dispatch(AppIntent::GenerateClickTrack {
+        loop_id,
+        request: ClickTrackRequest {
+            bpm: 600.0,
+            click_count: 2,
+            ..Default::default()
+        },
+    });
+    harness
+        .drive_until("completed click generation", |snapshot| {
+            snapshot
+                .io_task
+                .as_ref()
+                .is_some_and(|task| task.status == IoTaskStatus::Completed)
+        })
+        .await;
+}
+
+#[shoop_wasm_test_support::shoop_test(
+    wasm_only = "requires the production WebAssembly Worker runtime"
+)]
+async fn remote_application_stack_processes_intents_and_engine_quanta() {
+    let mut harness = RemoteAppHarness::start().await;
+    let track = add_audio_track(&mut harness).await;
+    harness
+        .process_quantum(&[vec![0.0; QUANTUM], vec![0.0; QUANTUM]], 2)
+        .await;
+    harness
+        .drive_until("published processed quantum", |snapshot| {
+            snapshot.status.callback_count > 0
+        })
+        .await;
+    assert_eq!(track.loops.len(), 8);
+    assert_eq!(
+        harness.snapshot().status.driver_state,
+        shoop_app_api::AudioDriverState::Dummy
+    );
+    harness.shutdown().await;
+}
+
+#[shoop_wasm_test_support::shoop_test(
+    wasm_only = "requires the production WebAssembly Worker runtime"
+)]
+async fn remote_loop_duplication_reproduces_async_capture_error() {
+    let mut harness = RemoteAppHarness::start().await;
+    let track = add_audio_track(&mut harness).await;
+    let source = track.loops[0].id;
+    let target = track.loops[1].id;
+    generate_click(&mut harness, source).await;
+    harness.dispatch(AppIntent::Loop {
+        track_id: track.id,
+        loop_id: source,
+        action: LoopAction::DuplicateTo(target),
+    });
+    harness
+        .drive_until("reported asynchronous duplication failure", |snapshot| {
+            has_notification(snapshot, "asynchronous session capture is not complete")
+        })
+        .await;
+    assert!(harness.snapshot().tracks[1].loops[1].empty);
+    harness.shutdown().await;
+}
+
+#[shoop_wasm_test_support::shoop_test(
+    wasm_only = "requires the production WebAssembly Worker runtime"
+)]
+async fn remote_peak_publication_reproduces_accumulated_maximum() {
+    let mut harness = RemoteAppHarness::start().await;
+    let track = add_audio_track(&mut harness).await;
+    let source = track.loops[0].id;
+    generate_click(&mut harness, source).await;
+    harness.dispatch(AppIntent::Global(GlobalControlAction::SetSync(false)));
+    harness.dispatch(AppIntent::Loop {
+        track_id: track.id,
+        loop_id: source,
+        action: LoopAction::PlayClicked,
+    });
+    for _ in 0..4 {
+        harness.process_quantum(&[], 2).await;
+    }
+    harness
+        .drive_until("published loud loop peak", |snapshot| {
+            snapshot.tracks[1].loops[0].peak_left_db > -100.0
+        })
+        .await;
+    let loud_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
+    harness.dispatch(AppIntent::Loop {
+        track_id: track.id,
+        loop_id: source,
+        action: LoopAction::StopClicked,
+    });
+    harness.drive_steps(2).await;
+    harness.process_quantum(&[], 2).await;
+    harness
+        .drive_until("stopped loop", |snapshot| {
+            snapshot.tracks[1].loops[0].mode == LoopMode::Stopped
+        })
+        .await;
+    for _ in 0..3 {
+        harness.process_quantum(&[], 2).await;
+    }
+    let retained_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
+    assert!(loud_peak > -100.0, "expected a loud peak, got {loud_peak}");
+    assert!(
+        (retained_peak - loud_peak).abs() < f32::EPSILON,
+        "peak unexpectedly reset: loud={loud_peak}, retained={retained_peak}"
+    );
+    harness.shutdown().await;
+}

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -276,7 +276,7 @@ async fn remote_application_stack_processes_intents_and_engine_quanta() {
         .await;
     assert_eq!(track.loops.len(), 8);
     assert_eq!(
-        harness.snapshot().status.driver_state,
+        harness.snapshot().status.audio_driver,
         shoop_app_api::AudioDriverState::Dummy
     );
     harness.shutdown().await;

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -356,11 +356,13 @@ async fn remote_peak_publication_resets_after_silence() {
         harness.process_quantum(&[], 2).await;
     }
     harness
-        .drive_until("published loud loop peak", |snapshot| {
+        .drive_until("published loud loop and track peaks", |snapshot| {
             snapshot.tracks[1].loops[0].peak_left_db > -100.0
+                && snapshot.tracks[1].controls.output_peak_left_db > -100.0
         })
         .await;
     let loud_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
+    let loud_track_peak = harness.snapshot().tracks[1].controls.output_peak_left_db;
     harness.dispatch(AppIntent::Loop {
         track_id: track.id,
         loop_id: source,
@@ -377,15 +379,21 @@ async fn remote_peak_publication_resets_after_silence() {
         harness.process_quantum(&[], 2).await;
     }
     harness
-        .drive_until("published silent loop peak", |snapshot| {
+        .drive_until("published silent loop and track peaks", |snapshot| {
             snapshot.tracks[1].loops[0].peak_left_db <= -100.0
+                && snapshot.tracks[1].controls.output_peak_left_db <= -100.0
         })
         .await;
     let silent_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
+    let silent_track_peak = harness.snapshot().tracks[1].controls.output_peak_left_db;
     assert!(loud_peak > -100.0, "expected a loud peak, got {loud_peak}");
     assert!(
         silent_peak <= -100.0,
-        "peak did not reset after silence: loud={loud_peak}, silent={silent_peak}"
+        "loop peak did not reset after silence: loud={loud_peak}, silent={silent_peak}"
+    );
+    assert!(
+        loud_track_peak > -100.0 && silent_track_peak <= -100.0,
+        "track peak did not reset after silence: loud={loud_track_peak}, silent={silent_track_peak}"
     );
     harness.shutdown().await;
 }

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -313,7 +313,10 @@ async fn remote_loop_duplication_copies_content_and_controls() {
     });
     harness
         .drive_until("completed asynchronous loop duplication", |snapshot| {
-            !snapshot.tracks[1].loops[1].empty
+            let target = &snapshot.tracks[1].loops[1];
+            !target.empty
+                && (target.gain - 0.42).abs() < f32::EPSILON
+                && (target.balance + 0.25).abs() < f32::EPSILON
         })
         .await;
     let snapshot = harness.snapshot();

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -321,7 +321,7 @@ async fn remote_loop_duplication_copies_content_and_controls() {
     let target_state = &snapshot.tracks[1].loops[1];
     assert_eq!(source_state.id, source);
     assert_eq!(target_state.id, target);
-    assert_eq!(target_state.length, source_state.length);
+    assert_eq!(target_state.length_frames, source_state.length_frames);
     assert_eq!(target_state.gain, source_state.gain);
     assert_eq!(target_state.balance, source_state.balance);
     assert!(

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -9,7 +9,7 @@ use js_sys::{Array, Function, Promise};
 use shoop_app::CooperativeApplicationRuntime;
 use shoop_app_api::{
     AppIntent, AppSnapshot, ClickTrackRequest, DirectTrackSpec, GlobalControlAction, IoTaskStatus,
-    LoopAction, LoopMode,
+    LoopAction, LoopMode, NotificationLevel,
 };
 use shoop_backend::BackendDriverState;
 use shoop_worklet_client::{MessageEndpoint, NullHostMidiBridge, RemoteBackendControl};
@@ -226,13 +226,6 @@ impl RemoteAppHarness {
     }
 }
 
-fn has_notification(snapshot: &AppSnapshot, needle: &str) -> bool {
-    snapshot
-        .notifications
-        .iter()
-        .any(|notification| notification.message.contains(needle))
-}
-
 async fn add_audio_track(harness: &mut RemoteAppHarness) -> shoop_app_api::TrackState {
     harness.dispatch(AppIntent::AddTrack(DirectTrackSpec {
         name: "Remote fixture".to_owned(),
@@ -289,7 +282,7 @@ async fn remote_application_stack_processes_intents_and_engine_quanta() {
 #[shoop_wasm_test_support::shoop_test(
     wasm_only = "requires the production WebAssembly Worker runtime"
 )]
-async fn remote_loop_duplication_reproduces_async_capture_error() {
+async fn remote_loop_duplication_copies_content_and_controls() {
     let mut harness = RemoteAppHarness::start().await;
     let track = add_audio_track(&mut harness).await;
     let source = track.loops[0].id;
@@ -298,21 +291,54 @@ async fn remote_loop_duplication_reproduces_async_capture_error() {
     harness.dispatch(AppIntent::Loop {
         track_id: track.id,
         loop_id: source,
+        action: LoopAction::GainChanged(0.42),
+    });
+    harness.dispatch(AppIntent::Loop {
+        track_id: track.id,
+        loop_id: source,
+        action: LoopAction::BalanceChanged(-0.25),
+    });
+    harness.drive_steps(2).await;
+    harness
+        .drive_until("published source loop controls", |snapshot| {
+            let source = &snapshot.tracks[1].loops[0];
+            (source.gain - 0.42).abs() < f32::EPSILON
+                && (source.balance + 0.25).abs() < f32::EPSILON
+        })
+        .await;
+    harness.dispatch(AppIntent::Loop {
+        track_id: track.id,
+        loop_id: source,
         action: LoopAction::DuplicateTo(target),
     });
     harness
-        .drive_until("reported asynchronous duplication failure", |snapshot| {
-            has_notification(snapshot, "asynchronous session capture is not complete")
+        .drive_until("completed asynchronous loop duplication", |snapshot| {
+            !snapshot.tracks[1].loops[1].empty
         })
         .await;
-    assert!(harness.snapshot().tracks[1].loops[1].empty);
+    let snapshot = harness.snapshot();
+    let source_state = &snapshot.tracks[1].loops[0];
+    let target_state = &snapshot.tracks[1].loops[1];
+    assert_eq!(source_state.id, source);
+    assert_eq!(target_state.id, target);
+    assert_eq!(target_state.length, source_state.length);
+    assert_eq!(target_state.gain, source_state.gain);
+    assert_eq!(target_state.balance, source_state.balance);
+    assert!(
+        !snapshot
+            .notifications
+            .iter()
+            .any(|notification| notification.level == NotificationLevel::Error),
+        "unexpected duplication errors: {:?}",
+        snapshot.notifications
+    );
     harness.shutdown().await;
 }
 
 #[shoop_wasm_test_support::shoop_test(
     wasm_only = "requires the production WebAssembly Worker runtime"
 )]
-async fn remote_peak_publication_reproduces_accumulated_maximum() {
+async fn remote_peak_publication_resets_after_silence() {
     let mut harness = RemoteAppHarness::start().await;
     let track = add_audio_track(&mut harness).await;
     let source = track.loops[0].id;
@@ -347,11 +373,16 @@ async fn remote_peak_publication_reproduces_accumulated_maximum() {
     for _ in 0..3 {
         harness.process_quantum(&[], 2).await;
     }
-    let retained_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
+    harness
+        .drive_until("published silent loop peak", |snapshot| {
+            snapshot.tracks[1].loops[0].peak_left_db <= -100.0
+        })
+        .await;
+    let silent_peak = harness.snapshot().tracks[1].loops[0].peak_left_db;
     assert!(loud_peak > -100.0, "expected a loud peak, got {loud_peak}");
     assert!(
-        (retained_peak - loud_peak).abs() < f32::EPSILON,
-        "peak unexpectedly reset: loud={loud_peak}, retained={retained_peak}"
+        silent_peak <= -100.0,
+        "peak did not reset after silence: loud={loud_peak}, silent={silent_peak}"
     );
     harness.shutdown().await;
 }

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -55,7 +55,7 @@ struct PhysicalAudioDriverState {
     context_state_handler: Option<Closure<dyn FnMut(WebEvent)>>,
     track_ended_handlers: Vec<Closure<dyn FnMut(WebEvent)>>,
     input_mode: Option<AudioInputMode>,
-    repaint_context: Option<egui::Context>,
+    repaint_context: Option<eframe::egui::Context>,
 }
 
 /// Owns browser audio resources and the restricted remote transport control.
@@ -201,7 +201,7 @@ impl BrowserAudioController {
         self.driver.state.borrow().context.clone()
     }
 
-    pub fn set_repaint_context(&self, context: egui::Context) {
+    pub fn set_repaint_context(&self, context: eframe::egui::Context) {
         self.driver.state.borrow_mut().repaint_context = Some(context);
     }
 

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -55,6 +55,7 @@ struct PhysicalAudioDriverState {
     context_state_handler: Option<Closure<dyn FnMut(WebEvent)>>,
     track_ended_handlers: Vec<Closure<dyn FnMut(WebEvent)>>,
     input_mode: Option<AudioInputMode>,
+    repaint_context: Option<egui::Context>,
 }
 
 /// Owns browser audio resources and the restricted remote transport control.
@@ -95,6 +96,7 @@ impl BrowserAudioController {
             context_state_handler: None,
             track_ended_handlers: Vec::new(),
             input_mode: None,
+            repaint_context: None,
         }));
         let weak = Rc::downgrade(&inner);
         let microphone_enable_handler = Closure::wrap(Box::new(move |_event: WebEvent| {
@@ -197,6 +199,10 @@ impl BrowserAudioController {
 
     pub fn audio_context(&self) -> Option<AudioContext> {
         self.driver.state.borrow().context.clone()
+    }
+
+    pub fn set_repaint_context(&self, context: egui::Context) {
+        self.driver.state.borrow_mut().repaint_context = Some(context);
     }
 
     pub fn update_presentation(&self) {
@@ -537,12 +543,18 @@ async fn start_audio_graph(
     node.connect_with_audio_node(&context.destination())?;
 
     let port = node.port()?;
-    let control = inner.borrow().transport.clone();
+    let weak = Rc::downgrade(&inner);
     let message_handler = Closure::wrap(Box::new(move |event: MessageEvent| {
-        if let Some(json) = event.data().as_string() {
-            let _ = control.receive(generation, &json);
-        } else {
-            control.fail("worklet emitted a non-string event");
+        if let Some(inner) = weak.upgrade() {
+            let inner = inner.borrow();
+            if let Some(json) = event.data().as_string() {
+                let _ = inner.transport.receive(generation, &json);
+            } else {
+                inner.transport.fail("worklet emitted a non-string event");
+            }
+            if let Some(context) = &inner.repaint_context {
+                context.request_repaint();
+            }
         }
     }) as Box<dyn FnMut(_)>);
     port.set_onmessage(Some(message_handler.as_ref().unchecked_ref()));

--- a/src/rust/shoopdaloop/src/browser_worker.rs
+++ b/src/rust/shoopdaloop/src/browser_worker.rs
@@ -40,7 +40,7 @@ pub struct BrowserWorkerDriver {
     application_port: MessagePort,
     message_handler: Closure<dyn FnMut(MessageEvent)>,
     error_handler: Closure<dyn FnMut(WebEvent)>,
-    repaint_context: Rc<RefCell<Option<egui::Context>>>,
+    repaint_context: Rc<RefCell<Option<eframe::egui::Context>>>,
 }
 
 impl BrowserWorkerDriver {
@@ -66,7 +66,7 @@ impl BrowserWorkerDriver {
         let application_port = channel.port1();
         let worker_port = channel.port2();
         let receive_control = transport.clone();
-        let repaint_context = Rc::new(RefCell::new(None::<egui::Context>));
+        let repaint_context = Rc::new(RefCell::new(None::<eframe::egui::Context>));
         let receive_repaint_context = Rc::clone(&repaint_context);
         let message_handler = Closure::wrap(Box::new(move |event: MessageEvent| {
             if let Some(json) = event.data().as_string() {
@@ -172,7 +172,7 @@ impl BrowserWorkerDriver {
         })
     }
 
-    pub fn set_repaint_context(&self, context: egui::Context) {
+    pub fn set_repaint_context(&self, context: eframe::egui::Context) {
         *self.repaint_context.borrow_mut() = Some(context);
     }
 

--- a/src/rust/shoopdaloop/src/browser_worker.rs
+++ b/src/rust/shoopdaloop/src/browser_worker.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use anyhow::{anyhow, Result};
 use js_sys::{Array, Object, Reflect, WebAssembly};
 use shoop_audio_protocol::{COMMAND_MAX_BYTES, PROTOCOL_VERSION};
@@ -37,6 +40,7 @@ pub struct BrowserWorkerDriver {
     application_port: MessagePort,
     message_handler: Closure<dyn FnMut(MessageEvent)>,
     error_handler: Closure<dyn FnMut(WebEvent)>,
+    repaint_context: Rc<RefCell<Option<egui::Context>>>,
 }
 
 impl BrowserWorkerDriver {
@@ -62,11 +66,16 @@ impl BrowserWorkerDriver {
         let application_port = channel.port1();
         let worker_port = channel.port2();
         let receive_control = transport.clone();
+        let repaint_context = Rc::new(RefCell::new(None::<egui::Context>));
+        let receive_repaint_context = Rc::clone(&repaint_context);
         let message_handler = Closure::wrap(Box::new(move |event: MessageEvent| {
             if let Some(json) = event.data().as_string() {
                 let _ = receive_control.receive(GENERATION, &json);
             } else {
                 receive_control.fail("worker engine emitted a non-string event");
+            }
+            if let Some(context) = receive_repaint_context.borrow().as_ref() {
+                context.request_repaint();
             }
         }) as Box<dyn FnMut(_)>);
         application_port.set_onmessage(Some(message_handler.as_ref().unchecked_ref()));
@@ -159,7 +168,12 @@ impl BrowserWorkerDriver {
             application_port,
             message_handler,
             error_handler,
+            repaint_context,
         })
+    }
+
+    pub fn set_repaint_context(&self, context: egui::Context) {
+        *self.repaint_context.borrow_mut() = Some(context);
     }
 
     pub fn state(&self) -> BackendDriverState {

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -710,6 +710,8 @@ impl UnifiedApp {
         let now = Instant::now();
         let elapsed = now.saturating_duration_since(self.last_update);
         self.last_update = now;
+        #[cfg(target_arch = "wasm32")]
+        self.runtime.set_repaint_context(ui.ctx().clone());
         self.runtime.tick(elapsed);
         self.runtime.process_audio_previews();
 
@@ -1400,6 +1402,15 @@ impl Runtime {
             preview_player: browser_preview::BrowserPreviewPlayer::default(),
             applied_settings_revision: settings.revision(),
         })
+    }
+
+    fn set_repaint_context(&self, context: egui::Context) {
+        match &self.mode {
+            BrowserRuntimeMode::WebAudio(controller) => {
+                controller.set_repaint_context(context);
+            }
+            BrowserRuntimeMode::Worker(driver) => driver.set_repaint_context(context),
+        }
     }
 
     fn tick(&mut self, elapsed: Duration) {


### PR DESCRIPTION
## Summary
- add a reusable application harness backed by the production Worker/worklet Wasm stack
- make primitive loop duplication progress session capture and content replacement asynchronously
- reset track and loop peak accumulators after each backend snapshot publication
- wake egui immediately when browser Worker/worklet responses arrive, so async duplication and meter snapshots render without an unrelated browser event
- replace the original bug-characterization assertions with correct-behavior regression tests
- exercise delayed async duplication with the in-process fake backend

## Test plan
- Node Wasm: remote duplication copies content length, gain, and balance without errors
- Node Wasm: remote loop and track peaks return to silence after loud playback stops
- Chromium Wasm: both remote regression tests pass
- in-process backend: repeated polling reports a fresh peak measurement window
- full CI matrix, Rust coverage, CodeQL, and Codecov patch/project checks pass

Local builds are unavailable on the phone used for this change; validation was performed by PR CI.

