### PR TITLE
Add loop timeline editing (start offset, preplay, length) across protocol, backend and UI

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -30,7 +30,7 @@ use shoop_app_api::{
     TrackSpecTopology, TrackState, TrackTopology, WaveformChannelState,
 };
 use shoop_backend::{
-    Backend, BackendAsyncResult, BackendAudioChannelUpdate, BackendAudioContent,
+    Backend, BackendAsyncResult, BackendAudioChannelUpdate, BackendAudioContent, BackendAudioData,
     BackendChannelMode, BackendCompositeConfig, BackendCompositeEntry, BackendCompositeId,
     BackendCompositeKind, BackendCompositeTarget, BackendConnectionSnapshot, BackendGrabRequest,
     BackendLoopContent, BackendLoopContentUpdate, BackendLoopId, BackendLoopMode,
@@ -871,7 +871,7 @@ struct LoopModel {
     state: LoopState,
     length: u32,
     position: u32,
-    audio_data: Option<Vec<Arc<[f32]>>>,
+    audio_data: Option<BackendAudioData>,
     midi_data: Option<Vec<MidiSequenceChannelState>>,
     script_composition: Vec<Vec<LoopId>>,
     composite: Option<CompositeDocument>,
@@ -957,6 +957,7 @@ fn midi_detail_channels(model: &LoopModel, data: BackendMidiData) -> Vec<MidiSeq
                     })
                     .collect(),
                 start_offset: i64::from(channel.start_offset),
+                preplay_samples: u64::from(channel.preplay),
                 loop_length: u64::from(model.length),
                 played_sample: matches!(
                     model.state.mode,
@@ -1289,6 +1290,14 @@ impl ApplicationModel {
         );
         let _entered = span.enter();
         let result = match intent {
+            AppIntent::SetLoopTimeline {
+                loop_id,
+                start_offset,
+                preplay_samples,
+                loop_length,
+            } => {
+                self.set_loop_timeline(backend, loop_id, start_offset, preplay_samples, loop_length)
+            }
             AppIntent::Loop {
                 track_id,
                 loop_id,
@@ -1474,6 +1483,66 @@ impl ApplicationModel {
         } else {
             span.record("outcome", "ok");
         }
+    }
+
+    fn set_loop_timeline(
+        &mut self,
+        backend: &mut dyn Backend,
+        loop_id: LoopId,
+        start_offset: Option<i64>,
+        preplay_samples: Option<u64>,
+        loop_length: Option<u64>,
+    ) -> Result<(), String> {
+        let backend_id = self
+            .loops
+            .get(&loop_id)
+            .ok_or_else(|| format!("stale loop {loop_id}"))?
+            .backend_id;
+        let start_offset = start_offset
+            .map(i32::try_from)
+            .transpose()
+            .map_err(|_| "loop start is outside the supported frame range".to_owned())?;
+        let preplay = preplay_samples
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| "preplay is outside the supported frame range".to_owned())?;
+        let length = loop_length
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| "loop length is outside the supported frame range".to_owned())?;
+        backend
+            .set_loop_timing(backend_id, start_offset, preplay, length)
+            .map_err(|error| format!("could not update loop timing: {error}"))?;
+
+        let model = self.loops.get_mut(&loop_id).expect("loop was checked");
+        if let Some(length) = length {
+            model.length = length;
+        }
+        if let Some(channels) = model.audio_data.as_mut() {
+            for channel in &mut channels.channels {
+                if let Some(offset) = start_offset {
+                    channel.start_offset = offset;
+                }
+                if let Some(samples) = preplay {
+                    channel.preplay = samples;
+                }
+            }
+        }
+        if let Some(channels) = model.midi_data.as_mut() {
+            for channel in channels {
+                if let Some(offset) = start_offset {
+                    channel.start_offset = i64::from(offset);
+                }
+                if let Some(samples) = preplay {
+                    channel.preplay_samples = u64::from(samples);
+                }
+                if let Some(length) = length {
+                    channel.loop_length = u64::from(length);
+                }
+            }
+        }
+        self.revision = self.revision.saturating_add(1);
+        Ok(())
     }
 
     fn handle_piano_action(
@@ -5654,13 +5723,13 @@ impl ApplicationModel {
         if needs_audio {
             if *has_audio {
                 let data = backend
-                    .loop_audio_data(*backend_id)
+                    .loop_audio_data_with_metadata(*backend_id)
                     .map_err(|error| format!("could not fetch selected loop audio: {error}"))?;
                 if let (Some(model), Some(data)) = (self.loops.get_mut(id), data) {
                     model.audio_data = Some(data);
                 }
             } else if let Some(model) = self.loops.get_mut(id) {
-                model.audio_data = Some(Vec::new());
+                model.audio_data = Some(BackendAudioData::default());
             }
         }
         if needs_midi {
@@ -7833,16 +7902,18 @@ impl ApplicationModel {
             .as_ref()
             .map(|channels| {
                 channels
+                    .channels
                     .iter()
                     .enumerate()
-                    .map(|(index, samples)| WaveformChannelState {
+                    .map(|(index, channel)| WaveformChannelState {
                         id: ChannelId::from_raw((model.id.raw() << 8) | index as u64 + 1),
                         label: labels
                             .get(index)
                             .cloned()
                             .unwrap_or_else(|| format!("Audio {}", index + 1)),
-                        samples: Arc::clone(samples),
-                        start_offset: 0,
+                        samples: Arc::clone(&channel.samples),
+                        start_offset: i64::from(channel.start_offset),
+                        preplay_samples: u64::from(channel.preplay),
                         loop_length: model.length as u64,
                         played_sample: matches!(model.state.mode, LoopMode::Playing)
                             .then_some(model.position as i64),
@@ -7886,6 +7957,7 @@ impl ApplicationModel {
             channels,
             midi_loading: composite.is_none() && model.state.has_midi && model.midi_data.is_none(),
             midi_channels,
+            sync_loop_length: u64::from(self.sync_length()),
             composite,
         })
     }
@@ -12201,7 +12273,12 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         {
             let model = model.loops.get_mut(&target).unwrap();
             model.length = 480;
-            model.audio_data = Some(vec![Arc::from([0.25, -0.25])]);
+            model.audio_data = Some(BackendAudioData {
+                channels: vec![shoop_backend::BackendAudioChannelData {
+                    samples: Arc::from([0.25, -0.25]),
+                    ..Default::default()
+                }],
+            });
             model.state.empty = false;
             model.state.selected = false;
         }
@@ -14716,6 +14793,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert_eq!(details.midi_channels.len(), 1);
         let channel = &details.midi_channels[0];
         assert_eq!(channel.start_offset, -3);
+        assert_eq!(channel.preplay_samples, 4);
         assert_eq!(channel.loop_length, 24);
         assert_eq!(channel.events.len(), 2);
         assert_eq!(channel.events[0].data.as_ref(), [0x90, 67, 99]);
@@ -14726,6 +14804,19 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             2
         );
         let original_events = Arc::clone(&channel.events);
+        model.handle_intent(
+            &mut backend,
+            AppIntent::SetLoopTimeline {
+                loop_id,
+                start_offset: Some(-8),
+                preplay_samples: Some(6),
+                loop_length: Some(30),
+            },
+        );
+        let edited = model.details_snapshot().unwrap();
+        assert_eq!(edited.midi_channels[0].start_offset, -8);
+        assert_eq!(edited.midi_channels[0].preplay_samples, 6);
+        assert_eq!(edited.midi_channels[0].loop_length, 30);
         model
             .apply_script_operation(
                 &mut backend,

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -871,6 +871,7 @@ pub struct WaveformChannelState {
     pub label: String,
     pub samples: Arc<[f32]>,
     pub start_offset: i64,
+    pub preplay_samples: u64,
     pub loop_length: u64,
     pub played_sample: Option<i64>,
 }
@@ -882,6 +883,7 @@ impl Default for WaveformChannelState {
             label: String::new(),
             samples: Arc::from([]),
             start_offset: 0,
+            preplay_samples: 0,
             loop_length: 0,
             played_sample: None,
         }
@@ -901,6 +903,7 @@ pub struct MidiSequenceChannelState {
     pub content_revision: u64,
     pub events: Arc<[MidiEventState]>,
     pub start_offset: i64,
+    pub preplay_samples: u64,
     pub loop_length: u64,
     pub played_sample: Option<i64>,
 }
@@ -913,6 +916,7 @@ impl Default for MidiSequenceChannelState {
             content_revision: 0,
             events: Arc::from([]),
             start_offset: 0,
+            preplay_samples: 0,
             loop_length: 0,
             played_sample: None,
         }
@@ -966,7 +970,15 @@ pub struct LoopDetailsState {
     pub channels: Vec<WaveformChannelState>,
     pub midi_loading: bool,
     pub midi_channels: Vec<MidiSequenceChannelState>,
+    pub sync_loop_length: u64,
     pub composite: Option<CompositeDetailsState>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TimelineEditTool {
+    LoopStart,
+    PreplayStart,
+    LoopEnd,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1572,6 +1584,12 @@ pub enum PianoAction {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AppIntent {
+    SetLoopTimeline {
+        loop_id: LoopId,
+        start_offset: Option<i64>,
+        preplay_samples: Option<u64>,
+        loop_length: Option<u64>,
+    },
     Loop {
         track_id: TrackId,
         loop_id: LoopId,
@@ -1868,6 +1886,7 @@ impl PianoAction {
 impl AppIntent {
     pub const fn kind(&self) -> &'static str {
         match self {
+            Self::SetLoopTimeline { .. } => "loop.timeline",
             Self::Loop { action, .. } => action.kind(),
             Self::Track { action, .. } => action.kind(),
             Self::Global(action) => action.kind(),

--- a/src/rust/shoop_audio_protocol/src/lib.rs
+++ b/src/rust/shoop_audio_protocol/src/lib.rs
@@ -277,13 +277,22 @@ impl Command {
             (
                 Self::SetLoopTiming {
                     loop_id: existing_loop,
-                    ..
+                    start_offset: existing_start_offset,
+                    preplay: existing_preplay,
+                    length: existing_length,
                 },
                 Self::SetLoopTiming {
                     loop_id: replacement_loop,
-                    ..
+                    start_offset: replacement_start_offset,
+                    preplay: replacement_preplay,
+                    length: replacement_length,
                 },
-            ) => existing_loop == replacement_loop,
+            ) => {
+                existing_loop == replacement_loop
+                    && (existing_start_offset.is_none() || replacement_start_offset.is_some())
+                    && (existing_preplay.is_none() || replacement_preplay.is_some())
+                    && (existing_length.is_none() || replacement_length.is_some())
+            }
             (Self::ConfigureDeviceChannels { .. }, Self::ConfigureDeviceChannels { .. })
             | (Self::ConfigureMidiEndpoints { .. }, Self::ConfigureMidiEndpoints { .. }) => true,
             (
@@ -840,6 +849,36 @@ mod tests {
         .supersedes_in_journal(&Command::ConfigureMidiEndpoints {
             endpoints: Vec::new(),
         }));
+
+        let start_only = Command::SetLoopTiming {
+            loop_id: 5,
+            start_offset: Some(-8),
+            preplay: None,
+            length: None,
+        };
+        let length_only = Command::SetLoopTiming {
+            loop_id: 5,
+            start_offset: None,
+            preplay: None,
+            length: Some(64),
+        };
+        let complete = Command::SetLoopTiming {
+            loop_id: 5,
+            start_offset: Some(-4),
+            preplay: Some(12),
+            length: Some(96),
+        };
+        assert!(!length_only.supersedes_in_journal(&start_only));
+        assert!(!start_only.supersedes_in_journal(&length_only));
+        assert!(complete.supersedes_in_journal(&start_only));
+        assert!(complete.supersedes_in_journal(&length_only));
+        assert!(!Command::SetLoopTiming {
+            loop_id: 6,
+            start_offset: Some(-4),
+            preplay: Some(12),
+            length: Some(96),
+        }
+        .supersedes_in_journal(&complete));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_audio_protocol/src/lib.rs
+++ b/src/rust/shoop_audio_protocol/src/lib.rs
@@ -119,6 +119,12 @@ pub enum Command {
         loop_id: u64,
         length: u32,
     },
+    SetLoopTiming {
+        loop_id: u64,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    },
     BeginLoopContentReplace {
         generation: u64,
         loop_id: u64,
@@ -264,6 +270,16 @@ impl Command {
                     ..
                 },
                 Self::SetLoopLength {
+                    loop_id: replacement_loop,
+                    ..
+                },
+            ) => existing_loop == replacement_loop,
+            (
+                Self::SetLoopTiming {
+                    loop_id: existing_loop,
+                    ..
+                },
+                Self::SetLoopTiming {
                     loop_id: replacement_loop,
                     ..
                 },
@@ -679,6 +695,8 @@ pub struct WaveformChunk {
     pub channel_count: usize,
     pub offset: usize,
     pub total_samples: usize,
+    pub start_offset: i32,
+    pub preplay: u32,
     pub final_chunk: bool,
     pub samples: Vec<f32>,
 }

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -2677,6 +2677,49 @@ mod tests {
             command(
                 &mut host,
                 sequence,
+                Command::SetLoopTiming {
+                    loop_id: 1,
+                    start_offset: Some(-16),
+                    preplay: Some(32),
+                    length: Some(1536),
+                },
+            )
+            .event,
+            Event::Ack
+        ));
+        sequence += 1;
+        let edited = host.backend.capture_session().unwrap();
+        assert_eq!(edited.tracks[0].loops[0].length, 1536);
+        assert!(edited.tracks[0].loops[0]
+            .audio
+            .iter()
+            .all(|channel| channel.start_offset == -16 && channel.preplay == 32));
+        assert!(edited.tracks[0].loops[0]
+            .midi
+            .iter()
+            .all(|channel| channel.start_offset == -16 && channel.preplay == 32));
+        let Event::Waveform(chunk) = command(
+            &mut host,
+            sequence,
+            Command::RequestWaveform {
+                loop_id: 1,
+                revision: 4,
+                channel: 0,
+                offset: 0,
+                max_samples: 2,
+            },
+        )
+        .event
+        else {
+            panic!("expected waveform chunk")
+        };
+        assert_eq!(chunk.start_offset, -16);
+        assert_eq!(chunk.preplay, 32);
+        sequence += 1;
+        assert!(matches!(
+            command(
+                &mut host,
+                sequence,
                 Command::TransitionLoop {
                     loop_id: 1,
                     mode: WireLoopMode::Playing,

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -431,6 +431,22 @@ impl WorkletHost {
                     .map_err(|error| error.to_string())?;
                 Ok(Event::Ack)
             }
+            Command::SetLoopTiming {
+                loop_id,
+                start_offset,
+                preplay,
+                length,
+            } => {
+                self.backend
+                    .set_loop_timing(
+                        BackendLoopId::from_raw(loop_id),
+                        start_offset,
+                        preplay,
+                        length,
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(Event::Ack)
+            }
             Command::BeginLoopContentReplace {
                 generation,
                 loop_id,
@@ -526,6 +542,8 @@ impl WorkletHost {
                     channel_count: chunk.channel_count,
                     offset: chunk.offset,
                     total_samples: chunk.total_samples,
+                    start_offset: chunk.start_offset,
+                    preplay: chunk.preplay,
                     final_chunk: chunk.offset.saturating_add(chunk.samples.len())
                         >= chunk.total_samples,
                     samples: chunk.samples,

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -506,6 +506,18 @@ pub struct BackendAudioContent {
     pub preplay: u32,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BackendAudioChannelData {
+    pub samples: Arc<[f32]>,
+    pub start_offset: i32,
+    pub preplay: u32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BackendAudioData {
+    pub channels: Vec<BackendAudioChannelData>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BackendLatestMidiMessage {
     pub bytes: [u8; 4],
@@ -650,6 +662,8 @@ pub struct BackendAudioDataChunk {
     pub channel_count: usize,
     pub offset: usize,
     pub total_samples: usize,
+    pub start_offset: i32,
+    pub preplay: u32,
     pub samples: Vec<f32>,
 }
 
@@ -831,6 +845,22 @@ pub trait Backend {
     fn set_loop_balance(&mut self, loop_id: BackendLoopId, balance: f32) -> Result<()>;
     fn grab_loops(&mut self, requests: &[BackendGrabRequest]) -> Result<()>;
     fn loop_audio_data(&mut self, loop_id: BackendLoopId) -> Result<Option<Vec<Arc<[f32]>>>>;
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        Ok(self
+            .loop_audio_data(loop_id)?
+            .map(|channels| BackendAudioData {
+                channels: channels
+                    .into_iter()
+                    .map(|samples| BackendAudioChannelData {
+                        samples,
+                        ..Default::default()
+                    })
+                    .collect(),
+            }))
+    }
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>>;
     fn loop_audio_data_chunk(
         &mut self,
@@ -851,6 +881,8 @@ pub trait Backend {
             channel_count: channels.len(),
             offset,
             total_samples: samples.len(),
+            start_offset: 0,
+            preplay: 0,
             samples: if offset < end {
                 samples[offset..end].to_vec()
             } else {
@@ -891,6 +923,15 @@ pub trait Backend {
     }
     fn set_loop_length(&mut self, _loop_id: BackendLoopId, _length: u32) -> Result<()> {
         Err(anyhow!("targeted loop length updates are unavailable"))
+    }
+    fn set_loop_timing(
+        &mut self,
+        _loop_id: BackendLoopId,
+        _start_offset: Option<i32>,
+        _preplay: Option<u32>,
+        _length: Option<u32>,
+    ) -> Result<()> {
+        Err(anyhow!("targeted loop timing updates are unavailable"))
     }
     fn capture_session(&mut self) -> Result<BackendSessionData> {
         Err(anyhow!("session capture is unavailable"))
@@ -4001,6 +4042,32 @@ impl Backend for EngineBackend {
             .map(Some)
     }
 
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        let channels = self
+            .loop_channels
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("unknown backend loop channels {loop_id:?}"))?;
+        let channels = channels
+            .audio
+            .iter()
+            .map(|index| {
+                let channel = self
+                    .session
+                    .audio_channel(*index)
+                    .ok_or_else(|| anyhow!("missing audio loop channel"))?;
+                Ok(BackendAudioChannelData {
+                    samples: Arc::from(channel.data()),
+                    start_offset: channel.start_offset(),
+                    preplay: channel.pre_play_samples(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(BackendAudioData { channels }))
+    }
+
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>> {
         let channels = self
             .loop_channels
@@ -4071,6 +4138,8 @@ impl Backend for EngineBackend {
             channel_count,
             offset,
             total_samples,
+            start_offset: channel_ref.start_offset(),
+            preplay: channel_ref.pre_play_samples(),
             samples,
         })
     }
@@ -4252,6 +4321,47 @@ impl Backend for EngineBackend {
             .loop_mut(engine_loop)
             .ok_or_else(|| anyhow!("missing engine loop"))?
             .set_length(length);
+        Ok(())
+    }
+
+    fn set_loop_timing(
+        &mut self,
+        loop_id: BackendLoopId,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    ) -> Result<()> {
+        let channels = self
+            .loop_channels
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("unknown backend loop channels {loop_id:?}"))?;
+        for index in &channels.audio {
+            let channel = self
+                .session
+                .audio_channel_mut(*index)
+                .ok_or_else(|| anyhow!("missing audio loop channel"))?;
+            if let Some(offset) = start_offset {
+                channel.set_start_offset(offset);
+            }
+            if let Some(samples) = preplay {
+                channel.set_pre_play_samples(samples);
+            }
+        }
+        for index in &channels.midi {
+            let channel = self
+                .session
+                .midi_channel_mut(*index)
+                .ok_or_else(|| anyhow!("missing MIDI loop channel"))?;
+            if let Some(offset) = start_offset {
+                channel.set_start_offset(offset);
+            }
+            if let Some(samples) = preplay {
+                channel.set_pre_play_samples(samples);
+            }
+        }
+        if let Some(length) = length {
+            self.set_loop_length(loop_id, length)?;
+        }
         Ok(())
     }
 
@@ -4703,6 +4813,13 @@ impl Backend for LocalDummyBackend {
         self.runtime.loop_audio_data(loop_id)
     }
 
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        self.runtime.loop_audio_data_with_metadata(loop_id)
+    }
+
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>> {
         self.runtime.loop_midi_data(loop_id)
     }
@@ -4760,6 +4877,17 @@ impl Backend for LocalDummyBackend {
 
     fn set_loop_length(&mut self, loop_id: BackendLoopId, length: u32) -> Result<()> {
         self.runtime.set_loop_length(loop_id, length)
+    }
+
+    fn set_loop_timing(
+        &mut self,
+        loop_id: BackendLoopId,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    ) -> Result<()> {
+        self.runtime
+            .set_loop_timing(loop_id, start_offset, preplay, length)
     }
 
     fn capture_session(&mut self) -> Result<BackendSessionData> {
@@ -6168,6 +6296,26 @@ impl Backend for FakeBackend {
         ))
     }
 
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        self.require_loop(loop_id)?;
+        let channels = self
+            .loop_content
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("missing fake loop content"))?
+            .audio
+            .iter()
+            .map(|channel| BackendAudioChannelData {
+                samples: Arc::from(channel.samples.clone()),
+                start_offset: channel.start_offset,
+                preplay: channel.preplay,
+            })
+            .collect();
+        Ok(Some(BackendAudioData { channels }))
+    }
+
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>> {
         self.require_loop(loop_id)?;
         let channels = self
@@ -6403,6 +6551,40 @@ impl Backend for FakeBackend {
             .length = length;
         self.operations
             .push(FakeOperation::SetLoopLength(loop_id, length));
+        Ok(())
+    }
+
+    fn set_loop_timing(
+        &mut self,
+        loop_id: BackendLoopId,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    ) -> Result<()> {
+        self.require_loop(loop_id)?;
+        let content = self
+            .loop_content
+            .get_mut(&loop_id)
+            .ok_or_else(|| anyhow!("missing fake loop content"))?;
+        for channel in &mut content.audio {
+            if let Some(offset) = start_offset {
+                channel.start_offset = offset;
+            }
+            if let Some(samples) = preplay {
+                channel.preplay = samples;
+            }
+        }
+        for channel in &mut content.midi {
+            if let Some(offset) = start_offset {
+                channel.start_offset = offset;
+            }
+            if let Some(samples) = preplay {
+                channel.preplay = samples;
+            }
+        }
+        if let Some(length) = length {
+            self.set_loop_length(loop_id, length)?;
+        }
         Ok(())
     }
 
@@ -7347,6 +7529,26 @@ mod tests {
         assert_eq!(retained_content.audio[1].start_offset, -2);
         assert_eq!(retained_content.audio[1].preplay, 5);
         assert_eq!(retained_content.midi[0].events[0].time, 2);
+
+        backend
+            .set_loop_timing(target, Some(-7), Some(12), Some(9))
+            .unwrap();
+        let edited = backend.capture_session().unwrap();
+        let edited_content = edited
+            .tracks
+            .iter()
+            .flat_map(|track| &track.loops)
+            .find(|loop_| loop_.source_id == target.raw())
+            .unwrap();
+        assert_eq!(edited_content.length, 9);
+        assert!(edited_content
+            .audio
+            .iter()
+            .all(|channel| channel.start_offset == -7 && channel.preplay == 12));
+        assert!(edited_content
+            .midi
+            .iter()
+            .all(|channel| channel.start_offset == -7 && channel.preplay == 12));
 
         backend
             .transition_loop(sync, BackendLoopMode::Recording, None)

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -869,11 +869,16 @@ pub trait Backend {
         offset: usize,
         max_samples: usize,
     ) -> Result<BackendAudioDataChunk> {
-        let channels = self.loop_audio_data(loop_id)?.unwrap_or_default();
-        let samples = channels
-            .get(channel)
-            .cloned()
+        let channels = self
+            .loop_audio_data_with_metadata(loop_id)?
+            .unwrap_or_default()
+            .channels;
+        let channel_data = channels.get(channel);
+        let samples = channel_data
+            .map(|channel| Arc::clone(&channel.samples))
             .unwrap_or_else(|| Arc::from([]));
+        let start_offset = channel_data.map_or(0, |channel| channel.start_offset);
+        let preplay = channel_data.map_or(0, |channel| channel.preplay);
         let end = offset.saturating_add(max_samples).min(samples.len());
         Ok(BackendAudioDataChunk {
             content_revision: 0,
@@ -881,8 +886,8 @@ pub trait Backend {
             channel_count: channels.len(),
             offset,
             total_samples: samples.len(),
-            start_offset: 0,
-            preplay: 0,
+            start_offset,
+            preplay,
             samples: if offset < end {
                 samples[offset..end].to_vec()
             } else {
@@ -7533,6 +7538,10 @@ mod tests {
         backend
             .set_loop_timing(target, Some(-7), Some(12), Some(9))
             .unwrap();
+        let audio_chunk = backend.loop_audio_data_chunk(target, 0, 1, 1).unwrap();
+        assert_eq!(audio_chunk.start_offset, -7);
+        assert_eq!(audio_chunk.preplay, 12);
+        assert_eq!(audio_chunk.samples, [2.0]);
         let edited = backend.capture_session().unwrap();
         let edited_content = edited
             .tracks

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -3379,6 +3379,35 @@ mod tests {
         assert_eq!(midi_details.channels[0].events[0].data, [0x90, 64, 127]);
         assert!(midi_details.channels[0].content_revision > 0);
 
+        let audio_details = backend
+            .loop_audio_data_with_metadata(target)
+            .unwrap()
+            .unwrap();
+        assert_eq!(audio_details.channels.len(), 2);
+        assert_eq!(
+            audio_details.channels[0].samples.as_ref(),
+            [1.0, 2.0, 3.0, 4.0]
+        );
+        assert_eq!(audio_details.channels[0].start_offset, -1);
+        assert_eq!(audio_details.channels[0].preplay, 2);
+        backend
+            .set_loop_timing(target, Some(-8), Some(9), Some(12))
+            .unwrap();
+        let edited_audio = backend
+            .loop_audio_data_with_metadata(target)
+            .unwrap()
+            .unwrap();
+        assert!(edited_audio
+            .channels
+            .iter()
+            .all(|channel| channel.start_offset == -8 && channel.preplay == 9));
+        let edited_midi = backend.loop_midi_data(target).unwrap().unwrap();
+        assert!(edited_midi
+            .channels
+            .iter()
+            .all(|channel| channel.start_offset == -8 && channel.preplay == 9));
+        assert_eq!(backend.poll().unwrap().loops[&target].length, 12);
+
         let captured = backend.capture_session().unwrap();
         assert_eq!(
             captured.tracks[0].loops[1].audio[0].samples,

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -2275,6 +2275,30 @@ impl Backend for NativeBackend {
         ))
     }
 
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        let runtime = self.runtime()?;
+        let loop_ = runtime
+            .loops
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("unknown native loop {loop_id:?}"))?;
+        let channels = loop_
+            .audio
+            .iter()
+            .map(|channel| {
+                let state = channel.get_state()?;
+                Ok(BackendAudioChannelData {
+                    samples: Arc::from(channel.get_data()),
+                    start_offset: state.start_offset,
+                    preplay: state.n_preplay_samples,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(BackendAudioData { channels }))
+    }
+
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>> {
         let runtime = self.runtime()?;
         let loop_ = runtime
@@ -2496,6 +2520,46 @@ impl Backend for NativeBackend {
         runtime
             .session
             .wait_for_command(sequence, shoop_engine::DEFAULT_WAIT_TIMEOUT)?;
+        Ok(())
+    }
+
+    fn set_loop_timing(
+        &mut self,
+        loop_id: BackendLoopId,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    ) -> Result<()> {
+        let runtime = self.runtime_mut()?;
+        let target = runtime
+            .loops
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("unknown native loop {loop_id:?}"))?;
+        let mut sequences = Vec::new();
+        for channel in &target.audio {
+            if let Some(offset) = start_offset {
+                sequences.push(channel.set_start_offset(offset)?);
+            }
+            if let Some(samples) = preplay {
+                sequences.push(channel.set_n_preplay_samples(samples)?);
+            }
+        }
+        for channel in &target.midi {
+            if let Some(offset) = start_offset {
+                sequences.push(channel.set_start_offset(offset)?);
+            }
+            if let Some(samples) = preplay {
+                sequences.push(channel.set_n_preplay_samples(samples)?);
+            }
+        }
+        if let Some(length) = length {
+            sequences.push(target.handle.set_length(length)?);
+        }
+        for sequence in sequences {
+            runtime
+                .session
+                .wait_for_command(sequence, shoop_engine::DEFAULT_WAIT_TIMEOUT)?;
+        }
         Ok(())
     }
 

--- a/src/rust/shoop_egui/src/colors.rs
+++ b/src/rust/shoop_egui/src/colors.rs
@@ -45,5 +45,7 @@ pub const DIAL_LABEL: Color32 = Color32::from_gray(180);
 pub const WAVEFORM_BACKGROUND: Color32 = Color32::from_rgb(25, 25, 27);
 pub const WAVEFORM_ZERO_LINE: Color32 = Color32::from_rgb(92, 48, 54);
 pub const WAVEFORM_LOOP_REGION: Color32 = Color32::from_rgba_unmultiplied_const(28, 28, 128, 110);
+pub const WAVEFORM_PREPLAY_REGION: Color32 = Color32::from_rgba_unmultiplied_const(96, 72, 24, 90);
+pub const WAVEFORM_SYNC_MARKER: Color32 = Color32::from_rgba_unmultiplied_const(180, 180, 210, 90);
 pub const WAVEFORM_LINE: Color32 = Color32::from_rgb(235, 35, 55);
 pub const WAVEFORM_PLAYHEAD: Color32 = Color32::from_rgb(80, 210, 100);

--- a/src/rust/shoop_egui/src/details_pane.rs
+++ b/src/rust/shoop_egui/src/details_pane.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AppIntent, CompositeLoopWidget, LoopDetailsState, LoopId, MidiSequenceWidget, WaveformWidget,
+    colors, AppIntent, CompositeLoopWidget, LoopDetailsState, LoopId, MidiSequenceWidget,
+    TimelineEditTool, WaveformWidget,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -10,6 +11,71 @@ pub(crate) struct MediaView {
     pub(crate) end_frame: f64,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MediaWidgetResponse {
+    pub pan_frames: f64,
+    pub clicked_frame: Option<i64>,
+}
+
+pub(crate) fn paint_timeline_regions(
+    painter: &egui::Painter,
+    rect: egui::Rect,
+    view: MediaView,
+    loop_start: i64,
+    preplay_samples: u64,
+    loop_length: u64,
+    sync_loop_length: u64,
+) {
+    let frame_to_x = |frame: i64| view.frame_to_x(frame as f64, rect);
+    let loop_end = loop_start.saturating_add_unsigned(loop_length);
+    let paint_range = |start: i64, end: i64, color| {
+        let left = frame_to_x(start).clamp(rect.left(), rect.right());
+        let right = frame_to_x(end).clamp(rect.left(), rect.right());
+        if right > left {
+            painter.rect_filled(
+                egui::Rect::from_min_max(
+                    egui::pos2(left, rect.top()),
+                    egui::pos2(right, rect.bottom()),
+                ),
+                0.0,
+                color,
+            );
+        }
+    };
+    paint_range(
+        loop_start.saturating_sub_unsigned(preplay_samples),
+        loop_start,
+        colors::WAVEFORM_PREPLAY_REGION,
+    );
+    paint_range(loop_start, loop_end, colors::WAVEFORM_LOOP_REGION);
+
+    if sync_loop_length == 0 {
+        return;
+    }
+    let visible_start = view.start_frame.floor() as i64;
+    let delta = visible_start.saturating_sub(loop_start).max(0) as u64;
+    let mut marker = loop_start.saturating_add_unsigned(
+        delta
+            .div_ceil(sync_loop_length)
+            .saturating_mul(sync_loop_length),
+    );
+    while marker <= loop_end {
+        let x = frame_to_x(marker);
+        if rect.x_range().contains(x) {
+            painter.vline(
+                x,
+                rect.y_range(),
+                egui::Stroke::new(1.0, colors::WAVEFORM_SYNC_MARKER),
+            );
+        }
+        let next = marker.saturating_add_unsigned(sync_loop_length);
+        if next == marker {
+            break;
+        }
+        marker = next;
+    }
+}
+
 impl MediaView {
     pub(crate) fn visible_frames(self) -> f64 {
         (self.end_frame - self.start_frame).max(1.0)
@@ -17,6 +83,11 @@ impl MediaView {
 
     pub(crate) fn frame_to_x(self, frame: f64, rect: egui::Rect) -> f32 {
         rect.left() + ((frame - self.start_frame) / self.visible_frames()) as f32 * rect.width()
+    }
+
+    pub(crate) fn x_to_frame(self, x: f32, rect: egui::Rect) -> f64 {
+        self.start_frame
+            + f64::from(x - rect.left()) / f64::from(rect.width().max(1.0)) * self.visible_frames()
     }
 
     pub(crate) fn pan(&mut self, drag_delta_x: f32, width: f32) {
@@ -64,6 +135,11 @@ fn media_bounds(details: &LoopDetailsState) -> (f64, f64) {
     let mut end = 1.0_f64;
     for channel in &details.channels {
         start = start.min(channel.start_offset as f64);
+        start = start.min(
+            channel
+                .start_offset
+                .saturating_sub_unsigned(channel.preplay_samples) as f64,
+        );
         end = end.max(channel.samples.len() as f64).max(
             channel
                 .start_offset
@@ -72,6 +148,11 @@ fn media_bounds(details: &LoopDetailsState) -> (f64, f64) {
     }
     for channel in &details.midi_channels {
         start = start.min(channel.start_offset as f64);
+        start = start.min(
+            channel
+                .start_offset
+                .saturating_sub_unsigned(channel.preplay_samples) as f64,
+        );
         end = end.max(
             channel
                 .start_offset
@@ -91,6 +172,7 @@ pub struct DetailsPane {
     waveforms: Vec<WaveformWidget>,
     midi_sequences: Vec<MidiSequenceWidget>,
     composite: CompositeLoopWidget,
+    edit_tool: Option<TimelineEditTool>,
 }
 
 impl DetailsPane {
@@ -138,8 +220,25 @@ impl DetailsPane {
         )
         .on_hover_text(format!("Media zoom: {:.1}×", self.media_view.zoom));
 
+        ui.horizontal(|ui| {
+            ui.label("Click tool:");
+            for (tool, label) in [
+                (TimelineEditTool::LoopStart, "Loop start"),
+                (TimelineEditTool::PreplayStart, "Preplay start"),
+                (TimelineEditTool::LoopEnd, "Loop end"),
+            ] {
+                if ui
+                    .selectable_label(self.edit_tool == Some(tool), label)
+                    .clicked()
+                {
+                    self.edit_tool = (self.edit_tool != Some(tool)).then_some(tool);
+                }
+            }
+        });
+
         let media_view = self.media_view.view(media_bounds(details));
         let mut pan_frames = 0.0;
+        let mut clicked_frame = None;
         self.waveforms
             .resize_with(details.channels.len(), WaveformWidget::default);
         self.midi_sequences
@@ -151,17 +250,65 @@ impl DetailsPane {
                 ui.spacing_mut().item_spacing.y = 0.0;
                 ui.vertical(|ui| {
                     for (channel, waveform) in details.channels.iter().zip(&mut self.waveforms) {
-                        pan_frames += waveform.show(ui, channel, media_view);
+                        let response = waveform.show(
+                            ui,
+                            channel,
+                            media_view,
+                            details.sync_loop_length,
+                            self.edit_tool.is_some(),
+                        );
+                        pan_frames += response.pan_frames;
+                        clicked_frame = clicked_frame.or(response.clicked_frame);
                     }
                     for (channel, sequence) in
                         details.midi_channels.iter().zip(&mut self.midi_sequences)
                     {
-                        pan_frames += sequence.show(ui, channel, media_view);
+                        let response = sequence.show(
+                            ui,
+                            channel,
+                            media_view,
+                            details.sync_loop_length,
+                            self.edit_tool.is_some(),
+                        );
+                        pan_frames += response.pan_frames;
+                        clicked_frame = clicked_frame.or(response.clicked_frame);
                     }
                 });
             });
         self.media_view.offset = media_view.start_frame + pan_frames;
-        Vec::new()
+        let Some((tool, frame)) = self.edit_tool.zip(clicked_frame) else {
+            return Vec::new();
+        };
+        let start_offset = details
+            .channels
+            .first()
+            .map(|channel| channel.start_offset)
+            .or_else(|| {
+                details
+                    .midi_channels
+                    .first()
+                    .map(|channel| channel.start_offset)
+            })
+            .unwrap_or(0);
+        let (start_offset, preplay_samples, loop_length) = match tool {
+            TimelineEditTool::LoopStart => (Some(frame), None, None),
+            TimelineEditTool::PreplayStart => (
+                None,
+                Some(u64::try_from(start_offset.saturating_sub(frame)).unwrap_or(0)),
+                None,
+            ),
+            TimelineEditTool::LoopEnd => (
+                None,
+                None,
+                Some(u64::try_from(frame.saturating_sub(start_offset)).unwrap_or(0)),
+            ),
+        };
+        vec![AppIntent::SetLoopTimeline {
+            loop_id: details.loop_id,
+            start_offset,
+            preplay_samples,
+            loop_length,
+        }]
     }
 }
 
@@ -227,22 +374,23 @@ mod tests {
                     data: Arc::from([0x90, 60, 100]),
                 }]),
                 start_offset: -20,
+                preplay_samples: 10,
                 loop_length: 150,
                 ..Default::default()
             }],
             ..Default::default()
         };
         let bounds = media_bounds(&details);
-        assert_eq!(bounds, (-20.0, 220.0));
+        assert_eq!(bounds, (-30.0, 220.0));
 
         let mut state = MediaViewState {
             zoom: 2.0,
-            offset: -20.0,
+            offset: -30.0,
         };
         let mut view = state.view(bounds);
-        assert_eq!((view.start_frame, view.end_frame), (-20.0, 100.0));
+        assert_eq!((view.start_frame, view.end_frame), (-30.0, 95.0));
         view.pan(-1_000.0, 100.0);
-        assert_eq!((view.start_frame, view.end_frame), (100.0, 220.0));
+        assert_eq!((view.start_frame, view.end_frame), (95.0, 220.0));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_egui/src/details_pane.rs
+++ b/src/rust/shoop_egui/src/details_pane.rs
@@ -165,6 +165,43 @@ fn media_bounds(details: &LoopDetailsState) -> (f64, f64) {
     (start, end.max(start + 1.0))
 }
 
+fn timeline_edit_intent(
+    details: &LoopDetailsState,
+    tool: TimelineEditTool,
+    frame: i64,
+) -> AppIntent {
+    let current_start = details
+        .channels
+        .first()
+        .map(|channel| channel.start_offset)
+        .or_else(|| {
+            details
+                .midi_channels
+                .first()
+                .map(|channel| channel.start_offset)
+        })
+        .unwrap_or(0);
+    let (start_offset, preplay_samples, loop_length) = match tool {
+        TimelineEditTool::LoopStart => (Some(frame), None, None),
+        TimelineEditTool::PreplayStart => (
+            None,
+            Some(u64::try_from(current_start.saturating_sub(frame)).unwrap_or(0)),
+            None,
+        ),
+        TimelineEditTool::LoopEnd => (
+            None,
+            None,
+            Some(u64::try_from(frame.saturating_sub(current_start)).unwrap_or(0)),
+        ),
+    };
+    AppIntent::SetLoopTimeline {
+        loop_id: details.loop_id,
+        start_offset,
+        preplay_samples,
+        loop_length,
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct DetailsPane {
     loop_id: LoopId,
@@ -279,36 +316,7 @@ impl DetailsPane {
         let Some((tool, frame)) = self.edit_tool.zip(clicked_frame) else {
             return Vec::new();
         };
-        let start_offset = details
-            .channels
-            .first()
-            .map(|channel| channel.start_offset)
-            .or_else(|| {
-                details
-                    .midi_channels
-                    .first()
-                    .map(|channel| channel.start_offset)
-            })
-            .unwrap_or(0);
-        let (start_offset, preplay_samples, loop_length) = match tool {
-            TimelineEditTool::LoopStart => (Some(frame), None, None),
-            TimelineEditTool::PreplayStart => (
-                None,
-                Some(u64::try_from(start_offset.saturating_sub(frame)).unwrap_or(0)),
-                None,
-            ),
-            TimelineEditTool::LoopEnd => (
-                None,
-                None,
-                Some(u64::try_from(frame.saturating_sub(start_offset)).unwrap_or(0)),
-            ),
-        };
-        vec![AppIntent::SetLoopTimeline {
-            loop_id: details.loop_id,
-            start_offset,
-            preplay_samples,
-            loop_length,
-        }]
+        vec![timeline_edit_intent(details, tool, frame)]
     }
 }
 
@@ -416,6 +424,7 @@ mod tests {
             loop_id: LoopId::from_raw(1),
             title: "MIDI only".to_owned(),
             midi_channels: vec![midi.clone()],
+            sync_loop_length: 4,
             ..Default::default()
         };
         let mut ignored_output_1 = context.run_ui(Default::default(), |ui| {
@@ -433,6 +442,7 @@ mod tests {
                 ..Default::default()
             }],
             midi_channels: vec![midi],
+            sync_loop_length: 4,
             ..Default::default()
         };
         let mut ignored_output_2 = context.run_ui(Default::default(), |ui| {
@@ -441,5 +451,53 @@ mod tests {
         ignored_output_2.textures_delta.clear();
         assert_eq!(pane.waveforms.len(), 1);
         assert_eq!(pane.midi_sequences.len(), 1);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn timeline_tools_create_bounded_loop_wide_edits() {
+        let details = LoopDetailsState {
+            loop_id: LoopId::from_raw(9),
+            channels: vec![WaveformChannelState {
+                start_offset: 20,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            timeline_edit_intent(&details, TimelineEditTool::LoopStart, -5),
+            AppIntent::SetLoopTimeline {
+                loop_id: details.loop_id,
+                start_offset: Some(-5),
+                preplay_samples: None,
+                loop_length: None,
+            }
+        );
+        assert_eq!(
+            timeline_edit_intent(&details, TimelineEditTool::PreplayStart, 8),
+            AppIntent::SetLoopTimeline {
+                loop_id: details.loop_id,
+                start_offset: None,
+                preplay_samples: Some(12),
+                loop_length: None,
+            }
+        );
+        assert_eq!(
+            timeline_edit_intent(&details, TimelineEditTool::LoopEnd, 52),
+            AppIntent::SetLoopTimeline {
+                loop_id: details.loop_id,
+                start_offset: None,
+                preplay_samples: None,
+                loop_length: Some(32),
+            }
+        );
+        assert_eq!(
+            timeline_edit_intent(&details, TimelineEditTool::LoopEnd, 10),
+            AppIntent::SetLoopTimeline {
+                loop_id: details.loop_id,
+                start_offset: None,
+                preplay_samples: None,
+                loop_length: Some(0),
+            }
+        );
     }
 }

--- a/src/rust/shoop_egui/src/midi_sequence_widget.rs
+++ b/src/rust/shoop_egui/src/midi_sequence_widget.rs
@@ -1,4 +1,8 @@
-use crate::{colors, MediaView, MidiEventState, MidiSequenceChannelState};
+use crate::{
+    colors,
+    details_pane::{paint_timeline_regions, MediaWidgetResponse},
+    MediaView, MidiEventState, MidiSequenceChannelState,
+};
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 
@@ -85,11 +89,13 @@ impl MidiSequenceWidget {
         ui: &mut egui::Ui,
         channel: &MidiSequenceChannelState,
         view: MediaView,
-    ) -> f64 {
+        sync_loop_length: u64,
+        editing: bool,
+    ) -> MediaWidgetResponse {
         self.update_notes(channel);
         let desired = egui::vec2(ui.available_width(), 96.0);
-        let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::drag());
-        let pan_frames = if response.dragged() {
+        let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::click_and_drag());
+        let pan_frames = if response.dragged() && !editing {
             let mut panned_view = view;
             panned_view.pan(response.drag_delta().x, rect.width());
             panned_view.start_frame - view.start_frame
@@ -105,24 +111,15 @@ impl MidiSequenceWidget {
             egui::StrokeKind::Inside,
         );
         let frame_to_x = |frame: f64| view.frame_to_x(frame, rect);
-
-        let loop_left = frame_to_x(channel.start_offset as f64).clamp(rect.left(), rect.right());
-        let loop_right = frame_to_x(
-            channel
-                .start_offset
-                .saturating_add_unsigned(channel.loop_length) as f64,
-        )
-        .clamp(rect.left(), rect.right());
-        if loop_right > loop_left {
-            painter.rect_filled(
-                egui::Rect::from_min_max(
-                    egui::pos2(loop_left, rect.top()),
-                    egui::pos2(loop_right, rect.bottom()),
-                ),
-                0.0,
-                colors::WAVEFORM_LOOP_REGION,
-            );
-        }
+        paint_timeline_regions(
+            &painter,
+            rect,
+            view,
+            channel.start_offset,
+            channel.preplay_samples,
+            channel.loop_length,
+            sync_loop_length,
+        );
 
         if self.notes.is_empty() {
             painter.text(
@@ -172,7 +169,14 @@ impl MidiSequenceWidget {
             rect.right_top() + egui::vec2(-6.0, 22.0),
         );
         ui.place(label_rect, egui::Label::new(&channel.label).truncate());
-        pan_frames
+        MediaWidgetResponse {
+            pan_frames,
+            clicked_frame: editing
+                .then(|| response.interact_pointer_pos())
+                .flatten()
+                .filter(|_| response.clicked())
+                .map(|position| view.x_to_frame(position.x, rect).round() as i64),
+        }
     }
 
     fn update_notes(&mut self, channel: &MidiSequenceChannelState) {
@@ -283,6 +287,8 @@ mod tests {
                     start_frame: 0.0,
                     end_frame: 16.0,
                 },
+                4,
+                false,
             );
             assert!(ui.next_widget_position().y >= top + 96.0);
         });
@@ -312,6 +318,8 @@ mod tests {
                         start_frame: 0.0,
                         end_frame: 16.0,
                     },
+                    4,
+                    false,
                 );
             });
             output.textures_delta.clear();

--- a/src/rust/shoop_egui/src/waveform_widget.rs
+++ b/src/rust/shoop_egui/src/waveform_widget.rs
@@ -1,4 +1,9 @@
-use crate::{colors, waveform::WaveformPyramid, MediaView, WaveformChannelState};
+use crate::{
+    colors,
+    details_pane::{paint_timeline_regions, MediaWidgetResponse},
+    waveform::WaveformPyramid,
+    MediaView, WaveformChannelState,
+};
 use std::sync::Arc;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -106,10 +111,12 @@ impl WaveformWidget {
         ui: &mut egui::Ui,
         channel: &WaveformChannelState,
         view: MediaView,
-    ) -> f64 {
+        sync_loop_length: u64,
+        editing: bool,
+    ) -> MediaWidgetResponse {
         let desired = egui::vec2(ui.available_width(), 72.0);
-        let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::drag());
-        let pan_frames = if response.dragged() {
+        let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::click_and_drag());
+        let pan_frames = if response.dragged() && !editing {
             let mut panned_view = view;
             panned_view.pan(response.drag_delta().x, rect.width());
             panned_view.start_frame - view.start_frame
@@ -129,6 +136,24 @@ impl WaveformWidget {
             rect.center().y,
             egui::Stroke::new(1.0, colors::WAVEFORM_ZERO_LINE),
         );
+        paint_timeline_regions(
+            &painter,
+            rect,
+            view,
+            channel.start_offset,
+            channel.preplay_samples,
+            channel.loop_length,
+            sync_loop_length,
+        );
+        let clicked_frame = editing
+            .then(|| response.interact_pointer_pos())
+            .flatten()
+            .filter(|_| response.clicked())
+            .map(|position| view.x_to_frame(position.x, rect).round() as i64);
+        let result = MediaWidgetResponse {
+            pan_frames,
+            clicked_frame,
+        };
         if channel.samples.is_empty() {
             painter.text(
                 rect.center(),
@@ -138,25 +163,10 @@ impl WaveformWidget {
                 colors::MUTED_FOREGROUND,
             );
             Self::show_label(ui, rect, &channel.label);
-            return pan_frames;
+            return result;
         }
 
         let sample_to_x = |sample: i64| view.frame_to_x(sample as f64, rect);
-        let loop_start = channel.start_offset;
-        let loop_end = loop_start.saturating_add_unsigned(channel.loop_length);
-        let left = sample_to_x(loop_start).clamp(rect.left(), rect.right());
-        let right = sample_to_x(loop_end).clamp(rect.left(), rect.right());
-        if right > left {
-            painter.rect_filled(
-                egui::Rect::from_min_max(
-                    egui::pos2(left, rect.top()),
-                    egui::pos2(right, rect.bottom()),
-                ),
-                0.0,
-                colors::WAVEFORM_LOOP_REGION,
-            );
-        }
-
         self.update_pyramid(ui.ctx(), &channel.samples);
         let Some(pyramid) = self
             .pyramid
@@ -171,7 +181,7 @@ impl WaveformWidget {
                 colors::MUTED_FOREGROUND,
             );
             Self::show_label(ui, rect, &channel.label);
-            return pan_frames;
+            return result;
         };
         let sample_start = view
             .start_frame
@@ -217,7 +227,7 @@ impl WaveformWidget {
             }
         }
         Self::show_label(ui, rect, &channel.label);
-        pan_frames
+        result
     }
 
     fn show_label(ui: &mut egui::Ui, rect: egui::Rect, label: &str) {
@@ -296,6 +306,8 @@ mod tests {
                     start_frame: 0.0,
                     end_frame: 16.0,
                 },
+                4,
+                false,
             );
             assert!(ui.next_widget_position().y >= top + 72.0);
         });

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -2610,6 +2610,115 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn waveform_timing_is_assembled_edited_and_replayed_without_losing_partial_updates() {
+        let (mut backend, control) = RemoteWorkletBackend::new(NullHostMidiBridge);
+        backend.midi_revision = 0;
+        let endpoint = MemoryEndpoint::default();
+        let sent = endpoint.sent.clone();
+        control.attach(Box::new(endpoint), 1, 0, 2).unwrap();
+        deliver(&control, 1, 1, Event::Ack);
+        let creation = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "timing".to_owned(),
+                audio_channels: 1,
+                midi: true,
+                initial_loops: 1,
+            })
+            .unwrap();
+        deliver(&control, 1, 2, Event::Ack);
+        let loop_id = creation.loops[0];
+
+        assert!(backend
+            .loop_audio_data_with_metadata(loop_id)
+            .unwrap()
+            .is_none());
+        deliver(
+            &control,
+            1,
+            3,
+            Event::Waveform(WaveformChunk {
+                loop_id: loop_id.raw(),
+                revision: 1,
+                channel: 0,
+                channel_count: 1,
+                offset: 0,
+                total_samples: 3,
+                start_offset: -4,
+                preplay: 6,
+                final_chunk: true,
+                samples: vec![0.25, -0.5, 0.75],
+            }),
+        );
+        backend.poll().unwrap();
+        let audio = backend
+            .loop_audio_data_with_metadata(loop_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(audio.channels[0].samples.as_ref(), [0.25, -0.5, 0.75]);
+        assert_eq!(audio.channels[0].start_offset, -4);
+        assert_eq!(audio.channels[0].preplay, 6);
+
+        backend.midi_data.insert(
+            loop_id,
+            MidiDataAssembly {
+                generation: 1,
+                channels: vec![BackendMidiChannelData {
+                    content_revision: 1,
+                    mode: BackendChannelMode::Direct,
+                    length: 16,
+                    events: Vec::new(),
+                    start_offset: -4,
+                    preplay: 6,
+                }],
+                next_channel: 1,
+                next_offset: 0,
+                complete: true,
+                in_flight: false,
+            },
+        );
+        backend
+            .set_loop_timing(loop_id, Some(-8), None, None)
+            .unwrap();
+        backend
+            .set_loop_timing(loop_id, None, Some(12), None)
+            .unwrap();
+        backend
+            .set_loop_timing(loop_id, None, None, Some(32))
+            .unwrap();
+        let audio = backend
+            .loop_audio_data_with_metadata(loop_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(audio.channels[0].start_offset, -8);
+        assert_eq!(audio.channels[0].preplay, 12);
+        let midi = &backend.midi_data[&loop_id].channels[0];
+        assert_eq!((midi.start_offset, midi.preplay, midi.length), (-8, 12, 32));
+
+        let commands_before_restart = sent.borrow().len();
+        control.detach(false);
+        let restarted = MemoryEndpoint::default();
+        let replayed = restarted.sent.clone();
+        control.attach(Box::new(restarted), 2, 0, 2).unwrap();
+        let commands = replayed
+            .borrow()
+            .iter()
+            .map(|message| {
+                serde_json::from_str::<CommandEnvelope>(message)
+                    .unwrap()
+                    .command
+            })
+            .collect::<Vec<_>>();
+        assert!(commands_before_restart >= 6);
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| matches!(command, Command::SetLoopTiming { .. }))
+                .count(),
+            3
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn rich_wire_snapshot_converts_every_remote_domain_shape() {
         use shoop_audio_protocol::{
             WireActiveCompositeChild, WireApplicationPort, WireApplicationPortOwner,

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -33,18 +33,18 @@ use shoop_audio_protocol::{
 };
 use shoop_backend::{
     encode_tiny_synth_fx_state, tiny_synth_fx_descriptor, Backend, BackendActiveCompositeChild,
-    BackendAsyncResult, BackendChannelMode, BackendCompositeConfig, BackendCompositeId,
-    BackendCompositeKind, BackendCompositeState, BackendCompositeTarget, BackendConfirmedLink,
-    BackendConnectionFailure, BackendDriverState, BackendGrabRequest, BackendHostPortDescriptor,
-    BackendLoopContentUpdate, BackendLoopId, BackendLoopMode, BackendLoopState,
-    BackendMidiChannelData, BackendMidiData, BackendMidiEvent, BackendMutationDetail,
-    BackendMutationFailure, BackendMutationKind, BackendOperationKind, BackendOperationProgress,
-    BackendPortDataType, BackendPortDescriptor, BackendPortDirection, BackendPortId,
-    BackendPortOwner, BackendPortRole, BackendSessionData, BackendSessionReplacement,
-    BackendSnapshot, BackendStatus, BackendTrackControl, BackendTrackCreation,
-    BackendTrackFxControl, BackendTrackId, BackendTrackState, BackendTrackTopology,
-    DirectTrackRequest, TinySynthFxControl, TinySynthFxMidiCcAssignment, TinySynthFxParameter,
-    TrackProcessorTypeId, TrackRequest,
+    BackendAsyncResult, BackendAudioChannelData, BackendAudioData, BackendChannelMode,
+    BackendCompositeConfig, BackendCompositeId, BackendCompositeKind, BackendCompositeState,
+    BackendCompositeTarget, BackendConfirmedLink, BackendConnectionFailure, BackendDriverState,
+    BackendGrabRequest, BackendHostPortDescriptor, BackendLoopContentUpdate, BackendLoopId,
+    BackendLoopMode, BackendLoopState, BackendMidiChannelData, BackendMidiData, BackendMidiEvent,
+    BackendMutationDetail, BackendMutationFailure, BackendMutationKind, BackendOperationKind,
+    BackendOperationProgress, BackendPortDataType, BackendPortDescriptor, BackendPortDirection,
+    BackendPortId, BackendPortOwner, BackendPortRole, BackendSessionData,
+    BackendSessionReplacement, BackendSnapshot, BackendStatus, BackendTrackControl,
+    BackendTrackCreation, BackendTrackFxControl, BackendTrackId, BackendTrackState,
+    BackendTrackTopology, DirectTrackRequest, TinySynthFxControl, TinySynthFxMidiCcAssignment,
+    TinySynthFxParameter, TrackProcessorTypeId, TrackRequest,
 };
 
 use crate::transport::{transport_pair, TransportCore};
@@ -52,6 +52,7 @@ use crate::transport::{transport_pair, TransportCore};
 struct WaveformAssembly {
     revision: u64,
     channels: Vec<Vec<f32>>,
+    timing: Vec<(i32, u32)>,
     next_channel: usize,
     next_offset: usize,
     complete: bool,
@@ -338,9 +339,13 @@ impl RemoteWorkletBackend {
         assembly.in_flight = false;
         if assembly.channels.len() < chunk.channel_count {
             assembly.channels.resize_with(chunk.channel_count, Vec::new);
+            assembly.timing.resize(chunk.channel_count, (0, 0));
         }
         if let Some(channel) = assembly.channels.get_mut(chunk.channel) {
             channel.extend_from_slice(&chunk.samples);
+        }
+        if let Some(timing) = assembly.timing.get_mut(chunk.channel) {
+            *timing = (chunk.start_offset, chunk.preplay);
         }
         if chunk.final_chunk {
             assembly.next_channel += 1;
@@ -1120,7 +1125,8 @@ fn command_mutation_identity(command: &Command) -> Option<(BackendMutationKind, 
         | Command::SetLoopSyncSource { loop_id, .. }
         | Command::TransitionLoop { loop_id, .. }
         | Command::ClearLoop { loop_id }
-        | Command::SetLoopLength { loop_id, .. } => {
+        | Command::SetLoopLength { loop_id, .. }
+        | Command::SetLoopTiming { loop_id, .. } => {
             (BackendMutationKind::LoopControl, Some(*loop_id))
         }
         Command::GrabLoops { requests } => (
@@ -1722,6 +1728,7 @@ impl Backend for RemoteWorkletBackend {
             WaveformAssembly {
                 revision: *revision,
                 channels: Vec::new(),
+                timing: Vec::new(),
                 next_channel: 0,
                 next_offset: 0,
                 complete: false,
@@ -1730,6 +1737,34 @@ impl Backend for RemoteWorkletBackend {
         );
         self.request_waveform_chunk(loop_id)?;
         Ok(None)
+    }
+
+    fn loop_audio_data_with_metadata(
+        &mut self,
+        loop_id: BackendLoopId,
+    ) -> Result<Option<BackendAudioData>> {
+        let Some(channels) = self.loop_audio_data(loop_id)? else {
+            return Ok(None);
+        };
+        let timing = &self
+            .waveforms
+            .get(&loop_id)
+            .ok_or_else(|| anyhow!("missing completed waveform assembly"))?
+            .timing;
+        Ok(Some(BackendAudioData {
+            channels: channels
+                .into_iter()
+                .enumerate()
+                .map(|(index, samples)| {
+                    let (start_offset, preplay) = timing.get(index).copied().unwrap_or_default();
+                    BackendAudioChannelData {
+                        samples,
+                        start_offset,
+                        preplay,
+                    }
+                })
+                .collect(),
+        }))
     }
 
     fn loop_midi_data(&mut self, loop_id: BackendLoopId) -> Result<Option<BackendMidiData>> {
@@ -1864,6 +1899,45 @@ impl Backend for RemoteWorkletBackend {
             loop_id: loop_id.raw(),
             length,
         })
+    }
+
+    fn set_loop_timing(
+        &mut self,
+        loop_id: BackendLoopId,
+        start_offset: Option<i32>,
+        preplay: Option<u32>,
+        length: Option<u32>,
+    ) -> Result<()> {
+        self.submit(Command::SetLoopTiming {
+            loop_id: loop_id.raw(),
+            start_offset,
+            preplay,
+            length,
+        })?;
+        if let Some(assembly) = self.waveforms.get_mut(&loop_id) {
+            for timing in &mut assembly.timing {
+                if let Some(offset) = start_offset {
+                    timing.0 = offset;
+                }
+                if let Some(samples) = preplay {
+                    timing.1 = samples;
+                }
+            }
+        }
+        if let Some(assembly) = self.midi_data.get_mut(&loop_id) {
+            for channel in &mut assembly.channels {
+                if let Some(offset) = start_offset {
+                    channel.start_offset = offset;
+                }
+                if let Some(samples) = preplay {
+                    channel.preplay = samples;
+                }
+                if let Some(length) = length {
+                    channel.length = length;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn capture_session(&mut self) -> Result<BackendSessionData> {


### PR DESCRIPTION
### Motivation
- Enable editing and propagation of loop timeline parameters (start offset, preplay samples and loop length) so UI edits update backend loop timing and are reflected in waveforms and MIDI detail views.

### Description
- Add a new intent `AppIntent::SetLoopTimeline` and handler `ApplicationModel::set_loop_timeline` that calls `Backend::set_loop_timing` and updates in-memory `LoopModel` fields.
- Extend backend API with `BackendAudioChannelData` and `BackendAudioData` types, `loop_audio_data_with_metadata` and `set_loop_timing`, and implement them for `EngineBackend`, `NativeBackend`, `FakeBackend`, `RemoteWorkletBackend` and `LocalDummyBackend`.
- Extend audio protocol with `Command::SetLoopTiming` and add timing fields (`start_offset`, `preplay`) to `WaveformChunk` and `MidiDataChunk` to carry timing metadata from audio worker.
- Update application state and view models to carry `preplay_samples` on `WaveformChannelState` and `MidiSequenceChannelState`, add `sync_loop_length` to `LoopDetailsState`, and introduce `TimelineEditTool` for selecting which timeline parameter to edit.
- UI changes in `shoop_egui`: paint preplay and sync marker regions, add clickable timeline edit tools in `DetailsPane`, and make `WaveformWidget`/`MidiSequenceWidget` return `MediaWidgetResponse` with click handling to construct `AppIntent::SetLoopTimeline` edits.
- Wire waveform assembly/timing propagation in `shoop_worklet_client` to retain start/preplay metadata for browser backends and update several call sites to use `loop_audio_data_with_metadata` and `BackendAudioData::default()` for empty audio.
- Update tests to assert timing metadata propagation and the edit flow (e.g. timeline editing via `AppIntent::SetLoopTimeline` and `set_loop_timing` behavior in fake/engine backends).

### Testing
- Ran crate unit tests and UI wasm tests covering updated modules including `shoop_backend`, `shoop_app`, `shoop_audio_protocol`, `shoop_egui` and `shoop_worklet_client` (including `shoop_wasm_test_support` tests); all automated tests completed successfully.
- Exercised backend timing functions with unit tests that call `set_loop_timing` and validated captured session data reflects updated `start_offset`, `preplay` and `length` (tests passed).
- Exercised UI timeline editing path in tests that dispatch `AppIntent::SetLoopTimeline` and verified the `LoopDetailsState` and MIDI/audio views updated accordingly (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87ff755594832892309f4d1675d883)