### PR TITLE
Support script composites and per-event script modes (API, backend, and UI)

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -893,14 +893,11 @@ fn composite_with_source_at(
     start_iteration: u64,
 ) -> CompositeDocument {
     let mut composite = existing.clone();
-    composite.kind = CompositeKindDocument::Regular;
-    for event in composite.playlists.iter_mut().flatten().flatten() {
-        event.mode = None;
-    }
+    let mode = (composite.kind == CompositeKindDocument::Script).then(|| "playing".to_owned());
     composite.playlists.push(vec![vec![CompositeEventDocument {
         delay: start_iteration,
         loop_id: source.raw(),
-        mode: None,
+        mode,
         n_cycles: None,
     }]]);
     composite
@@ -1275,6 +1272,15 @@ impl ApplicationModel {
                 source_loop_id,
                 n_cycles,
             } => self.set_composite_loop_cycles(backend, target_loop_id, source_loop_id, n_cycles),
+            AppIntent::SetCompositeKind {
+                target_loop_id,
+                kind,
+            } => self.set_composite_kind(backend, target_loop_id, kind),
+            AppIntent::SetCompositeEventMode {
+                target_loop_id,
+                event,
+                mode,
+            } => self.set_composite_event_mode(backend, target_loop_id, event, mode),
             AppIntent::KeyEvent(event) => self.handle_script_key_event(backend, event),
             AppIntent::AddScriptSource {
                 name,
@@ -4856,7 +4862,10 @@ impl ApplicationModel {
         target_model.script_composition = sections;
         target_model.length = length;
         target_model.state.empty = false;
-        target_model.state.composite_kind = shoop_app_api::CompositeKind::Regular;
+        target_model.state.composite_kind = match composite.kind {
+            CompositeKindDocument::Regular => shoop_app_api::CompositeKind::Regular,
+            CompositeKindDocument::Script => shoop_app_api::CompositeKind::Script,
+        };
         target_model.composite = Some(composite);
         target_model.backend_composite = Some(backend_composite);
         target_model.backend_composite_signature = signature;
@@ -4991,6 +5000,133 @@ impl ApplicationModel {
             .unwrap_or(u32::MAX);
         let target_model = self.loops.get_mut(&target).unwrap();
         target_model.length = length;
+        target_model.composite = Some(composite);
+        target_model.backend_composite = backend_composite;
+        target_model.backend_composite_signature = signature;
+        Ok(())
+    }
+
+    fn set_composite_kind(
+        &mut self,
+        backend: &mut dyn Backend,
+        target: LoopId,
+        kind: shoop_app_api::CompositeKind,
+    ) -> Result<(), String> {
+        let document_kind = match kind {
+            shoop_app_api::CompositeKind::Regular => CompositeKindDocument::Regular,
+            shoop_app_api::CompositeKind::Script => CompositeKindDocument::Script,
+            shoop_app_api::CompositeKind::None => {
+                return Err("a composite cannot be changed to a primitive loop".to_owned());
+            }
+        };
+        let mut composite = self
+            .loops
+            .get(&target)
+            .ok_or_else(|| format!("stale or unknown composition target {target}"))?
+            .composite
+            .clone()
+            .ok_or_else(|| format!("composition target {target} is not a composite"))?;
+        composite.kind = document_kind;
+        for event in composite.playlists.iter_mut().flatten().flatten() {
+            event.mode = match document_kind {
+                CompositeKindDocument::Regular => None,
+                CompositeKindDocument::Script => Some("playing".to_owned()),
+            };
+        }
+        self.commit_composite_editor_change(backend, target, composite)
+    }
+
+    fn set_composite_event_mode(
+        &mut self,
+        backend: &mut dyn Backend,
+        target: LoopId,
+        event_id: CompositeEventId,
+        mode: LoopMode,
+    ) -> Result<(), String> {
+        let mode = match mode {
+            LoopMode::Stopped => "stopped",
+            LoopMode::Playing => "playing",
+            LoopMode::Recording => "recording",
+            LoopMode::Replacing => "replacing",
+            LoopMode::PlayingDryThroughWet => "playing_dry_through_wet",
+            LoopMode::RecordingDryIntoWet => "recording_dry_into_wet",
+            LoopMode::Unknown => return Err("unknown is not a script event mode".to_owned()),
+        };
+        let mut composite = self
+            .loops
+            .get(&target)
+            .ok_or_else(|| format!("stale or unknown composition target {target}"))?
+            .composite
+            .clone()
+            .ok_or_else(|| format!("composition target {target} is not a composite"))?;
+        if composite.kind != CompositeKindDocument::Script {
+            return Err("event modes can only be edited in script composites".to_owned());
+        }
+        let event = composite
+            .playlists
+            .get_mut(event_id.playlist_index as usize)
+            .and_then(|playlist| playlist.get_mut(event_id.section_index as usize))
+            .and_then(|section| section.get_mut(event_id.parallel_index as usize))
+            .ok_or_else(|| "stale or unknown composite event".to_owned())?;
+        event.mode = Some(mode.to_owned());
+        self.commit_composite_editor_change(backend, target, composite)
+    }
+
+    fn commit_composite_editor_change(
+        &mut self,
+        backend: &mut dyn Backend,
+        target: LoopId,
+        composite: CompositeDocument,
+    ) -> Result<(), String> {
+        let target_model = self.loops.get(&target).unwrap();
+        let previous_backend_composite = target_model.backend_composite;
+        let has_events = composite
+            .playlists
+            .iter()
+            .flatten()
+            .any(|section| !section.is_empty());
+        let config = (has_events && backend.supports_composite_loops())
+            .then(|| self.backend_composite_config(&composite))
+            .transpose()?
+            .flatten();
+        let backend_composite = match (previous_backend_composite, config) {
+            (Some(id), Some(config)) => {
+                backend
+                    .configure_composite_loop(id, &config)
+                    .map_err(|error| format!("could not configure composite loop: {error}"))?;
+                Some(id)
+            }
+            (None, Some(config)) => {
+                let id = backend
+                    .create_composite_loop()
+                    .map_err(|error| format!("could not create composite loop: {error}"))?;
+                if let Err(error) = backend.configure_composite_loop(id, &config) {
+                    let _ = backend.remove_composite_loop(id);
+                    return Err(format!("could not configure composite loop: {error}"));
+                }
+                Some(id)
+            }
+            (Some(id), None) => {
+                backend
+                    .remove_composite_loop(id)
+                    .map_err(|error| format!("could not remove composite loop: {error}"))?;
+                None
+            }
+            (None, None) => None,
+        };
+        let signature = self.composite_length_signature(&composite);
+        let length = self
+            .composite_details_snapshot(&composite)
+            .timeline_length_frames
+            .try_into()
+            .unwrap_or(u32::MAX);
+        let kind = match composite.kind {
+            CompositeKindDocument::Regular => shoop_app_api::CompositeKind::Regular,
+            CompositeKindDocument::Script => shoop_app_api::CompositeKind::Script,
+        };
+        let target_model = self.loops.get_mut(&target).unwrap();
+        target_model.length = length;
+        target_model.state.composite_kind = kind;
         target_model.composite = Some(composite);
         target_model.backend_composite = backend_composite;
         target_model.backend_composite_signature = signature;

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1591,6 +1591,15 @@ pub enum AppIntent {
         source_loop_id: LoopId,
         n_cycles: Option<u32>,
     },
+    SetCompositeKind {
+        target_loop_id: LoopId,
+        kind: CompositeKind,
+    },
+    SetCompositeEventMode {
+        target_loop_id: LoopId,
+        event: CompositeEventId,
+        mode: LoopMode,
+    },
     KeyEvent(KeyEvent),
     AddScriptSource {
         name: String,
@@ -1825,6 +1834,8 @@ impl AppIntent {
             Self::ComposeLoopAt { .. } => "loop.compose_at",
             Self::DeleteCompositeEvents { .. } => "loop.composite.delete_events",
             Self::SetCompositeLoopCycles { .. } => "loop.composite.set_loop_cycles",
+            Self::SetCompositeKind { .. } => "loop.composite.set_kind",
+            Self::SetCompositeEventMode { .. } => "loop.composite.set_event_mode",
             Self::KeyEvent(_) => "scripting.key_event",
             Self::AddScriptSource { .. } => "scripting.add_source",
             Self::AddEphemeralScript { .. } => "scripting.add_ephemeral",
@@ -2147,6 +2158,27 @@ mod tests {
             n_cycles: Some(4),
         };
         assert_eq!(force_length.kind(), "loop.composite.set_loop_cycles");
+        assert_eq!(
+            AppIntent::SetCompositeKind {
+                target_loop_id: loop_id,
+                kind: CompositeKind::Script,
+            }
+            .kind(),
+            "loop.composite.set_kind"
+        );
+        assert_eq!(
+            AppIntent::SetCompositeEventMode {
+                target_loop_id: loop_id,
+                event: CompositeEventId {
+                    playlist_index: 1,
+                    section_index: 2,
+                    parallel_index: 3,
+                },
+                mode: LoopMode::Recording,
+            }
+            .kind(),
+            "loop.composite.set_event_mode"
+        );
         assert_eq!(
             LoopAction::NameChanged("Verse".to_owned()).kind(),
             "loop.name"

--- a/src/rust/shoop_egui/src/composite_loop_widget.rs
+++ b/src/rust/shoop_egui/src/composite_loop_widget.rs
@@ -132,6 +132,39 @@ fn event_color(event: &CompositeEventDetailsState) -> egui::Color32 {
     }
 }
 
+const SCRIPT_EVENT_MODES: [(LoopMode, &str); 6] = [
+    (LoopMode::Playing, "Play"),
+    (LoopMode::Recording, "Record"),
+    (LoopMode::Replacing, "Replace"),
+    (LoopMode::PlayingDryThroughWet, "Play dry through wet"),
+    (LoopMode::RecordingDryIntoWet, "Record dry into wet"),
+    (LoopMode::Stopped, "Stop"),
+];
+
+fn script_mode_label(mode: Option<&str>) -> &str {
+    match mode {
+        Some("playing") => "Play",
+        Some("recording") => "Record",
+        Some("replacing") => "Replace",
+        Some("playing_dry_through_wet") => "Play dry/wet",
+        Some("recording_dry_into_wet") => "Record dry/wet",
+        Some("stopped") => "Stop",
+        _ => "Unknown",
+    }
+}
+
+fn script_mode_key(mode: LoopMode) -> &'static str {
+    match mode {
+        LoopMode::Playing => "playing",
+        LoopMode::Recording => "recording",
+        LoopMode::Replacing => "replacing",
+        LoopMode::PlayingDryThroughWet => "playing_dry_through_wet",
+        LoopMode::RecordingDryIntoWet => "recording_dry_into_wet",
+        LoopMode::Stopped => "stopped",
+        LoopMode::Unknown => "unknown",
+    }
+}
+
 #[derive(Debug)]
 pub struct CompositeLoopWidget {
     loop_id: LoopId,
@@ -167,6 +200,12 @@ pub struct CompositeLoopWidget {
     force_length_menu_rect: Option<egui::Rect>,
     #[cfg(test)]
     natural_length_menu_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    regular_kind_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    script_kind_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    mode_menu_rects: Vec<(LoopMode, egui::Rect)>,
 }
 
 impl Default for CompositeLoopWidget {
@@ -205,6 +244,12 @@ impl Default for CompositeLoopWidget {
             force_length_menu_rect: None,
             #[cfg(test)]
             natural_length_menu_rect: None,
+            #[cfg(test)]
+            regular_kind_rect: None,
+            #[cfg(test)]
+            script_kind_rect: None,
+            #[cfg(test)]
+            mode_menu_rects: Vec::new(),
         }
     }
 }
@@ -245,15 +290,31 @@ impl CompositeLoopWidget {
             self.delete_menu_rect = None;
             self.force_length_menu_rect = None;
             self.natural_length_menu_rect = None;
+            self.regular_kind_rect = None;
+            self.script_kind_rect = None;
+            self.mode_menu_rects.clear();
         }
 
+        let mut intents = Vec::new();
         let fit_width = (ui.available_width() - TRACK_LABEL_WIDTH).max(1.0);
         ui.horizontal(|ui| {
-            ui.label(match details.kind {
-                crate::CompositeKind::Regular => "Regular composition",
-                crate::CompositeKind::Script => "Script composition",
-                crate::CompositeKind::None => "Composition",
-            });
+            ui.label("Type");
+            let mut kind = details.kind;
+            let regular = ui.selectable_value(&mut kind, crate::CompositeKind::Regular, "Regular");
+            let script = ui.selectable_value(&mut kind, crate::CompositeKind::Script, "Script");
+            #[cfg(test)]
+            {
+                self.regular_kind_rect = Some(regular.rect);
+                self.script_kind_rect = Some(script.rect);
+            }
+            #[cfg(not(test))]
+            let _ = (regular, script);
+            if kind != details.kind {
+                intents.push(AppIntent::SetCompositeKind {
+                    target_loop_id: loop_id,
+                    kind,
+                });
+            }
             ui.separator();
             ui.label("Zoom");
             if ui.small_button("−").clicked() {
@@ -279,7 +340,6 @@ impl CompositeLoopWidget {
             }
         });
 
-        let mut intents = Vec::new();
         let mut drop_iteration = None;
         let (_drop_zone, dropped) = ui.dnd_drop_zone::<LoopDragPayload, _>(
             egui::Frame::new().inner_margin(egui::Margin::same(3)),
@@ -382,6 +442,7 @@ impl CompositeLoopWidget {
                 let mut context_event = None;
                 let mut delete_requested = false;
                 let mut length_request = None;
+                let mut mode_request = None;
                 let mut row_top = rect.top() + HEADER_HEIGHT + TRACK_GAP;
                 for (track_state, track_layout) in details.tracks.iter().zip(&packed) {
                     let height = track_height(track_layout.lane_count);
@@ -458,6 +519,21 @@ impl CompositeLoopWidget {
                                         });
                                 }
                                 response.context_menu(|ui| {
+                                    if details.kind == crate::CompositeKind::Script {
+                                        ui.label("Mode");
+                                        for (mode, label) in SCRIPT_EVENT_MODES {
+                                            let selected = event.mode.as_deref()
+                                                == Some(script_mode_key(mode));
+                                            let response = ui.selectable_label(selected, label);
+                                            #[cfg(test)]
+                                            self.mode_menu_rects.push((mode, response.rect));
+                                            if response.clicked() {
+                                                mode_request = Some((event_key, mode));
+                                                ui.close();
+                                            }
+                                        }
+                                        ui.separator();
+                                    }
                                     ui.horizontal(|ui| {
                                         ui.label("Length");
                                         ui.add(
@@ -532,10 +608,19 @@ impl CompositeLoopWidget {
                                     egui::pos2(label_left, event_rect.top()),
                                     event_rect.right_bottom(),
                                 );
+                                let label = if details.kind == crate::CompositeKind::Script {
+                                    format!(
+                                        "{} · {}",
+                                        event.loop_name,
+                                        script_mode_label(event.mode.as_deref())
+                                    )
+                                } else {
+                                    event.loop_name.clone()
+                                };
                                 painter.with_clip_rect(event_rect.shrink(3.0)).text(
                                     label_rect.center(),
                                     egui::Align2::CENTER_CENTER,
-                                    &event.loop_name,
+                                    label,
                                     egui::FontId::proportional(12.0),
                                     colors::FOREGROUND,
                                 );
@@ -592,6 +677,13 @@ impl CompositeLoopWidget {
                         target_loop_id: self.loop_id,
                         source_loop_id,
                         n_cycles,
+                    });
+                }
+                if let Some((event, mode)) = mode_request {
+                    intents.push(AppIntent::SetCompositeEventMode {
+                        target_loop_id: self.loop_id,
+                        event: event.into(),
+                        mode,
                     });
                 }
                 if !self.selected_events.is_empty()
@@ -1620,5 +1712,136 @@ mod tests {
             assert!(widget.content_size.x > size.x);
             assert!(widget.content_size.y > size.y);
         }
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn type_toggle_emits_kind_change_and_script_events_show_their_mode() {
+        let context = egui::Context::default();
+        let loop_id = LoopId::from_raw(8);
+        let mut widget = CompositeLoopWidget::default();
+        let regular = details(vec![event(1, 1, 0, 100)]);
+        let _ = widget_frame(&context, &mut widget, loop_id, &regular, Vec::new());
+        let script_center = widget.script_kind_rect.unwrap().center();
+        let _ = widget_frame(
+            &context,
+            &mut widget,
+            loop_id,
+            &regular,
+            vec![
+                egui::Event::PointerMoved(script_center),
+                egui::Event::PointerButton {
+                    pos: script_center,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        let intents = widget_frame(
+            &context,
+            &mut widget,
+            loop_id,
+            &regular,
+            vec![egui::Event::PointerButton {
+                pos: script_center,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+        assert_eq!(
+            intents,
+            [AppIntent::SetCompositeKind {
+                target_loop_id: loop_id,
+                kind: CompositeKind::Script,
+            }]
+        );
+
+        let mut script = regular;
+        script.kind = CompositeKind::Script;
+        script.events[0].mode = Some("recording".to_owned());
+        let output = context.run_ui(Default::default(), |ui| {
+            widget.show(ui, loop_id, &script);
+        });
+        assert!(output.shapes.iter().any(|shape| match &shape.shape {
+            egui::Shape::Text(text) => text.galley.job.text.contains("Loop 1 · Record"),
+            _ => false,
+        }));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn script_event_context_menu_emits_mode_change_for_one_instance() {
+        let context = egui::Context::default();
+        let loop_id = LoopId::from_raw(8);
+        let mut script = details(vec![keyed_event(3, 1, 1, 20, 100)]);
+        script.kind = CompositeKind::Script;
+        script.events[0].mode = Some("playing".to_owned());
+        let mut widget = CompositeLoopWidget::default();
+        let _ = widget_frame(&context, &mut widget, loop_id, &script, Vec::new());
+        let event_center = widget.rendered_events[0].1.center();
+        for pressed in [true, false] {
+            let _ = widget_frame(
+                &context,
+                &mut widget,
+                loop_id,
+                &script,
+                vec![
+                    egui::Event::PointerMoved(event_center),
+                    egui::Event::PointerButton {
+                        pos: event_center,
+                        button: egui::PointerButton::Secondary,
+                        pressed,
+                        modifiers: egui::Modifiers::NONE,
+                    },
+                ],
+            );
+        }
+        let _ = widget_frame(&context, &mut widget, loop_id, &script, Vec::new());
+        let record_center = widget
+            .mode_menu_rects
+            .iter()
+            .find(|(mode, _)| *mode == LoopMode::Recording)
+            .unwrap()
+            .1
+            .center();
+        let _ = widget_frame(
+            &context,
+            &mut widget,
+            loop_id,
+            &script,
+            vec![
+                egui::Event::PointerMoved(record_center),
+                egui::Event::PointerButton {
+                    pos: record_center,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        let intents = widget_frame(
+            &context,
+            &mut widget,
+            loop_id,
+            &script,
+            vec![egui::Event::PointerButton {
+                pos: record_center,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            }],
+        );
+        assert_eq!(
+            intents,
+            [AppIntent::SetCompositeEventMode {
+                target_loop_id: loop_id,
+                event: CompositeEventId {
+                    playlist_index: 3,
+                    section_index: 0,
+                    parallel_index: 0,
+                },
+                mode: LoopMode::Recording,
+            }]
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce explicit composite kinds (Regular vs Script) and per-event script modes so composite schedules can express scripting playback semantics.
- Make compositional changes editable from the UI and propagate those edits to the backend configuration when supported.

### Description
- Add new app intents `SetCompositeKind` and `SetCompositeEventMode` to the public API and expose stable intent kinds `loop.composite.set_kind` and `loop.composite.set_event_mode`.
- Implement handling in `ApplicationModel` with `set_composite_kind`, `set_composite_event_mode`, and a common `commit_composite_editor_change` that updates the `CompositeDocument`, maps document kinds to API kinds, and creates/configures/removes backend composite loops as needed.
- Adjust `composite_with_source_at` to set script event `mode` when the composite is a script kind.
- Extend the `CompositeLoopWidget` UI to add a type toggle (Regular/Script), display script event modes in event labels, and provide a context-menu submenu to change an event's mode; introduce helpers `SCRIPT_EVENT_MODES`, `script_mode_label`, and `script_mode_key` to map UI choices to mode keys.
- Add unit/GUI tests for new intent kinds and widget interactions that emit the new intents and render script event mode labels.

### Testing
- Ran the Rust test suite (`cargo test`) including API tests and widget tests; the new tests `type_toggle_emits_kind_change_and_script_events_show_their_mode` and `script_event_context_menu_emits_mode_change_for_one_instance` passed. 
- Existing intent-kind and composite-related tests were also executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a836a84ada4832895f299a3f3cde0f8)