### PR TITLE
Enable dragging composite loop instances (move/duplicate/group drag)

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -1270,6 +1270,18 @@ impl ApplicationModel {
                 target_loop_id,
                 events,
             } => self.delete_composite_events(backend, target_loop_id, &events),
+            AppIntent::RelocateCompositeEvents {
+                target_loop_id,
+                events,
+                start_iteration,
+                duplicate,
+            } => self.relocate_composite_events(
+                backend,
+                target_loop_id,
+                &events,
+                start_iteration,
+                duplicate,
+            ),
             AppIntent::SetCompositeLoopCycles {
                 target_loop_id,
                 source_loop_id,
@@ -4978,6 +4990,92 @@ impl ApplicationModel {
         target_model.state.composite_kind = composite_kind;
         target_model.composite = Some(composite);
         target_model.backend_composite = backend_composite;
+        target_model.backend_composite_signature = signature;
+        Ok(())
+    }
+
+    fn relocate_composite_events(
+        &mut self,
+        backend: &mut dyn Backend,
+        target: LoopId,
+        events: &[CompositeEventId],
+        start_iteration: u64,
+        duplicate: bool,
+    ) -> Result<(), String> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        let target_model = self
+            .loops
+            .get(&target)
+            .ok_or_else(|| format!("stale or unknown composition target {target}"))?;
+        let existing = target_model
+            .composite
+            .as_ref()
+            .ok_or_else(|| format!("composition target {target} is not a composite"))?;
+        let details = self.composite_details_snapshot(existing);
+        let selected = events.iter().copied().collect::<BTreeSet<_>>();
+        let selected_details = details
+            .events
+            .iter()
+            .filter(|event| {
+                selected.contains(&CompositeEventId {
+                    playlist_index: event.playlist_index,
+                    section_index: event.section_index,
+                    parallel_index: event.parallel_index,
+                })
+            })
+            .collect::<Vec<_>>();
+        if selected_details.len() != selected.len() {
+            return Err("composite relocation references a stale event".to_owned());
+        }
+        let cycle_length = details.cycle_length_frames.max(1);
+        let origin = selected_details
+            .iter()
+            .map(|event| event.start_frame / cycle_length)
+            .min()
+            .unwrap_or(0);
+        let mut composite = if duplicate {
+            existing.clone()
+        } else {
+            self.composite_without_events_preserving_positions(existing, &selected)?
+        };
+        for event in selected_details {
+            let document = &existing.playlists[event.playlist_index as usize]
+                [event.section_index as usize][event.parallel_index as usize];
+            let relative = event.start_frame / cycle_length - origin;
+            let mut document = document.clone();
+            document.delay = start_iteration
+                .checked_add(relative)
+                .ok_or_else(|| "composite relocation position overflow".to_owned())?;
+            composite.playlists.push(vec![vec![document]]);
+        }
+
+        let config = self
+            .backend_composite_config(&composite)?
+            .ok_or_else(|| "relocated composite is not backend-configurable".to_owned())?;
+        let backend_composite = match target_model.backend_composite {
+            Some(id) => {
+                backend
+                    .configure_composite_loop(id, &config)
+                    .map_err(|error| format!("could not configure composite loop: {error}"))?;
+                id
+            }
+            None => self
+                .create_and_configure_backend_composite(backend, &composite)?
+                .ok_or_else(|| "could not create relocated composite schedule".to_owned())?,
+        };
+        let signature = self.composite_length_signature(&composite);
+        let length = self
+            .composite_details_snapshot(&composite)
+            .timeline_length_frames
+            .try_into()
+            .unwrap_or(u32::MAX);
+        let target_model = self.loops.get_mut(&target).unwrap();
+        target_model.length = length;
+        target_model.state.empty = false;
+        target_model.composite = Some(composite);
+        target_model.backend_composite = Some(backend_composite);
         target_model.backend_composite_signature = signature;
         Ok(())
     }
@@ -11905,6 +12003,48 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert!(model.loops[&target].composite.is_some());
         assert!(model.loops[&target].state.empty);
         assert_eq!(model.loops[&target].length, 0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn composite_event_groups_move_or_duplicate_while_preserving_relative_positions() {
+        for duplicate in [false, true] {
+            let (mut backend, mut model, _, target, _) = engine_model_with_regular_composite();
+            let before =
+                model.composite_details_snapshot(model.loops[&target].composite.as_ref().unwrap());
+            let selected = [0_usize, 2]
+                .into_iter()
+                .map(|index| CompositeEventId {
+                    playlist_index: before.events[index].playlist_index,
+                    section_index: before.events[index].section_index,
+                    parallel_index: before.events[index].parallel_index,
+                })
+                .collect::<Vec<_>>();
+            let cycle_length = before.cycle_length_frames;
+            let relative = before.events[2].start_frame - before.events[0].start_frame;
+
+            model
+                .relocate_composite_events(&mut backend, target, &selected, 10, duplicate)
+                .unwrap();
+
+            let after =
+                model.composite_details_snapshot(model.loops[&target].composite.as_ref().unwrap());
+            assert_eq!(after.events.len(), if duplicate { 5 } else { 3 });
+            let moved = &after.events[after.events.len() - 2..];
+            assert_eq!(moved[0].start_frame, 10 * cycle_length);
+            assert_eq!(moved[1].start_frame - moved[0].start_frame, relative);
+            assert!(after.events.iter().any(|event| {
+                event.loop_id == before.events[1].loop_id
+                    && event.start_frame == before.events[1].start_frame
+            }));
+            assert_eq!(
+                after
+                    .events
+                    .iter()
+                    .filter(|event| event.loop_id == before.events[0].loop_id)
+                    .count(),
+                if duplicate { 2 } else { 1 }
+            );
+        }
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1587,6 +1587,12 @@ pub enum AppIntent {
         target_loop_id: LoopId,
         events: Vec<CompositeEventId>,
     },
+    RelocateCompositeEvents {
+        target_loop_id: LoopId,
+        events: Vec<CompositeEventId>,
+        start_iteration: u64,
+        duplicate: bool,
+    },
     SetCompositeLoopCycles {
         target_loop_id: LoopId,
         source_loop_id: LoopId,
@@ -1835,6 +1841,7 @@ impl AppIntent {
             Self::ComposeLoopSerial { .. } => "loop.compose_serial",
             Self::ComposeLoopAt { .. } => "loop.compose_at",
             Self::DeleteCompositeEvents { .. } => "loop.composite.delete_events",
+            Self::RelocateCompositeEvents { .. } => "loop.composite.relocate_events",
             Self::SetCompositeLoopCycles { .. } => "loop.composite.set_loop_cycles",
             Self::KeyEvent(_) => "scripting.key_event",
             Self::AddScriptSource { .. } => "scripting.add_source",

--- a/src/rust/shoop_egui/src/composite_loop_widget.rs
+++ b/src/rust/shoop_egui/src/composite_loop_widget.rs
@@ -20,6 +20,11 @@ pub(crate) struct LoopDragPayload {
     pub loop_id: LoopId,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CompositeEventDragPayload {
+    events: Vec<CompositeEventId>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct CompositeEventKey {
     playlist_index: u32,
@@ -438,7 +443,7 @@ impl CompositeLoopWidget {
                                         event_key.section_index,
                                         event_key.parallel_index,
                                     )),
-                                    egui::Sense::click(),
+                                    egui::Sense::click_and_drag(),
                                 );
                                 if response.clicked() {
                                     clicked_event = Some(event_key);
@@ -457,6 +462,20 @@ impl CompositeLoopWidget {
                                                 .unwrap_or(u32::MAX)
                                         });
                                 }
+                                if response.drag_started() {
+                                    if !self.selected_events.contains(&event_key) {
+                                        self.selected_events.clear();
+                                        self.selected_events.insert(event_key);
+                                    }
+                                }
+                                response.dnd_set_drag_payload(CompositeEventDragPayload {
+                                    events: self
+                                        .selected_events
+                                        .iter()
+                                        .copied()
+                                        .map(CompositeEventId::from)
+                                        .collect(),
+                                });
                                 response.context_menu(|ui| {
                                     ui.horizontal(|ui| {
                                         ui.label("Length");
@@ -610,7 +629,9 @@ impl CompositeLoopWidget {
                     ui.ctx().request_repaint();
                 }
 
-                let payload = egui::DragAndDrop::payload::<LoopDragPayload>(ui.ctx());
+                let loop_payload = egui::DragAndDrop::payload::<LoopDragPayload>(ui.ctx());
+                let event_payload =
+                    egui::DragAndDrop::payload::<CompositeEventDragPayload>(ui.ctx());
                 self.update_box_selection(
                     ui,
                     &painter,
@@ -618,7 +639,7 @@ impl CompositeLoopWidget {
                     rect,
                     visible_timeline_left,
                     &event_rects,
-                    payload.is_some(),
+                    loop_payload.is_some() || event_payload.is_some(),
                 );
                 if let Some(played_frame) = details.played_frame {
                     let x = frame_to_x(played_frame);
@@ -635,17 +656,17 @@ impl CompositeLoopWidget {
                     }
                 }
                 let pointer = ui.ctx().pointer_hover_pos();
-                let hovered_iteration = payload
-                    .filter(|payload| payload.loop_id != self.loop_id)
-                    .zip(pointer)
-                    .filter(|(_, pointer)| {
-                        rect.contains(*pointer)
+                let valid_payload = loop_payload
+                    .is_some_and(|payload| payload.loop_id != self.loop_id)
+                    || event_payload.is_some();
+                let hovered_iteration = pointer
+                    .filter(|pointer| {
+                        valid_payload
+                            && rect.contains(*pointer)
                             && clip_rect.contains(*pointer)
                             && pointer.x >= timeline_left
                     })
-                    .map(|(_, pointer)| {
-                        ((pointer.x - timeline_left) / self.cycle_width).floor() as u64
-                    })
+                    .map(|pointer| ((pointer.x - timeline_left) / self.cycle_width).floor() as u64)
                     .filter(|iteration| *iteration < displayed_cycles);
                 if let Some(iteration) = hovered_iteration {
                     let column_rect = egui::Rect::from_min_size(
@@ -666,6 +687,17 @@ impl CompositeLoopWidget {
                     {
                         self.highlighted_iteration = Some(iteration);
                         self.highlighted_rect = Some(column_rect);
+                    }
+                }
+                if ui.input(|input| input.pointer.any_released()) {
+                    if let Some(payload) = event_payload.zip(hovered_iteration) {
+                        intents.push(AppIntent::RelocateCompositeEvents {
+                            target_loop_id: self.loop_id,
+                            events: payload.0.events.clone(),
+                            start_iteration: payload.1,
+                            duplicate: ui.input(|input| input.modifiers.ctrl),
+                        });
+                        egui::DragAndDrop::clear_payload(ui.ctx());
                     }
                 }
                 hovered_iteration
@@ -1481,6 +1513,83 @@ mod tests {
                 }],
             );
             assert!(intents.is_empty());
+        }
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn selected_composite_events_drop_as_a_group_and_ctrl_duplicates() {
+        let context = egui::Context::default();
+        let target = LoopId::from_raw(8);
+        let state = details(vec![
+            keyed_event(0, 1, 1, 0, 100),
+            keyed_event(1, 2, 1, 200, 300),
+        ]);
+        let mut widget = CompositeLoopWidget::default();
+        let _ = widget_frame(&context, &mut widget, target, &state, Vec::new());
+        let events = vec![
+            CompositeEventId {
+                playlist_index: 0,
+                section_index: 0,
+                parallel_index: 0,
+            },
+            CompositeEventId {
+                playlist_index: 1,
+                section_index: 0,
+                parallel_index: 0,
+            },
+        ];
+        let drop_position = egui::pos2(
+            widget.timeline_left.unwrap() + DEFAULT_CYCLE_WIDTH * 2.5,
+            widget.timeline_rect.unwrap().center().y,
+        );
+
+        for (modifiers, duplicate) in [
+            (egui::Modifiers::NONE, false),
+            (egui::Modifiers::CTRL, true),
+        ] {
+            egui::DragAndDrop::set_payload(
+                &context,
+                CompositeEventDragPayload {
+                    events: events.clone(),
+                },
+            );
+            let _ = widget_frame(
+                &context,
+                &mut widget,
+                target,
+                &state,
+                vec![
+                    egui::Event::PointerMoved(drop_position),
+                    egui::Event::PointerButton {
+                        pos: drop_position,
+                        button: egui::PointerButton::Primary,
+                        pressed: true,
+                        modifiers,
+                    },
+                ],
+            );
+            assert_eq!(widget.highlighted_iteration, Some(2));
+            let intents = widget_frame(
+                &context,
+                &mut widget,
+                target,
+                &state,
+                vec![egui::Event::PointerButton {
+                    pos: drop_position,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers,
+                }],
+            );
+            assert_eq!(
+                intents,
+                [AppIntent::RelocateCompositeEvents {
+                    target_loop_id: target,
+                    events: events.clone(),
+                    start_iteration: 2,
+                    duplicate,
+                }]
+            );
         }
     }
 

--- a/src/rust/shoop_egui/src/composite_loop_widget.rs
+++ b/src/rust/shoop_egui/src/composite_loop_widget.rs
@@ -23,6 +23,7 @@ pub(crate) struct LoopDragPayload {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CompositeEventDragPayload {
     events: Vec<CompositeEventId>,
+    grabbed_offset: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -462,20 +463,40 @@ impl CompositeLoopWidget {
                                                 .unwrap_or(u32::MAX)
                                         });
                                 }
-                                if response.drag_started() {
+                                let event_drag_started = response.drag_started()
+                                    && ui.input(|input| {
+                                        input
+                                            .pointer
+                                            .press_origin()
+                                            .is_some_and(|origin| event_rect.contains(origin))
+                                    });
+                                if event_drag_started {
                                     if !self.selected_events.contains(&event_key) {
                                         self.selected_events.clear();
                                         self.selected_events.insert(event_key);
                                     }
+                                    response.dnd_set_drag_payload(CompositeEventDragPayload {
+                                        events: self
+                                            .selected_events
+                                            .iter()
+                                            .copied()
+                                            .map(CompositeEventId::from)
+                                            .collect(),
+                                        grabbed_offset: event.start_frame.saturating_sub(
+                                            details
+                                                .events
+                                                .iter()
+                                                .filter(|candidate| {
+                                                    self.selected_events.contains(
+                                                        &CompositeEventKey::from(*candidate),
+                                                    )
+                                                })
+                                                .map(|candidate| candidate.start_frame)
+                                                .min()
+                                                .unwrap_or(event.start_frame),
+                                        ) / details.cycle_length_frames.max(1),
+                                    });
                                 }
-                                response.dnd_set_drag_payload(CompositeEventDragPayload {
-                                    events: self
-                                        .selected_events
-                                        .iter()
-                                        .copied()
-                                        .map(CompositeEventId::from)
-                                        .collect(),
-                                });
                                 response.context_menu(|ui| {
                                     ui.horizontal(|ui| {
                                         ui.label("Length");
@@ -694,9 +715,12 @@ impl CompositeLoopWidget {
                         intents.push(AppIntent::RelocateCompositeEvents {
                             target_loop_id: self.loop_id,
                             events: payload.0.events.clone(),
-                            start_iteration: payload.1,
+                            start_iteration: payload.1.saturating_sub(payload.0.grabbed_offset),
                             duplicate: ui.input(|input| input.modifiers.ctrl),
                         });
+                        if !ui.input(|input| input.modifiers.ctrl) {
+                            self.selected_events.clear();
+                        }
                         egui::DragAndDrop::clear_payload(ui.ctx());
                     }
                 }
@@ -1547,10 +1571,19 @@ mod tests {
             (egui::Modifiers::NONE, false),
             (egui::Modifiers::CTRL, true),
         ] {
+            widget.selected_events = events
+                .iter()
+                .map(|event| CompositeEventKey {
+                    playlist_index: event.playlist_index,
+                    section_index: event.section_index,
+                    parallel_index: event.parallel_index,
+                })
+                .collect();
             egui::DragAndDrop::set_payload(
                 &context,
                 CompositeEventDragPayload {
                     events: events.clone(),
+                    grabbed_offset: 1,
                 },
             );
             let _ = widget_frame(
@@ -1586,10 +1619,11 @@ mod tests {
                 [AppIntent::RelocateCompositeEvents {
                     target_loop_id: target,
                     events: events.clone(),
-                    start_iteration: 2,
+                    start_iteration: 1,
                     duplicate,
                 }]
             );
+            assert_eq!(widget.selected_events.is_empty(), !duplicate);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Make composite timeline instances draggable so a user can reposition individual or multiple selected instances within the composite editor and preserve the same drop look-and-feel as dragging from the track widget. 
- Allow duplicating on drop when Ctrl is held and support group operations when multiple instances are selected.

### Description
- Add a new application intent `RelocateCompositeEvents` to `src/rust/shoop_app_api/src/lib.rs` carrying the selected `events`, `start_iteration`, and `duplicate` flag. 
- Implement `relocate_composite_events` in the application model (`src/rust/shoop_app/src/lib.rs`) to validate event IDs, compute relative positions, append relocated events or remove originals, and reconfigure or create the backend composite as needed. 
- Extend the composite editor UI in `src/rust/shoop_egui/src/composite_loop_widget.rs` with a `CompositeEventDragPayload`, make event widgets draggable (`egui::Sense::click_and_drag()`), preserve/adjust selection on drag start, set the drag payload from the selected group, show the existing timeline highlight for hover, and emit `AppIntent::RelocateCompositeEvents` on drop with Ctrl-driven duplication. 
- Add focused unit tests for the UI and model: `selected_composite_events_drop_as_a_group_and_ctrl_duplicates` in the composite widget tests and `composite_event_groups_move_or_duplicate_while_preserving_relative_positions` in the app model tests, and apply formatting changes.

### Testing
- ✅ `cargo test -p shoop_egui selected_composite_events_drop_as_a_group_and_ctrl_duplicates` (UI unit test passed). 
- ✅ `cargo test -p shoop_app composite_event_groups_move_or_duplicate_while_preserving_relative_positions` (application-model unit test passed). 
- ✅ `python3 scripts/check_shoop_test_usage.py` (test attribute policy OK). 
- ✅ `cargo fmt --all -- --check` (format check passed). 
- ✅ `cargo check -p shoop_egui -p shoop_app` (type/checks for affected crates passed). 
- ⚠️ `RUSTFLAGS="-D warnings" cargo build --workspace` completed through affected crates but full workspace linking failed due to environment linker/PIC incompatibility with the project's Tracy static objects when building the audio worklet. 
- ⚠️ `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` could not run because `cargo-nextest` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83ee2b890483289a5c754c34b28c73)