### PR TITLE
Preserve the dedicated sync track when creating a new session

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -2994,7 +2994,7 @@ impl ApplicationModel {
     fn begin_new_session(&mut self) -> Result<(), String> {
         self.ensure_io_idle()?;
         let task_id = self.start_io_task(IoTaskKind::LoadSession, "Creating new session");
-        let document = SessionDocument::empty(self.status.sample_rate);
+        let document = new_session_document(self.status.sample_rate);
         self.begin_session_load(
             "new session".to_owned(),
             SessionBundle::new(document),
@@ -8278,6 +8278,81 @@ impl ApplicationModel {
     }
 }
 
+fn new_session_document(sample_rate: u32) -> SessionDocument {
+    let mut document = SessionDocument::empty(sample_rate);
+    document.track_groups.push(TrackGroupDocument {
+        name: "sync".to_owned(),
+        tracks: vec![TrackDocument {
+            id: 1,
+            name: "Sync".to_owned(),
+            port_name_base: "sync_loop".to_owned(),
+            is_sync: true,
+            width: None,
+            topology: TrackTopologyDocument::Direct {
+                audio_channels: 1,
+                midi: false,
+            },
+            controls: TrackControlsDocument::default(),
+            loops: vec![LoopDocument {
+                id: 1,
+                name: "sync loop".to_owned(),
+                length_frames: 0,
+                is_sync: true,
+                gain: 1.0,
+                balance: 0.0,
+                channels: vec![ChannelDocument {
+                    id: 1,
+                    mode: ChannelModeDocument::Direct,
+                    data_type: DataTypeDocument::Audio,
+                    data_length_frames: 0,
+                    start_offset_frames: 0,
+                    preplay_frames: 0,
+                    gain: 1.0,
+                    connected_port_ids: vec![1, 2],
+                    media_id: None,
+                    recording_started_at: None,
+                    recording_fx_state_id: None,
+                }],
+                composite: None,
+            }],
+            ports: vec![
+                PortDocument {
+                    id: 1,
+                    name: "sync_loop_direct_in".to_owned(),
+                    data_type: DataTypeDocument::Audio,
+                    direction: PortDirectionDocument::Input,
+                    role: PortRoleDocument::AudioInput,
+                    input_connectability: vec![ConnectabilityDocument::External],
+                    output_connectability: vec![ConnectabilityDocument::Internal],
+                    gain: 1.0,
+                    muted: false,
+                    passthrough_muted: false,
+                    internal_connections: Vec::new(),
+                    external_connections: Vec::new(),
+                    ringbuffer_frames: 0,
+                },
+                PortDocument {
+                    id: 2,
+                    name: "sync_loop_direct_out".to_owned(),
+                    data_type: DataTypeDocument::Audio,
+                    direction: PortDirectionDocument::Output,
+                    role: PortRoleDocument::AudioOutput,
+                    input_connectability: vec![ConnectabilityDocument::Internal],
+                    output_connectability: vec![ConnectabilityDocument::External],
+                    gain: 1.0,
+                    muted: false,
+                    passthrough_muted: false,
+                    internal_connections: Vec::new(),
+                    external_connections: Vec::new(),
+                    ringbuffer_frames: 0,
+                },
+            ],
+            fx_chain: None,
+        }],
+    });
+    document
+}
+
 fn click_timing_spec(request: &ClickTrackRequest) -> ClickTrackTimingSpec {
     ClickTrackTimingSpec {
         bpm: request.bpm,
@@ -9269,7 +9344,7 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
-    fn new_session_replaces_existing_tracks() {
+    fn new_session_replaces_existing_tracks_and_restores_sync_track() {
         let mut runtime =
             CooperativeApplicationRuntime::start(Box::new(FakeBackend::default())).unwrap();
         runtime
@@ -9285,9 +9360,13 @@ mod tests {
         runtime.dispatch(AppIntent::RequestNewSession).unwrap();
         runtime.tick(Duration::ZERO);
 
-        assert!(runtime.snapshot().tracks.is_empty());
+        let snapshot = runtime.snapshot();
+        assert_eq!(snapshot.tracks.len(), 1);
+        assert!(snapshot.tracks[0].is_sync);
+        assert_eq!(snapshot.tracks[0].loops.len(), 1);
+        assert!(snapshot.tracks[0].loops[0].sync);
         assert_eq!(
-            runtime.snapshot().io_task.as_ref().unwrap().status,
+            snapshot.io_task.as_ref().unwrap().status,
             IoTaskStatus::Completed
         );
     }


### PR DESCRIPTION
### Motivation

- Creating a New session previously used `SessionDocument::empty`, which produced a trackless document and removed the application-created dedicated sync track required for synchronization paths. 
- The change restores the canonical sync track so new sessions behave like startup state and keep UI/backend sync plumbing intact.

### Description

- Replace the use of `SessionDocument::empty` in `begin_new_session` with `new_session_document(sample_rate)` so new sessions include the standard sync track and loop. 
- Add a `new_session_document` helper that builds a `SessionDocument` with a single sync `TrackDocument`, a sync `LoopDocument`, a mono audio channel, and input/output `PortDocument` entries. 
- Update and rename the existing test to `new_session_replaces_existing_tracks_and_restores_sync_track` and add assertions that a single sync track and sync loop are present after requesting a new session. 
- All changes are contained in `src/rust/shoop_app/src/lib.rs`.

### Testing

- Ran the focused unit test with `cargo test -p shoop_app new_session_replaces_existing_tracks_and_restores_sync_track`, which passed. 
- Ran `cargo fmt --all -- --check` and `python3 scripts/check_shoop_test_usage.py`, both succeeded. 
- Attempted a workspace build with `RUSTFLAGS="-D warnings" cargo build --workspace`, which progressed but the full workspace link failed due to native linking/PIC issues in the environment (Tracy/jack/alsa native artifacts), not due to the code change. 
- Attempted the full CI test command with `cargo nextest` but `cargo-nextest` is not installed in the environment, so that run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86d72e1a808328a73e45d707965c22)