### PR TITLE
Show playhead in composite loop editor

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -7291,10 +7291,15 @@ impl ApplicationModel {
                     .collect()
             })
             .unwrap_or_default();
-        let composite = model
-            .composite
-            .as_ref()
-            .map(|composite| self.composite_details_snapshot(composite));
+        let composite = model.composite.as_ref().map(|composite| {
+            let mut details = self.composite_details_snapshot(composite);
+            details.played_frame = matches!(
+                model.state.mode,
+                LoopMode::Playing | LoopMode::PlayingDryThroughWet
+            )
+            .then_some(u64::from(model.position));
+            details
+        });
         Some(LoopDetailsState {
             generation: self.revision,
             loop_id: model.id,
@@ -7378,6 +7383,7 @@ impl ApplicationModel {
             },
             cycle_length_frames,
             timeline_length_frames,
+            played_frame: None,
             tracks,
             events,
         }

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -952,6 +952,7 @@ pub struct CompositeDetailsState {
     pub kind: CompositeKind,
     pub cycle_length_frames: u64,
     pub timeline_length_frames: u64,
+    pub played_frame: Option<u64>,
     pub tracks: Vec<CompositeTrackDetailsState>,
     pub events: Vec<CompositeEventDetailsState>,
 }

--- a/src/rust/shoop_egui/src/composite_loop_widget.rs
+++ b/src/rust/shoop_egui/src/composite_loop_widget.rs
@@ -156,6 +156,8 @@ pub struct CompositeLoopWidget {
     #[cfg(test)]
     timeline_left: Option<f32>,
     #[cfg(test)]
+    playhead_x: Option<f32>,
+    #[cfg(test)]
     box_selection_rect: Option<egui::Rect>,
     #[cfg(test)]
     delete_menu_rect: Option<egui::Rect>,
@@ -186,6 +188,8 @@ impl Default for CompositeLoopWidget {
             timeline_rect: None,
             #[cfg(test)]
             timeline_left: None,
+            #[cfg(test)]
+            playhead_x: None,
             #[cfg(test)]
             box_selection_rect: None,
             #[cfg(test)]
@@ -225,6 +229,7 @@ impl CompositeLoopWidget {
             self.highlighted_rect = None;
             self.timeline_rect = None;
             self.timeline_left = None;
+            self.playhead_x = None;
             self.box_selection_rect = None;
             self.delete_menu_rect = None;
         }
@@ -337,10 +342,10 @@ impl CompositeLoopWidget {
                     self.timeline_rect = Some(rect);
                     self.timeline_left = Some(timeline_left);
                 }
+                let cycle_width = self.cycle_width;
                 let frame_to_x = |frame: u64| {
                     let cycle_length = details.cycle_length_frames.max(1) as f64;
-                    timeline_left
-                        + (frame as f64 / cycle_length * f64::from(self.cycle_width)) as f32
+                    timeline_left + (frame as f64 / cycle_length * f64::from(cycle_width)) as f32
                 };
 
                 painter.rect_filled(rect, 0.0, colors::WAVEFORM_BACKGROUND);
@@ -525,6 +530,20 @@ impl CompositeLoopWidget {
                     &event_rects,
                     payload.is_some(),
                 );
+                if let Some(played_frame) = details.played_frame {
+                    let x = frame_to_x(played_frame);
+                    if timeline_clip_rect.x_range().contains(x) {
+                        painter.vline(
+                            x,
+                            rect.y_range(),
+                            egui::Stroke::new(2.0, colors::WAVEFORM_PLAYHEAD),
+                        );
+                        #[cfg(test)]
+                        {
+                            self.playhead_x = Some(x);
+                        }
+                    }
+                }
                 let pointer = ui.ctx().pointer_hover_pos();
                 let hovered_iteration = payload
                     .filter(|payload| payload.loop_id != self.loop_id)
@@ -751,6 +770,7 @@ mod tests {
                 .map(|event| event.end_frame)
                 .max()
                 .unwrap_or(0),
+            played_frame: None,
             tracks: vec![
                 CompositeTrackDetailsState {
                     id: TrackId::from_raw(1),
@@ -1321,6 +1341,27 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn current_position_is_painted_at_its_timeline_frame() {
+        let context = egui::Context::default();
+        let mut widget = CompositeLoopWidget::default();
+        let mut state = details(vec![event(1, 1, 0, 300)]);
+        state.played_frame = Some(150);
+
+        widget_frame(
+            &context,
+            &mut widget,
+            LoopId::from_raw(8),
+            &state,
+            Vec::new(),
+        );
+
+        assert_eq!(
+            widget.playhead_x,
+            Some(widget.timeline_left.unwrap() + DEFAULT_CYCLE_WIDTH * 1.5)
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn widget_paints_named_events_grows_rows_and_has_bounded_zoomed_overflow() {
         let context = egui::Context::default();
         let state = details(vec![event(1, 1, 0, 300), event(2, 1, 100, 200)]);
@@ -1381,6 +1422,7 @@ mod tests {
             kind: CompositeKind::Regular,
             cycle_length_frames: 100,
             timeline_length_frames: 1_000,
+            played_frame: None,
             tracks,
             events,
         };

--- a/src/rust/shoop_egui/src/details_pane.rs
+++ b/src/rust/shoop_egui/src/details_pane.rs
@@ -91,6 +91,7 @@ mod tests {
                 kind: CompositeKind::Script,
                 cycle_length_frames: 100,
                 timeline_length_frames: 200,
+                played_frame: None,
                 tracks: vec![CompositeTrackDetailsState {
                     id: TrackId::from_raw(2),
                     name: "Rhythm".to_owned(),


### PR DESCRIPTION
### Motivation

- Make the composite loop editor show the moving playhead (current playback frame) so it matches the audio and MIDI content views and makes the editor easier to follow while playing.

### Description

- Add an optional `played_frame: Option<u64>` to `CompositeDetailsState` to carry the selected composite's active playback frame. 
- Populate `played_frame` from the model when the selected composite is playing (including dry-through playback) in the application snapshot path. 
- Draw a clipped, vertical playhead in `CompositeLoopWidget::show` using the same playhead color used by the waveform/midi views and expose a test-only `playhead_x` for verification. 
- Add a regression test (`current_position_is_painted_at_its_timeline_frame`) and small test scaffolding updates in `details_pane`/composite test helpers to cover the new behavior.

### Testing

- Ran the new unit test: `cargo test -p shoop_egui composite_loop_widget::tests::current_position_is_painted_at_its_timeline_frame`, which passed. 
- Ran `cargo test -p shoop_app -p shoop_egui` (all package tests); the test run completed successfully (all tests passed). 
- Performed a targeted warning-denying build of the changed packages with `RUSTFLAGS="-D warnings" cargo build -p shoop_app_api -p shoop_app -p shoop_egui`, which succeeded. 
- Checked formatting and diffs with `cargo fmt --all -- --check` and `git diff --check`, both succeeded. 
- Attempted a full workspace `RUSTFLAGS="-D warnings" cargo build --workspace`; native crates compiled but the final workspace link failed due to the container’s non-PIC Tracy native archive when producing `libshoop_audio_worklet.so` (environment/linker issue unrelated to the UI change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82cfecac708328838c2275b8162194)