### PR TITLE
Highlight loops referenced by selected composite schedules

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -7198,6 +7198,25 @@ impl ApplicationModel {
     }
 
     fn snapshot(&self) -> AppSnapshot {
+        let selected_composite_references = self
+            .loops
+            .values()
+            .filter(|model| model.state.selected)
+            .filter_map(|model| {
+                model.composite.as_ref().map(|composite| {
+                    (
+                        model.state.composite_kind,
+                        composite
+                            .playlists
+                            .iter()
+                            .flatten()
+                            .flatten()
+                            .map(|event| LoopId::from_raw(event.loop_id)),
+                    )
+                })
+            })
+            .flat_map(|(kind, references)| references.map(move |loop_id| (loop_id, kind)))
+            .collect::<BTreeMap<_, _>>();
         AppSnapshot {
             revision: self.revision,
             tracks: self
@@ -7218,6 +7237,10 @@ impl ApplicationModel {
                             let mut state = model.state.clone();
                             state.name.clone_from(&model.name);
                             state.length_frames = u64::from(model.length);
+                            state.selected_composite_kind = selected_composite_references
+                                .get(&model.id)
+                                .copied()
+                                .unwrap_or_default();
                             state
                         })
                         .collect(),
@@ -11219,6 +11242,31 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert!(details.midi_channels.is_empty());
         let details = details.composite.unwrap();
         assert_eq!(details.kind, shoop_app_api::CompositeKind::Script);
+        let snapshot = model.snapshot();
+        let loop_state = |id| {
+            snapshot
+                .tracks
+                .iter()
+                .flat_map(|track| &track.loops)
+                .find(|loop_| loop_.id == id)
+                .unwrap()
+        };
+        assert_eq!(
+            loop_state(rhythm_a).selected_composite_kind,
+            shoop_app_api::CompositeKind::Script
+        );
+        assert_eq!(
+            loop_state(rhythm_b).selected_composite_kind,
+            shoop_app_api::CompositeKind::Script
+        );
+        assert_eq!(
+            loop_state(melody).selected_composite_kind,
+            shoop_app_api::CompositeKind::Script
+        );
+        assert_eq!(
+            loop_state(target).selected_composite_kind,
+            shoop_app_api::CompositeKind::None
+        );
         assert_eq!(details.cycle_length_frames, 50);
         assert_eq!(
             details

--- a/src/rust/shoop_egui/src/colors.rs
+++ b/src/rust/shoop_egui/src/colors.rs
@@ -25,6 +25,7 @@ pub const MIDI_ACTIVITY: Color32 = Color32::from_rgb(72, 156, 230);
 pub const AUDIO_ACTIVITY: Color32 = Color32::from_rgb(0, 188, 212);
 
 pub const LOOP_REGULAR_COMPOSITE: Color32 = Color32::from_rgb(156, 96, 112);
+pub const LOOP_COMPOSITE_REFERENCE_EDGE: Color32 = Color32::from_rgb(196, 120, 141);
 pub const LOOP_SCRIPT_COMPOSITE: Color32 = Color32::from_rgb(119, 170, 119);
 pub const LOOP_AUDIO_BACKGROUND: Color32 = Color32::from_rgb(0, 0, 68);
 pub const LOOP_RECORDING_BACKGROUND: Color32 = Color32::from_rgb(68, 0, 0);

--- a/src/rust/shoop_egui/src/loop_widget.rs
+++ b/src/rust/shoop_egui/src/loop_widget.rs
@@ -274,6 +274,20 @@ fn can_generate_click_track(state: &LoopState) -> bool {
     state.composite_kind == CompositeKind::None && (state.has_audio || state.has_midi)
 }
 
+fn loop_border_color(state: &LoopState) -> egui::Color32 {
+    if state.targeted {
+        colors::LOOP_TARGET_EDGE
+    } else if state.selected {
+        colors::LOOP_SELECTED_EDGE
+    } else if state.selected_composite_kind != CompositeKind::None {
+        colors::LOOP_COMPOSITE_REFERENCE_EDGE
+    } else if state.empty {
+        colors::MUTED_FOREGROUND
+    } else {
+        colors::LOOP_CONTENT_EDGE
+    }
+}
+
 fn can_convert_to_composite(state: &LoopState) -> bool {
     state.composite_kind == CompositeKind::None
 }
@@ -639,19 +653,7 @@ impl LoopWidget {
             );
         }
 
-        let border_color = if state.targeted {
-            colors::LOOP_TARGET_EDGE
-        } else if state.selected {
-            colors::LOOP_SELECTED_EDGE
-        } else if state.selected_composite_kind == CompositeKind::Regular {
-            colors::LOOP_REGULAR_COMPOSITE
-        } else if state.selected_composite_kind == CompositeKind::Script {
-            colors::LOOP_SCRIPT_COMPOSITE
-        } else if state.empty {
-            colors::MUTED_FOREGROUND
-        } else {
-            colors::LOOP_CONTENT_EDGE
-        };
+        let border_color = loop_border_color(state);
         ui.painter().rect_stroke(
             rect,
             rounding,
@@ -1926,6 +1928,33 @@ mod tests {
             composite_kind: CompositeKind::Regular,
             ..Default::default()
         }));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn composite_reference_border_yields_to_selection_and_targeting() {
+        let referenced = LoopState {
+            selected_composite_kind: CompositeKind::Regular,
+            ..Default::default()
+        };
+        assert_eq!(
+            loop_border_color(&referenced),
+            colors::LOOP_COMPOSITE_REFERENCE_EDGE
+        );
+        assert_eq!(
+            loop_border_color(&LoopState {
+                selected: true,
+                ..referenced.clone()
+            }),
+            colors::LOOP_SELECTED_EDGE
+        );
+        assert_eq!(
+            loop_border_color(&LoopState {
+                targeted: true,
+                selected: true,
+                ..referenced
+            }),
+            colors::LOOP_TARGET_EDGE
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]


### PR DESCRIPTION
### Motivation

- Make composite-loop selections visually indicate which primitive loops are referenced by the composite's schedule so the user can see references at-a-glance. 
- Use a slightly brighter pink outline for referenced loops that visually matches composite styling while preserving selection/targeting outline precedence.

### Description

- Add a new color `LOOP_COMPOSITE_REFERENCE_EDGE` in `src/rust/shoop_egui/src/colors.rs` for the brighter pink composite reference outline. 
- Compute referenced loops for any selected composite in the application snapshot by collecting every loop ID referenced in the selected composite playlists and attach the `selected_composite_kind` to track loop states in `src/rust/shoop_app/src/lib.rs`. 
- Introduce `loop_border_color` in `src/rust/shoop_egui/src/loop_widget.rs` and replace the previous inline border-selection logic so referenced-composite outlines are used when appropriate while still yielding precedence to `targeted` and `selected` outlines. 
- Add unit tests: a `shoop_app` test to ensure referenced-composite propagation into snapshots, and a `shoop_egui` test validating that the composite-reference border is used and yields to selection/targeting.

### Testing

- Ran `cargo fmt --all -- --check` (installed `rustfmt` during the run) and the formatting check passed. 
- Ran `cargo test -p shoop_egui composite_reference_border_yields_to_selection_and_targeting` and the test passed. 
- Ran `cargo test -p shoop_app composite_details -- --nocapture` (the composite details test exercising the snapshot propagation) and the test passed. 
- Ran `python3 scripts/check_shoop_test_usage.py` which passed. 
- Attempted full workspace build with `RUSTFLAGS="-D warnings" cargo build --workspace`, which failed during linking of native crates in this environment (errors from native/tracy and audio backends requiring PIC and system libs); this is an environment/tooling failure unrelated to the logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82dd37316c83289e9f9e526ce72668)