### PR TITLE
Add `--session` startup arg and UI for loading .shoop sessions from paths or URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ehttp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04499d3c719edecfad5c9b46031726c8540905d73be6d7e4f9788c4a298da908"
+dependencies = [
+ "document-features",
+ "js-sys",
+ "ureq",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,6 +3676,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rodio"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3782,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4170,6 +4233,7 @@ dependencies = [
  "anyhow",
  "clap",
  "eframe",
+ "ehttp",
  "js-sys",
  "log",
  "rfd",
@@ -4361,6 +4425,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
@@ -4885,6 +4955,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5249,6 +5341,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6060,6 +6170,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ zip = { version = "8.6", default-features = false, features = ["deflate"] }
 hound = "3.5"
 rfd = { version = "0.16", default-features = false }
 tracing = "0.1"
+ehttp = "0.6"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "=0.11.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -1358,6 +1358,7 @@ impl ApplicationModel {
             }
             AppIntent::RequestSaveSession => self.begin_save_session(),
             AppIntent::RequestLoadSessionPicker
+            | AppIntent::RequestLoadSessionUrl
             | AppIntent::RequestLoopAudioImportPicker { .. }
             | AppIntent::RequestLoopMidiImportPicker { .. } => Ok(()),
             AppIntent::LoadSessionBytes { name, bytes } => self.begin_load_session(name, &bytes),

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1674,6 +1674,7 @@ pub enum AppIntent {
     ResetXruns,
     RequestSaveSession,
     RequestLoadSessionPicker,
+    RequestLoadSessionUrl,
     LoadSessionBytes {
         name: String,
         bytes: Arc<[u8]>,
@@ -1877,6 +1878,7 @@ impl AppIntent {
             Self::ResetXruns => "audio.reset_xruns",
             Self::RequestSaveSession => "session.request_save",
             Self::RequestLoadSessionPicker => "session.request_load_picker",
+            Self::RequestLoadSessionUrl => "session.request_load_url",
             Self::LoadSessionBytes { .. } => "session.load_bytes",
             Self::ConfirmSampleRateConversion { .. } => "io.confirm_sample_rate",
             Self::ConfirmAudioChannelMapping { .. } => "io.confirm_channel_mapping",

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -729,6 +729,9 @@ impl AppWidget {
                             if self.global_controls.take_load_session_requested() {
                                 actions.push(AppAction::RequestLoadSessionPicker);
                             }
+                            if self.global_controls.take_load_session_url_requested() {
+                                actions.push(AppAction::RequestLoadSessionUrl);
+                            }
                             if self.global_controls.take_settings_requested() {
                                 self.settings.open(settings_state);
                             }

--- a/src/rust/shoop_egui/src/global_controls.rs
+++ b/src/rust/shoop_egui/src/global_controls.rs
@@ -15,6 +15,7 @@ pub struct GlobalControls {
     connections_requested: bool,
     save_session_requested: bool,
     load_session_requested: bool,
+    load_session_url_requested: bool,
     settings_requested: bool,
     apply_n_cycles: OptimisticValue<u32>,
     apply_n_cycles_dragging: bool,
@@ -72,6 +73,7 @@ impl GlobalControls {
         self.connections_requested = false;
         self.save_session_requested = false;
         self.load_session_requested = false;
+        self.load_session_url_requested = false;
         self.settings_requested = false;
         let mut actions = Vec::new();
         ui.horizontal(|ui| {
@@ -94,6 +96,11 @@ impl GlobalControls {
                     self.record_rect(TestGlobalControl::LoadSession, &load_session);
                     if load_session.clicked() {
                         self.load_session_requested = true;
+                        ui.close();
+                    }
+                    let load_session_url = ui.button("Load session from URL…");
+                    if load_session_url.clicked() {
+                        self.load_session_url_requested = true;
                         ui.close();
                     }
                     let settings = ui.button("Settings");
@@ -332,6 +339,10 @@ impl GlobalControls {
             }
         });
         actions
+    }
+
+    pub fn take_load_session_url_requested(&mut self) -> bool {
+        std::mem::take(&mut self.load_session_url_requested)
     }
 
     pub fn take_connections_requested(&mut self) -> bool {

--- a/src/rust/shoop_egui/src/global_controls.rs
+++ b/src/rust/shoop_egui/src/global_controls.rs
@@ -29,6 +29,7 @@ enum TestGlobalControl {
     Connections,
     SaveSession,
     LoadSession,
+    LoadSessionUrl,
     Settings,
     StopAll,
     MidiPanic,
@@ -50,6 +51,7 @@ struct TestGlobalControlRects {
     connections: Option<egui::Rect>,
     save_session: Option<egui::Rect>,
     load_session: Option<egui::Rect>,
+    load_session_url: Option<egui::Rect>,
     settings: Option<egui::Rect>,
     stop_all: Option<egui::Rect>,
     midi_panic: Option<egui::Rect>,
@@ -99,6 +101,7 @@ impl GlobalControls {
                         ui.close();
                     }
                     let load_session_url = ui.button("Load session from URL…");
+                    self.record_rect(TestGlobalControl::LoadSessionUrl, &load_session_url);
                     if load_session_url.clicked() {
                         self.load_session_url_requested = true;
                         ui.close();
@@ -368,6 +371,7 @@ impl GlobalControls {
             TestGlobalControl::Connections => &mut self.test_rects.connections,
             TestGlobalControl::SaveSession => &mut self.test_rects.save_session,
             TestGlobalControl::LoadSession => &mut self.test_rects.load_session,
+            TestGlobalControl::LoadSessionUrl => &mut self.test_rects.load_session_url,
             TestGlobalControl::Settings => &mut self.test_rects.settings,
             TestGlobalControl::StopAll => &mut self.test_rects.stop_all,
             TestGlobalControl::MidiPanic => &mut self.test_rects.midi_panic,
@@ -398,6 +402,7 @@ impl GlobalControls {
             TestGlobalControl::Connections => self.test_rects.connections,
             TestGlobalControl::SaveSession => self.test_rects.save_session,
             TestGlobalControl::LoadSession => self.test_rects.load_session,
+            TestGlobalControl::LoadSessionUrl => self.test_rects.load_session_url,
             TestGlobalControl::Settings => self.test_rects.settings,
             TestGlobalControl::StopAll => self.test_rects.stop_all,
             TestGlobalControl::MidiPanic => self.test_rects.midi_panic,
@@ -507,7 +512,7 @@ mod tests {
             egui::RawInput {
                 screen_rect: Some(egui::Rect::from_min_size(
                     egui::Pos2::ZERO,
-                    egui::vec2(1000.0, 100.0),
+                    egui::vec2(1000.0, 160.0),
                 )),
                 events,
                 ..Default::default()
@@ -625,6 +630,15 @@ mod tests {
         )
         .is_empty());
         assert!(controls.take_load_session_requested());
+        assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
+        assert!(click(
+            &context,
+            &mut controls,
+            &state,
+            TestGlobalControl::LoadSessionUrl
+        )
+        .is_empty());
+        assert!(controls.take_load_session_url_requested());
         assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
         assert!(click(&context, &mut controls, &state, TestGlobalControl::Settings).is_empty());
         assert!(controls.take_settings_requested());

--- a/src/rust/shoopdaloop/Cargo.toml
+++ b/src/rust/shoopdaloop/Cargo.toml
@@ -22,6 +22,7 @@ shoop_backend = { path = "../shoop_backend" }
 shoop_egui = { path = "../shoop_egui" }
 shoop_scripting = { path = "../shoop_scripting" }
 tracing = { workspace = true }
+ehttp = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 shoop_common = { path = "../shoop_common" }

--- a/src/rust/shoopdaloop/src/app_args.rs
+++ b/src/rust/shoopdaloop/src/app_args.rs
@@ -13,6 +13,9 @@ pub enum SettingsTest {
 #[derive(Clone, Debug, Default, Parser)]
 #[command(name = "shoopdaloop", about = "ShoopDaLoop application")]
 pub struct AppArgs {
+    /// Open a .shoop session from a filesystem path or URL on startup.
+    #[arg(long)]
+    pub session: Option<String>,
     #[cfg(not(target_arch = "wasm32"))]
     /// Capture Tracy profiling data to ./traces.
     #[arg(long)]
@@ -123,18 +126,40 @@ fn hex_digit(value: u8) -> Result<u8, clap::error::ErrorKind> {
     }
 }
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod native_tests {
+    use super::*;
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn cli_parses_session_source() {
+        let args =
+            AppArgs::try_parse_from(["shoopdaloop", "--session", "https://example.com/demo.shoop"])
+                .unwrap();
+        assert_eq!(
+            args.session.as_deref(),
+            Some("https://example.com/demo.shoop")
+        );
+    }
+}
+
 #[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     use super::*;
 
     #[shoop_wasm_test_support::shoop_test]
     fn web_query_parses_flags_and_typed_values() {
-        let args = parse_web_query("?offline=1&settings-test=verify&session-only=true&instance=2")
-            .unwrap();
+        let args = parse_web_query(
+            "?offline=1&settings-test=verify&session-only=true&instance=2&session=https%3A%2F%2Fexample.com%2Fdemo.shoop",
+        )
+        .unwrap();
         assert!(args.offline);
         assert_eq!(args.settings_test, Some(SettingsTest::Verify));
         assert!(args.session_only);
         assert_eq!(args.instance, Some(2));
+        assert_eq!(
+            args.session.as_deref(),
+            Some("https://example.com/demo.shoop")
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -227,6 +227,7 @@ struct UnifiedApp {
     last_update: Instant,
     startup_session: Option<String>,
     session_url_input: String,
+    session_url_error: Option<String>,
     session_url_prompt_open: bool,
     session_url_confirmation: Option<String>,
     #[cfg(target_arch = "wasm32")]
@@ -317,6 +318,7 @@ impl UnifiedApp {
             last_update: Instant::now(),
             startup_session: args.session.clone(),
             session_url_input: String::new(),
+            session_url_error: None,
             session_url_prompt_open: false,
             session_url_confirmation: None,
             #[cfg(target_arch = "wasm32")]
@@ -357,26 +359,35 @@ impl UnifiedApp {
 
     fn show_session_url_dialogs(&mut self, context: &egui::Context) {
         if self.session_url_prompt_open {
-            let mut open = true;
             let mut submit = false;
-            egui::Window::new("Load session from URL")
-                .collapsible(false)
-                .resizable(false)
-                .open(&mut open)
-                .show(context, |ui| {
-                    ui.label("Session URL:");
-                    let response = ui.text_edit_singleline(&mut self.session_url_input);
+            let mut cancel = false;
+            egui::Modal::new(egui::Id::new("load_session_url_prompt")).show(context, |ui| {
+                ui.heading("Load session from URL");
+                ui.add_space(8.0);
+                ui.label("Session URL:");
+                let response = ui.text_edit_singleline(&mut self.session_url_input);
+                if let Some(error) = &self.session_url_error {
+                    ui.colored_label(ui.visuals().error_fg_color, error);
+                }
+                ui.horizontal(|ui| {
                     submit = (response.lost_focus()
                         && ui.input(|input| input.key_pressed(egui::Key::Enter)))
                         || ui.button("Continue").clicked();
+                    cancel = ui.button("Cancel").clicked();
                 });
-            self.session_url_prompt_open = open && !submit;
-            if submit {
+            });
+            if cancel {
+                self.session_url_prompt_open = false;
+                self.session_url_error = None;
+            } else if submit {
                 let source = self.session_url_input.trim().to_owned();
                 if is_http_url(&source) {
+                    self.session_url_prompt_open = false;
+                    self.session_url_error = None;
                     self.session_url_confirmation = Some(source);
                 } else {
-                    self.pending_file_error("Please enter an http:// or https:// URL".to_owned());
+                    self.session_url_error =
+                        Some("Please enter an http:// or https:// URL".to_owned());
                 }
             }
         }
@@ -384,17 +395,16 @@ impl UnifiedApp {
         if let Some(url) = self.session_url_confirmation.clone() {
             let mut fetch = false;
             let mut cancel = false;
-            egui::Window::new("Fetch session from URL?")
-                .collapsible(false)
-                .resizable(false)
-                .show(context, |ui| {
-                    ui.label("ShoopDaLoop will download and open this session:");
-                    ui.monospace(&url);
-                    ui.horizontal(|ui| {
-                        fetch = ui.button("Fetch and open").clicked();
-                        cancel = ui.button("Cancel").clicked();
-                    });
+            egui::Modal::new(egui::Id::new("confirm_session_url_fetch")).show(context, |ui| {
+                ui.heading("Fetch session from URL?");
+                ui.add_space(8.0);
+                ui.label("ShoopDaLoop will download and open this session:");
+                ui.monospace(&url);
+                ui.horizontal(|ui| {
+                    fetch = ui.button("Fetch and open").clicked();
+                    cancel = ui.button("Cancel").clicked();
                 });
+            });
             if fetch {
                 self.session_url_confirmation = None;
                 self.fetch_session_url(url);
@@ -402,23 +412,6 @@ impl UnifiedApp {
                 self.session_url_confirmation = None;
             }
         }
-    }
-
-    fn pending_file_error(&self, message: String) {
-        #[cfg(not(target_arch = "wasm32"))]
-        let _ = self
-            .pending_file_intent_tx
-            .send(AppIntent::ReportFileIoError {
-                task_id: None,
-                message,
-            });
-        #[cfg(target_arch = "wasm32")]
-        self.pending_file_intents
-            .borrow_mut()
-            .push_back(AppIntent::ReportFileIoError {
-                task_id: None,
-                message,
-            });
     }
 
     fn fetch_session_url(&self, url: String) {
@@ -1132,7 +1125,15 @@ fn file_name(path: &Path) -> String {
 }
 
 fn is_http_url(source: &str) -> bool {
-    source.starts_with("https://") || source.starts_with("http://")
+    ["https://", "http://"].iter().any(|scheme| {
+        source
+            .get(..scheme.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme))
+            && source[scheme.len()..]
+                .split(['/', '?', '#'])
+                .next()
+                .is_some_and(|authority| !authority.is_empty())
+    })
 }
 
 fn session_source_name(source: &str) -> String {
@@ -4334,6 +4335,18 @@ mod tests {
     };
 
     use super::*;
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn session_sources_recognize_http_urls_and_names() {
+        assert!(is_http_url("https://example.com/session.shoop"));
+        assert!(is_http_url("HTTP://EXAMPLE.COM/session.shoop"));
+        assert!(!is_http_url("https://"));
+        assert!(!is_http_url("session.shoop"));
+        assert_eq!(
+            session_source_name("https://example.com/sessions/demo.shoop?download=1#top"),
+            "demo.shoop"
+        );
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -225,6 +225,10 @@ struct UnifiedApp {
     #[cfg(not(target_arch = "wasm32"))]
     pending_tracing_action: Option<PendingTracingAction>,
     last_update: Instant,
+    startup_session: Option<String>,
+    session_url_input: String,
+    session_url_prompt_open: bool,
+    session_url_confirmation: Option<String>,
     #[cfg(target_arch = "wasm32")]
     browser_self_test: BrowserSelfTest,
     #[cfg(target_arch = "wasm32")]
@@ -311,6 +315,10 @@ impl UnifiedApp {
             #[cfg(not(target_arch = "wasm32"))]
             pending_tracing_action: None,
             last_update: Instant::now(),
+            startup_session: args.session.clone(),
+            session_url_input: String::new(),
+            session_url_prompt_open: false,
+            session_url_confirmation: None,
             #[cfg(target_arch = "wasm32")]
             browser_self_test: BrowserSelfTest::from_args(args),
             #[cfg(target_arch = "wasm32")]
@@ -330,6 +338,111 @@ impl UnifiedApp {
 }
 
 impl UnifiedApp {
+    fn process_session_source(&mut self, source: String) {
+        if is_http_url(&source) {
+            self.session_url_confirmation = Some(source);
+            return;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        load_session_path(source, self.pending_file_intent_tx.clone());
+        #[cfg(target_arch = "wasm32")]
+        self.pending_file_intents
+            .borrow_mut()
+            .push_back(AppIntent::ReportFileIoError {
+                task_id: None,
+                message: "Filesystem session paths are unavailable in the web app".to_owned(),
+            });
+    }
+
+    fn show_session_url_dialogs(&mut self, context: &egui::Context) {
+        if self.session_url_prompt_open {
+            let mut open = true;
+            let mut submit = false;
+            egui::Window::new("Load session from URL")
+                .collapsible(false)
+                .resizable(false)
+                .open(&mut open)
+                .show(context, |ui| {
+                    ui.label("Session URL:");
+                    let response = ui.text_edit_singleline(&mut self.session_url_input);
+                    submit = (response.lost_focus()
+                        && ui.input(|input| input.key_pressed(egui::Key::Enter)))
+                        || ui.button("Continue").clicked();
+                });
+            self.session_url_prompt_open = open && !submit;
+            if submit {
+                let source = self.session_url_input.trim().to_owned();
+                if is_http_url(&source) {
+                    self.session_url_confirmation = Some(source);
+                } else {
+                    self.pending_file_error("Please enter an http:// or https:// URL".to_owned());
+                }
+            }
+        }
+
+        if let Some(url) = self.session_url_confirmation.clone() {
+            let mut fetch = false;
+            let mut cancel = false;
+            egui::Window::new("Fetch session from URL?")
+                .collapsible(false)
+                .resizable(false)
+                .show(context, |ui| {
+                    ui.label("ShoopDaLoop will download and open this session:");
+                    ui.monospace(&url);
+                    ui.horizontal(|ui| {
+                        fetch = ui.button("Fetch and open").clicked();
+                        cancel = ui.button("Cancel").clicked();
+                    });
+                });
+            if fetch {
+                self.session_url_confirmation = None;
+                self.fetch_session_url(url);
+            } else if cancel {
+                self.session_url_confirmation = None;
+            }
+        }
+    }
+
+    fn pending_file_error(&self, message: String) {
+        #[cfg(not(target_arch = "wasm32"))]
+        let _ = self
+            .pending_file_intent_tx
+            .send(AppIntent::ReportFileIoError {
+                task_id: None,
+                message,
+            });
+        #[cfg(target_arch = "wasm32")]
+        self.pending_file_intents
+            .borrow_mut()
+            .push_back(AppIntent::ReportFileIoError {
+                task_id: None,
+                message,
+            });
+    }
+
+    fn fetch_session_url(&self, url: String) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let pending = self.pending_file_intent_tx.clone();
+            let name = session_source_name(&url);
+            ehttp::fetch(ehttp::Request::get(&url), move |result| {
+                let _ = pending.send(session_fetch_result(name, result));
+            });
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let pending = Rc::clone(&self.pending_file_intents);
+            let name = session_source_name(&url);
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = ehttp::fetch_async(ehttp::Request::get(&url)).await;
+                pending
+                    .borrow_mut()
+                    .push_back(session_fetch_result(name, result));
+            });
+        }
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn process_tracing(&mut self) {
         let Some(tracing) = self.tracing.as_ref().cloned() else {
@@ -706,6 +819,9 @@ impl UnifiedApp {
     }
 
     fn show(&mut self, ui: &mut egui::Ui) {
+        if let Some(source) = self.startup_session.take() {
+            self.process_session_source(source);
+        }
         let _span = tracing::trace_span!("frontend.egui.update").entered();
         self.settings.poll();
         if let Err(error) = self
@@ -767,6 +883,7 @@ impl UnifiedApp {
             self.handle_settings_action(action);
         }
         self.show_file_drop_overlay(ui.ctx());
+        self.show_session_url_dialogs(ui.ctx());
         #[cfg(not(target_arch = "wasm32"))]
         let drain_file_outputs = true;
         #[cfg(target_arch = "wasm32")]
@@ -818,6 +935,10 @@ impl UnifiedApp {
                         }
                     });
                 }
+                None
+            }
+            AppIntent::RequestLoadSessionUrl => {
+                self.session_url_prompt_open = true;
                 None
             }
             AppIntent::RequestLoopAudioImportPicker { loop_id } => {
@@ -900,6 +1021,9 @@ impl UnifiedApp {
                         });
                     }
                 });
+            }
+            AppIntent::RequestLoadSessionUrl => {
+                self.session_url_prompt_open = true;
             }
             AppIntent::RequestLoopAudioImportPicker { loop_id } => {
                 let pending = Rc::clone(&self.pending_file_intents);
@@ -1005,6 +1129,55 @@ fn file_name(path: &Path) -> String {
         .unwrap_or_default()
         .to_string_lossy()
         .into_owned()
+}
+
+fn is_http_url(source: &str) -> bool {
+    source.starts_with("https://") || source.starts_with("http://")
+}
+
+fn session_source_name(source: &str) -> String {
+    source
+        .split(['?', '#'])
+        .next()
+        .and_then(|path| path.rsplit('/').next())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("downloaded-session.shoop")
+        .to_owned()
+}
+
+fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) -> AppIntent {
+    match result {
+        Ok(response) if response.ok => AppIntent::LoadSessionBytes {
+            name,
+            bytes: std::sync::Arc::from(response.bytes),
+        },
+        Ok(response) => AppIntent::ReportFileIoError {
+            task_id: None,
+            message: format!("Could not fetch session: HTTP {}", response.status),
+        },
+        Err(error) => AppIntent::ReportFileIoError {
+            task_id: None,
+            message: format!("Could not fetch session: {error}"),
+        },
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn load_session_path(source: String, sender: Sender<AppIntent>) {
+    std::thread::spawn(move || {
+        let path = Path::new(&source);
+        let intent = match std::fs::read(path) {
+            Ok(bytes) => AppIntent::LoadSessionBytes {
+                name: file_name(path),
+                bytes: std::sync::Arc::from(bytes),
+            },
+            Err(error) => AppIntent::ReportFileIoError {
+                task_id: None,
+                message: format!("Could not read {}: {error}", path.display()),
+            },
+        };
+        let _ = sender.send(intent);
+    });
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Motivation

- Allow the app to open a .shoop session on startup via a new `--session` CLI flag or `session` web query parameter. 
- Support both native filesystem paths and HTTP(S) URLs, requiring explicit user confirmation before downloading external sessions. 
- Provide a convenient UI entry point for URL-based session loading from the main application menu.

### Description

- Add `session: Option<String>` to `AppArgs` and accept `session` in the browser query parsing so web builds can receive `?session=...` parameters. 
- Add a new `RequestLoadSessionUrl` intent and wire a new menu item `Load session from URL…` in `GlobalControls` which dispatches to the UI flow; integrate it in `app_widget` action handling. 
- Implement startup handling in `UnifiedApp`: store an optional `startup_session`, detect whether the source is an HTTP(S) URL (`is_http_url`) and either open a filesystem path (`load_session_path`) or present a confirmation dialog and fetch the URL (`fetch_session_url`) using `ehttp` (native) or `ehttp::fetch_async` (wasm). 
- Forward downloaded bytes into the existing session load pipeline via `AppIntent::LoadSessionBytes`, add helpers `session_source_name` and `session_fetch_result`, and add `ehttp` to dependencies/Cargo metadata. 
- Add a small native unit test for CLI parsing (`native_tests::cli_parses_session_source`) and extend web query tests to cover `session` decoding.

### Testing

- Ran `cargo fmt --all -- --check` and `python3 scripts/check_shoop_test_usage.py` (both passed). 
- Built the native package with `RUSTFLAGS='-D warnings' cargo build -p shoopdaloop --no-default-features` which completed successfully. 
- Checked the web target with `cargo check -p shoopdaloop --target wasm32-unknown-unknown --no-default-features` which completed successfully. 
- Executed the targeted unit test `RUSTFLAGS='-D warnings' cargo test -p shoopdaloop --no-default-features native_tests::cli_parses_session_source` which passed, and captured a native UI screenshot run that demonstrates the URL confirmation dialog (`artifacts/session-url-confirmation.png`). 
- Attempted a full workspace test build (`SHOOP_ALLOW_MISSING_BACKENDS=1 cargo test --workspace --features shoop_engine/app_backend`), but the workspace link step failed due to an environment-specific non-PIC static Tracy library when linking `shoop_audio_worklet`; this is an external environment/linker issue and not caused by the implemented logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c4c101548328a050fd03f04e3173)