### PR TITLE
Add confirmed “New session” menu action and session-reset flow

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -1356,6 +1356,7 @@ impl ApplicationModel {
                 self.status.xruns = 0;
                 Ok(())
             }
+            AppIntent::RequestNewSession => self.begin_new_session(),
             AppIntent::RequestSaveSession => self.begin_save_session(),
             AppIntent::RequestLoadSessionPicker
             | AppIntent::RequestLoopAudioImportPicker { .. }
@@ -2990,6 +2991,17 @@ impl ApplicationModel {
         Ok(())
     }
 
+    fn begin_new_session(&mut self) -> Result<(), String> {
+        self.ensure_io_idle()?;
+        let task_id = self.start_io_task(IoTaskKind::LoadSession, "Creating new session");
+        let document = SessionDocument::empty(self.status.sample_rate);
+        self.begin_session_load(
+            "new session".to_owned(),
+            SessionBundle::new(document),
+            task_id,
+        )
+    }
+
     fn begin_load_session(&mut self, name: String, bytes: &[u8]) -> Result<(), String> {
         self.ensure_io_idle()?;
         let task_id = self.start_io_task(IoTaskKind::LoadSession, "Validating session");
@@ -3001,6 +3013,15 @@ impl ApplicationModel {
                 return Err(message);
             }
         };
+        self.begin_session_load(name, bundle, task_id)
+    }
+
+    fn begin_session_load(
+        &mut self,
+        name: String,
+        bundle: SessionBundle,
+        task_id: TaskId,
+    ) -> Result<(), String> {
         if let Err(error) =
             ScriptManager::validate_session_scripts(&session_script_sources(&bundle))
         {
@@ -9245,6 +9266,30 @@ mod tests {
         assert!(snapshot.tracks[0].loops[0].sync);
         assert!(snapshot.tracks[0].id.is_valid());
         assert!(snapshot.tracks[0].loops[0].id.is_valid());
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn new_session_replaces_existing_tracks() {
+        let mut runtime =
+            CooperativeApplicationRuntime::start(Box::new(FakeBackend::default())).unwrap();
+        runtime
+            .dispatch(AppIntent::AddTrack(DirectTrackSpec {
+                name: "Recorded track".to_owned(),
+                audio_channels: 2,
+                midi: true,
+            }))
+            .unwrap();
+        runtime.tick(Duration::ZERO);
+        assert!(runtime.snapshot().tracks.len() > 1);
+
+        runtime.dispatch(AppIntent::RequestNewSession).unwrap();
+        runtime.tick(Duration::ZERO);
+
+        assert!(runtime.snapshot().tracks.is_empty());
+        assert_eq!(
+            runtime.snapshot().io_task.as_ref().unwrap().status,
+            IoTaskStatus::Completed
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1672,6 +1672,7 @@ pub enum AppIntent {
         message: String,
     },
     ResetXruns,
+    RequestNewSession,
     RequestSaveSession,
     RequestLoadSessionPicker,
     LoadSessionBytes {
@@ -1875,6 +1876,7 @@ impl AppIntent {
                 "audio_driver.complete_persistence"
             }
             Self::ResetXruns => "audio.reset_xruns",
+            Self::RequestNewSession => "session.request_new",
             Self::RequestSaveSession => "session.request_save",
             Self::RequestLoadSessionPicker => "session.request_load_picker",
             Self::LoadSessionBytes { .. } => "session.load_bytes",

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -526,6 +526,7 @@ pub struct AppWidget {
     pressed_script_keys: BTreeMap<egui::Key, (i64, i64)>,
     script_control_pressed: bool,
     pending_ephemeral_scripts: VecDeque<PendingEphemeralScript>,
+    new_session_confirmation_open: bool,
     tracing_status: TracingStatus,
     tracing_stopped: Option<TracingStopped>,
     last_callback_count: u64,
@@ -590,6 +591,7 @@ impl AppWidget {
             pressed_script_keys: BTreeMap::new(),
             script_control_pressed: false,
             pending_ephemeral_scripts: VecDeque::new(),
+            new_session_confirmation_open: false,
             tracing_status: TracingStatus::default(),
             tracing_stopped: None,
             last_callback_count: 0,
@@ -722,6 +724,9 @@ impl AppWidget {
                             );
                             if self.global_controls.take_connections_requested() {
                                 self.connections.open(ConnectionScope::AllTracks);
+                            }
+                            if self.global_controls.take_new_session_requested() {
+                                self.new_session_confirmation_open = true;
                             }
                             if self.global_controls.take_save_session_requested() {
                                 actions.push(AppAction::RequestSaveSession);
@@ -913,6 +918,7 @@ impl AppWidget {
         actions.extend(settings_response.app_actions);
         settings_actions.extend(settings_response.settings_actions);
         self.show_ephemeral_script_confirmation(ui.ctx(), state, &mut actions);
+        self.show_new_session_confirmation(ui.ctx(), &mut actions);
         self.show_tracing_stopped(ui.ctx());
         if !actions.is_empty() || !settings_actions.is_empty() {
             tracing::debug!(
@@ -1004,6 +1010,43 @@ impl AppWidget {
             actions.push(self.accept_ephemeral_script().unwrap());
         } else if cancel {
             self.pending_ephemeral_scripts.pop_front();
+        }
+    }
+
+    fn show_new_session_confirmation(
+        &mut self,
+        context: &egui::Context,
+        actions: &mut Vec<AppAction>,
+    ) {
+        if !self.new_session_confirmation_open {
+            return;
+        }
+        let mut accept = false;
+        let mut cancel = false;
+        let modal =
+            egui::Modal::new(egui::Id::new("new_session_confirmation")).show(context, |ui| {
+                ui.heading("Create a new session?");
+                ui.label("All tracks and unsaved session data will be discarded.");
+                ui.add_space(6.0);
+                egui::Sides::new().show(
+                    ui,
+                    |ui| {
+                        if ui.button("Cancel").clicked() {
+                            cancel = true;
+                        }
+                    },
+                    |ui| {
+                        if ui.button("New session").clicked() {
+                            accept = true;
+                        }
+                    },
+                );
+            });
+        if accept {
+            actions.push(AppAction::RequestNewSession);
+        }
+        if accept || cancel || modal.should_close() {
+            self.new_session_confirmation_open = false;
         }
     }
 

--- a/src/rust/shoop_egui/src/global_controls.rs
+++ b/src/rust/shoop_egui/src/global_controls.rs
@@ -13,6 +13,7 @@ const CONTROL_BUTTON_SIZE: [f32; 2] = [34.0, 28.0];
 #[derive(Debug, Default)]
 pub struct GlobalControls {
     connections_requested: bool,
+    new_session_requested: bool,
     save_session_requested: bool,
     load_session_requested: bool,
     settings_requested: bool,
@@ -26,6 +27,7 @@ pub struct GlobalControls {
 enum TestGlobalControl {
     MainMenu,
     Connections,
+    NewSession,
     SaveSession,
     LoadSession,
     Settings,
@@ -47,6 +49,7 @@ enum TestGlobalControl {
 struct TestGlobalControlRects {
     main_menu: Option<egui::Rect>,
     connections: Option<egui::Rect>,
+    new_session: Option<egui::Rect>,
     save_session: Option<egui::Rect>,
     load_session: Option<egui::Rect>,
     settings: Option<egui::Rect>,
@@ -70,6 +73,7 @@ impl GlobalControls {
         state: &GlobalControlState,
     ) -> Vec<GlobalControlAction> {
         self.connections_requested = false;
+        self.new_session_requested = false;
         self.save_session_requested = false;
         self.load_session_requested = false;
         self.settings_requested = false;
@@ -84,6 +88,12 @@ impl GlobalControls {
                         ui.close();
                     }
                     ui.separator();
+                    let new_session = ui.button("New session");
+                    self.record_rect(TestGlobalControl::NewSession, &new_session);
+                    if new_session.clicked() {
+                        self.new_session_requested = true;
+                        ui.close();
+                    }
                     let save_session = ui.button("Save session…");
                     self.record_rect(TestGlobalControl::SaveSession, &save_session);
                     if save_session.clicked() {
@@ -342,6 +352,10 @@ impl GlobalControls {
         std::mem::take(&mut self.save_session_requested)
     }
 
+    pub fn take_new_session_requested(&mut self) -> bool {
+        std::mem::take(&mut self.new_session_requested)
+    }
+
     pub fn take_load_session_requested(&mut self) -> bool {
         std::mem::take(&mut self.load_session_requested)
     }
@@ -355,6 +369,7 @@ impl GlobalControls {
         let target = match control {
             TestGlobalControl::MainMenu => &mut self.test_rects.main_menu,
             TestGlobalControl::Connections => &mut self.test_rects.connections,
+            TestGlobalControl::NewSession => &mut self.test_rects.new_session,
             TestGlobalControl::SaveSession => &mut self.test_rects.save_session,
             TestGlobalControl::LoadSession => &mut self.test_rects.load_session,
             TestGlobalControl::Settings => &mut self.test_rects.settings,
@@ -385,6 +400,7 @@ impl GlobalControls {
         match control {
             TestGlobalControl::MainMenu => self.test_rects.main_menu,
             TestGlobalControl::Connections => self.test_rects.connections,
+            TestGlobalControl::NewSession => self.test_rects.new_session,
             TestGlobalControl::SaveSession => self.test_rects.save_session,
             TestGlobalControl::LoadSession => self.test_rects.load_session,
             TestGlobalControl::Settings => self.test_rects.settings,
@@ -496,7 +512,7 @@ mod tests {
             egui::RawInput {
                 screen_rect: Some(egui::Rect::from_min_size(
                     egui::Pos2::ZERO,
-                    egui::vec2(1000.0, 100.0),
+                    egui::vec2(1000.0, 200.0),
                 )),
                 events,
                 ..Default::default()
@@ -596,6 +612,15 @@ mod tests {
         )
         .is_empty());
         assert!(controls.take_connections_requested());
+        assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
+        assert!(click(
+            &context,
+            &mut controls,
+            &state,
+            TestGlobalControl::NewSession
+        )
+        .is_empty());
+        assert!(controls.take_new_session_requested());
         assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
         assert!(click(
             &context,


### PR DESCRIPTION
### Motivation

- Provide a safe, discoverable way to create a fresh session from the main menu while preventing accidental data loss by requiring explicit confirmation. 
- Reuse the existing session-load machinery to implement a deterministic replacement with an empty `SessionDocument` at the current sample rate.

### Description

- Add a `New session` entry to the main menu and a `new_session_requested` flag in `GlobalControls` with a `take_new_session_requested` accessor. 
- Add a confirmation modal in the UI (`AppWidget::show_new_session_confirmation`) that opens when the menu item is activated and emits the `RequestNewSession` intent only after confirmation. 
- Add `RequestNewSession` to the application intent API (`shoop_app_api::AppIntent`) and handle it in the application model by implementing `begin_new_session` and factoring session load work into `begin_session_load` to reuse the existing validation/commit flow. 
- Add a `new_session_replaces_existing_tracks` unit test under `shoop_app` and update `shoop_egui` tests/layout so the new menu item is exercised by existing UI tests.

### Testing

- Ran `cargo test -p shoop_egui buttons_generate_typed_global_actions_and_main_menu_has_no_business_intent` and it passed. 
- Ran `cargo test -p shoop_app new_session_replaces_existing_tracks` and it passed. 
- Ran `python3 scripts/check_shoop_test_usage.py`, `cargo fmt --all -- --check`, and `python3 scripts/check_tracing_coverage.py --require-closed`, and they succeeded. 
- Attempted workspace build with `RUSTFLAGS="-D warnings" cargo build --workspace` which failed due to linker/C++ object PIC issues from a third-party native dependency (Tracy) during full workspace linking. 
- Attempted the full gate `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` but `cargo-nextest` was not available in the environment so it could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86c37d7c30832890a4a5374dc991a4)