### PR TITLE
Group loop detail media channels into a unified canvas

### DIFF
--- a/src/rust/shoop_egui/src/details_pane.rs
+++ b/src/rust/shoop_egui/src/details_pane.rs
@@ -54,16 +54,17 @@ impl DetailsPane {
             .id_salt("details_media")
             .scroll_source(crate::control_safe_scroll_source())
             .show(ui, |ui| {
-                for (channel, waveform) in details.channels.iter().zip(&mut self.waveforms) {
-                    waveform.show(ui, channel);
-                    ui.add_space(4.0);
-                }
-                for (channel, sequence) in
-                    details.midi_channels.iter().zip(&mut self.midi_sequences)
-                {
-                    sequence.show(ui, channel);
-                    ui.add_space(4.0);
-                }
+                ui.spacing_mut().item_spacing.y = 0.0;
+                ui.vertical(|ui| {
+                    for (channel, waveform) in details.channels.iter().zip(&mut self.waveforms) {
+                        waveform.show(ui, channel);
+                    }
+                    for (channel, sequence) in
+                        details.midi_channels.iter().zip(&mut self.midi_sequences)
+                    {
+                        sequence.show(ui, channel);
+                    }
+                });
             });
         Vec::new()
     }

--- a/src/rust/shoop_egui/src/midi_sequence_widget.rs
+++ b/src/rust/shoop_egui/src/midi_sequence_widget.rs
@@ -176,13 +176,11 @@ impl MidiSequenceWidget {
                 );
             }
         }
-        painter.text(
-            rect.left_top() + egui::vec2(6.0, 5.0),
-            egui::Align2::LEFT_TOP,
-            &channel.label,
-            egui::FontId::proportional(12.0),
-            ui.visuals().text_color(),
+        let label_rect = egui::Rect::from_min_max(
+            rect.left_top() + egui::vec2(6.0, 3.0),
+            egui::pos2(rect.right() - 122.0, rect.top() + 22.0),
         );
+        ui.put(label_rect, egui::Label::new(&channel.label).truncate());
         let zoom_rect = egui::Rect::from_min_size(
             egui::pos2(rect.right() - 116.0, rect.top() + 3.0),
             egui::vec2(110.0, 18.0),

--- a/src/rust/shoop_egui/src/midi_sequence_widget.rs
+++ b/src/rust/shoop_egui/src/midi_sequence_widget.rs
@@ -86,28 +86,16 @@ impl Default for MidiSequenceWidget {
 impl MidiSequenceWidget {
     pub fn show(&mut self, ui: &mut egui::Ui, channel: &MidiSequenceChannelState) {
         self.update_notes(channel);
-        ui.horizontal(|ui| {
-            ui.label(&channel.label);
-            ui.add(
-                egui::Slider::new(&mut self.zoom, 1.0..=64.0)
-                    .logarithmic(true)
-                    .show_value(false)
-                    .text("zoom"),
-            )
-            .on_hover_text(format!("MIDI zoom: {:.1}×", self.zoom));
-        });
-
         let desired = egui::vec2(ui.available_width(), 96.0);
         let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::drag());
         let painter = ui.painter_at(rect);
-        painter.rect_filled(rect, 2.0, colors::WAVEFORM_BACKGROUND);
+        painter.rect_filled(rect, 0.0, colors::WAVEFORM_BACKGROUND);
         painter.rect_stroke(
             rect,
-            2.0,
+            0.0,
             egui::Stroke::new(1.0, colors::MUTED_FOREGROUND),
             egui::StrokeKind::Inside,
         );
-
         let event_end = self.notes.iter().map(|note| note.end).max().unwrap_or(0);
         let timeline_start = channel.start_offset.min(0) as f64;
         let timeline_end = channel
@@ -188,6 +176,25 @@ impl MidiSequenceWidget {
                 );
             }
         }
+        painter.text(
+            rect.left_top() + egui::vec2(6.0, 5.0),
+            egui::Align2::LEFT_TOP,
+            &channel.label,
+            egui::FontId::proportional(12.0),
+            ui.visuals().text_color(),
+        );
+        let zoom_rect = egui::Rect::from_min_size(
+            egui::pos2(rect.right() - 116.0, rect.top() + 3.0),
+            egui::vec2(110.0, 18.0),
+        );
+        ui.put(
+            zoom_rect,
+            egui::Slider::new(&mut self.zoom, 1.0..=64.0)
+                .logarithmic(true)
+                .show_value(false)
+                .text("zoom"),
+        )
+        .on_hover_text(format!("MIDI zoom: {:.1}×", self.zoom));
     }
 
     fn update_notes(&mut self, channel: &MidiSequenceChannelState) {

--- a/src/rust/shoop_egui/src/waveform_widget.rs
+++ b/src/rust/shoop_egui/src/waveform_widget.rs
@@ -213,13 +213,11 @@ impl WaveformWidget {
     }
 
     fn show_overlay(ui: &mut egui::Ui, rect: egui::Rect, label: &str, zoom: &mut f32) {
-        ui.painter().text(
-            rect.left_top() + egui::vec2(6.0, 5.0),
-            egui::Align2::LEFT_TOP,
-            label,
-            egui::FontId::proportional(12.0),
-            ui.visuals().text_color(),
+        let label_rect = egui::Rect::from_min_max(
+            rect.left_top() + egui::vec2(6.0, 3.0),
+            egui::pos2(rect.right() - 122.0, rect.top() + 22.0),
         );
+        ui.put(label_rect, egui::Label::new(label).truncate());
         let zoom_rect = egui::Rect::from_min_size(
             egui::pos2(rect.right() - 116.0, rect.top() + 3.0),
             egui::vec2(110.0, 18.0),

--- a/src/rust/shoop_egui/src/waveform_widget.rs
+++ b/src/rust/shoop_egui/src/waveform_widget.rs
@@ -106,24 +106,13 @@ impl Default for WaveformWidget {
 
 impl WaveformWidget {
     pub fn show(&mut self, ui: &mut egui::Ui, channel: &WaveformChannelState) {
-        ui.horizontal(|ui| {
-            ui.label(&channel.label);
-            ui.add(
-                egui::Slider::new(&mut self.zoom, 1.0..=64.0)
-                    .logarithmic(true)
-                    .show_value(false)
-                    .text("zoom"),
-            )
-            .on_hover_text(format!("Waveform zoom: {:.1}×", self.zoom));
-        });
-
         let desired = egui::vec2(ui.available_width(), 72.0);
         let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::drag());
         let painter = ui.painter_at(rect);
-        painter.rect_filled(rect, 2.0, colors::WAVEFORM_BACKGROUND);
+        painter.rect_filled(rect, 0.0, colors::WAVEFORM_BACKGROUND);
         painter.rect_stroke(
             rect,
-            2.0,
+            0.0,
             egui::Stroke::new(1.0, colors::MUTED_FOREGROUND),
             egui::StrokeKind::Inside,
         );
@@ -132,7 +121,6 @@ impl WaveformWidget {
             rect.center().y,
             egui::Stroke::new(1.0, colors::WAVEFORM_ZERO_LINE),
         );
-
         if channel.samples.is_empty() {
             painter.text(
                 rect.center(),
@@ -141,6 +129,7 @@ impl WaveformWidget {
                 egui::FontId::proportional(12.0),
                 colors::MUTED_FOREGROUND,
             );
+            Self::show_overlay(ui, rect, &channel.label, &mut self.zoom);
             return;
         }
 
@@ -187,6 +176,7 @@ impl WaveformWidget {
                 egui::FontId::proportional(12.0),
                 colors::MUTED_FOREGROUND,
             );
+            Self::show_overlay(ui, rect, &channel.label, &mut self.zoom);
             return;
         };
         let bins = pyramid.bins(
@@ -219,6 +209,29 @@ impl WaveformWidget {
                 );
             }
         }
+        Self::show_overlay(ui, rect, &channel.label, &mut self.zoom);
+    }
+
+    fn show_overlay(ui: &mut egui::Ui, rect: egui::Rect, label: &str, zoom: &mut f32) {
+        ui.painter().text(
+            rect.left_top() + egui::vec2(6.0, 5.0),
+            egui::Align2::LEFT_TOP,
+            label,
+            egui::FontId::proportional(12.0),
+            ui.visuals().text_color(),
+        );
+        let zoom_rect = egui::Rect::from_min_size(
+            egui::pos2(rect.right() - 116.0, rect.top() + 3.0),
+            egui::vec2(110.0, 18.0),
+        );
+        ui.put(
+            zoom_rect,
+            egui::Slider::new(zoom, 1.0..=64.0)
+                .logarithmic(true)
+                .show_value(false)
+                .text("zoom"),
+        )
+        .on_hover_text(format!("Waveform zoom: {:.1}×", *zoom));
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Motivation

- Visually group audio and MIDI channels that belong to the same loop so they appear as a single contiguous canvas with multiple lanes, and remove vertical gaps between lanes. 
- Overlay the channel name and per-lane zoom control to save vertical space and keep lanes visually compact.

### Description

- Make the details pane render audio waveform and MIDI lanes with no vertical gaps by setting `ui.spacing_mut().item_spacing.y = 0.0` and vertically stacking the lanes in `DetailsPane`.【F:src/rust/shoop_egui/src/details_pane.rs†L53-L68】
- Convert waveform lane visuals to square edges and move label/zoom into an overlay inside the lane, add `show_overlay` helper to draw the channel label and an inline `egui::Slider` for zoom; adjust background/stroke radii to preserve the full lane canvas.【F:src/rust/shoop_egui/src/waveform_widget.rs†L107-L123】【F:src/rust/shoop_egui/src/waveform_widget.rs†L212-L235】
- Apply the same unified-canvas presentation to MIDI lanes by drawing the channel label and inline zoom overlay atop the MIDI lane and using square lane edges.【F:src/rust/shoop_egui/src/midi_sequence_widget.rs†L86-L98】【F:src/rust/shoop_egui/src/midi_sequence_widget.rs†L179-L197】
- Remove the separate horizontal label/slider rows previously placed outside each lane so the visible waveform/MIDI area remains maximized and lanes visually touch.

### Testing

- `cargo fmt --all` completed successfully and formatting was applied. 
- `cargo test -p shoop_egui details_pane --lib` ran the focused details-pane tests and they passed (2 tests passed). 
- `cargo test -p shoop_egui --lib` ran the package test suite and passed (174 tests passed). 
- `RUSTFLAGS="-D warnings" cargo build --workspace` was attempted but the full workspace build failed due to a missing system dependency (`alsa.pc` / ALSA dev package), while building the `shoop_egui` package itself completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85445e1abc8328a36e806abf96f37e)