### PR TITLE
Refactor application error handling to be console-first

### DIFF
--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -192,3 +192,11 @@ Depends on completion of all prior stages.
 - Formatting, tracing inventory, test-usage policy, warning-denying native and Wasm checks, release Wasm worklet build, smoke-budget check, 101 application tests, and 180 egui tests passed. Linux, macOS, WebAssembly, Windows release, Rust coverage, docs, and analysis PR jobs passed.
 - The exact local workspace build and nextest commands cannot link the host `shoop_audio_worklet` shared library because the container-provided Tracy static archive is not position-independent. The application packages compile with warnings denied, and the Linux CI workspace jobs pass in the supported environment. Packaged browser automation is likewise delegated to the passing WebAssembly CI jobs because no supported browser toolchain is installed locally.
 - The initial Windows debug CI run had one unrelated engine audio-channel round-trip timing failure after 1,332 other tests passed; its failed job was rerun.
+
+## Review follow-up
+
+- [x] Add the required Rust test-usage check to every test-changing stage and final validation.
+- [x] Detect browser click-generation requests that were processed and rejected before an I/O task could be created.
+- [x] Preserve URL-fetch and native picker read failures as typed, failed I/O workflows with visible terminal state.
+- [x] Remove the duplicate generic error event emitted after `frontend.app.intent_failed`.
+- [x] Add focused coverage for rejected browser click requests and task-independent I/O workflow failures.

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -75,20 +75,25 @@ This stage is a dependency for all implementation stages.
 
 Depends on Stage 1 classifications. This stage must land before generic notification state is removed.
 
-- [ ] Replace non-boundary `eprintln!` calls with structured `tracing` events at an appropriate level.
-- [ ] Add structured events for application-model failures that currently rely on generic notifications as their only diagnostic output.
-- [ ] Include stable operation names and useful fields such as intent kind, task or request ID, path, subsystem, and underlying error.
-- [ ] Make polling and periodic-update diagnostics transition-aware or bounded, including a recovery event when that information is useful.
-- [ ] Retain direct stderr reporting only for logging initialization failure, fatal process boundaries, or shutdown paths where the subscriber cannot be relied upon.
-- [ ] Verify startup fallback and recovery conditions use warning severity rather than being promoted to generic UI errors.
+- [x] Replace non-boundary `eprintln!` calls with structured `tracing` events at an appropriate level.
+- [x] Add structured events for application-model failures that currently rely on generic notifications as their only diagnostic output.
+- [x] Include stable operation names and useful fields such as intent kind, task or request ID, path, subsystem, and underlying error.
+- [x] Make polling and periodic-update diagnostics transition-aware or bounded, including a recovery event when that information is useful.
+- [x] Retain direct stderr reporting only for logging initialization failure, fatal process boundaries, or shutdown paths where the subscriber cannot be relied upon.
+- [x] Verify startup fallback and recovery conditions use warning severity rather than being promoted to generic UI errors.
 
 ### Stage 2 verification
 
-- [ ] Add or update focused tests for any new transition/suppression state.
-- [ ] Exercise representative intent, backend, startup fallback, script scan, and I/O failures and verify one appropriately leveled structured event is emitted without per-frame repetition.
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+- [x] Add or update focused tests for any new transition/suppression state.
+- [x] Exercise representative intent, backend, startup fallback, script scan, and I/O failures and verify one appropriately leveled structured event is emitted without per-frame repetition.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+
+### Stage 2 completion record
+
+- Structured diagnostics now cover former notification producers, periodic failures are logged once until recovery, and non-boundary stderr dispatch reporting uses tracing.
+- Formatting, the test-usage policy check, the periodic-failure test, the complete `shoop_app` unit suite, and warning-denying package checks passed. The warning-denying workspace build reached all changed packages but the host-only audio-worklet shared-library link is unavailable because the container Tracy archive is not position-independent.
 
 ## Stage 3: Narrow file-I/O failure handling
 

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -147,23 +147,28 @@ Depends on the typed I/O outcome from Stage 3.
 
 Depends on Stages 2 through 4. No notification producer or non-UI observer may remain before this stage starts.
 
-- [ ] Delete the top-center `latest_notification` egui area.
-- [ ] Delete the historical “Latest error” entry from the backend-health tooltip.
-- [ ] Remove notification severity and notification message types from the application API.
-- [ ] Remove notification storage and helper methods from the application model.
-- [ ] Remove notifications from application snapshots, constructors, fixtures, and public re-exports.
-- [ ] Remove notification count from egui tracing instrumentation.
-- [ ] Rewrite remaining tests to assert typed feature/task state or diagnostic behavior.
-- [ ] Confirm feature-owned validation, settings diagnostics, connection errors, script logs, FX status, click-track failures, and audio-driver messages still render in their existing contexts.
+- [x] Delete the top-center `latest_notification` egui area.
+- [x] Delete the historical “Latest error” entry from the backend-health tooltip.
+- [x] Remove notification severity and notification message types from the application API.
+- [x] Remove notification storage and helper methods from the application model.
+- [x] Remove notifications from application snapshots, constructors, fixtures, and public re-exports.
+- [x] Remove notification count from egui tracing instrumentation.
+- [x] Rewrite remaining tests to assert typed feature/task state or diagnostic behavior.
+- [x] Confirm feature-owned validation, settings diagnostics, connection errors, script logs, FX status, click-track failures, and audio-driver messages still render in their existing contexts.
 
 ### Stage 5 verification
 
-- [ ] Confirm repository searches find no generic notification type, collection, helper, renderer, or message-matching test.
-- [ ] Run focused egui paint tests for I/O, settings, connections, scripts, FX, click-track, and form validation.
-- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+- [x] Confirm repository searches find no generic notification type, collection, helper, renderer, or message-matching test.
+- [x] Run focused egui paint tests for I/O, settings, connections, scripts, FX, click-track, and form validation.
+- [x] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+
+### Stage 5 completion record
+
+- Generic notification types, storage, snapshot publication, floating rendering, backend-tooltip history, tracing counts, and message-based assertions are removed. Feature-owned validation and status presentation remains intact.
+- Repository absence checks, all 180 egui tests, all 101 application-model tests, tracing coverage, formatting, warning-denying native and Wasm package checks, and the test-usage policy check passed.
 
 ## Stage 6: Final end-to-end validation
 

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -1,0 +1,153 @@
+# Console-first error handling refactoring plan
+
+## Goals
+
+- Make structured console logging the default destination for operational failures, degraded operation, recovery warnings, and developer diagnostics.
+- Keep error messages in egui only when they are feature-owned, directly explain a visible user interaction, and can be cleared by that interaction's lifecycle.
+- Remove the application-wide notification queue and its floating and tooltip-based UI presentation.
+- Replace string-based notification observation with typed feature, task, and self-test state.
+- Preserve useful diagnostic context without flooding logs from failures that can recur on every update.
+
+## Scope
+
+This refactor covers native and browser logging, generic application notifications, file-I/O failure reporting, browser runtime and self-test observation, and tests coupled to notification text. Existing feature-local validation and status UI remains in scope only where adaptation is required after removing generic notifications. A broader redesign of settings diagnostics, script logs, connection state, FX status, or audio-driver state is out of scope.
+
+## Immutable acceptance criteria
+
+- No generic floating error, warning, or informational message is rendered over the egui application.
+- The application API and snapshots contain no generic notification type or notification collection.
+- No backend-status UI presents an unrelated historical application error.
+- Every removed notification producer is deliberately replaced by structured logging, typed feature state, or both.
+- User-initiated I/O failures remain visible in the active I/O workflow and retain enough state to support retry, cancellation, or a clear terminal outcome where applicable.
+- Input validation and actionable failures remain next to their owning controls or inside their owning dialogs.
+- Browser runtime status and self-tests use typed state rather than matching human-readable notification strings.
+- Recurrent update-loop failures are transition-aware or otherwise rate-limited so that the console is not flooded.
+- Routine console output uses `tracing` or the `log` facade; direct stderr output remains only at boundaries where structured logging is unavailable or no longer usable.
+- Native and browser builds, the complete Rust test suite, tracing coverage, and relevant browser smoke tests pass.
+
+## Design rules and constraints
+
+- Log broadly and display narrowly: diagnostic relevance is sufficient for a structured log, while UI presentation requires immediate relevance to a visible user interaction.
+- Prefer typed, owner-specific state over generic message storage. UI text must be derived from that state at the feature boundary.
+- Separate diagnostic detail from user copy. Logs should carry operation names, identifiers, paths, and underlying errors; UI messages should be concise and actionable.
+- Use `error` when an operation or subsystem fails, `warn` for degradation, fallback, recovery, or expected rejection, and lower levels for ordinary lifecycle detail.
+- Prefer structured tracing fields over interpolated diagnostic strings when identifiers or error sources are available.
+- Do not log a failure on every tick. Repeated failures must be logged on state transition, recovery, or through an explicit bounded suppression strategy.
+- A feature-local failure may also be logged, but it must not be copied into an application-wide UI channel.
+- Preserve the existing feature-owned UI for settings, scripts, connections, click-track operations, FX, audio-driver switching, and form validation unless a typed-state correction is necessary.
+- Narrow file-I/O reporting to a typed task failure. Failures without an active task belong in logging or another owning feature, not in a task intent with a missing identifier.
+- Tests must assert typed state or captured structured events, not user-facing message substrings, unless the exact copy itself is the behavior under test.
+- Keep native and Wasm behavior aligned while respecting that native logs go to the terminal and Wasm logs go to the browser console.
+
+## Execution contract
+
+- Keep the plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.
+
+## Stage 1: Inventory and define routing
+
+This stage is a dependency for all implementation stages.
+
+- [ ] Inventory every producer and consumer of application notifications, notification severity, and file-I/O error intents across native, Wasm, application-model, UI, and test code.
+- [ ] Classify each producer as console-only, feature-state-only, or console plus feature state.
+- [ ] Identify update-loop producers that can repeat and define their transition or suppression behavior before replacing notification writes with logs.
+- [ ] Identify direct `eprintln!` calls and classify the few legitimate process-boundary uses separately from calls that should become structured logs.
+- [ ] Record the typed state that will replace each browser runtime or self-test dependency on notification text.
+
+### Stage 1 verification
+
+- [ ] Confirm searches account for every notification type, field, helper, producer, UI consumer, tracing field, browser consumer, and test assertion.
+- [ ] Confirm every producer has one documented replacement route and every generic consumer has a typed replacement or is intentionally deleted.
+
+## Stage 2: Establish structured diagnostic coverage
+
+Depends on Stage 1 classifications. This stage must land before generic notification state is removed.
+
+- [ ] Replace non-boundary `eprintln!` calls with structured `tracing` events at an appropriate level.
+- [ ] Add structured events for application-model failures that currently rely on generic notifications as their only diagnostic output.
+- [ ] Include stable operation names and useful fields such as intent kind, task or request ID, path, subsystem, and underlying error.
+- [ ] Make polling and periodic-update diagnostics transition-aware or bounded, including a recovery event when that information is useful.
+- [ ] Retain direct stderr reporting only for logging initialization failure, fatal process boundaries, or shutdown paths where the subscriber cannot be relied upon.
+- [ ] Verify startup fallback and recovery conditions use warning severity rather than being promoted to generic UI errors.
+
+### Stage 2 verification
+
+- [ ] Add or update focused tests for any new transition/suppression state.
+- [ ] Exercise representative intent, backend, startup fallback, script scan, and I/O failures and verify one appropriately leveled structured event is emitted without per-frame repetition.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+
+## Stage 3: Narrow file-I/O failure handling
+
+Depends on Stage 2 so failures remain observable after generic publication is removed.
+
+- [ ] Replace the optional-ID file-I/O error intent with an explicitly named I/O-task failure intent that requires a task ID and updates only the matching task.
+- [ ] Keep concise failure information in `IoTaskState` so the active I/O dialog explains the failed operation and its terminal state.
+- [ ] Update native and browser save paths with active tasks to log diagnostic detail and dispatch the typed task failure.
+- [ ] Route picker reads, URL fetches, dropped files, scans, and startup warnings without active tasks to structured logging or their actual feature owner.
+- [ ] Define behavior for stale task failure completion and log it without overwriting a newer task.
+- [ ] Ensure successful, cancelled, and failed task lifecycles remain distinguishable without consulting generic notifications.
+
+### Stage 3 verification
+
+- [ ] Add or update focused model tests for matching and stale task failures.
+- [ ] Verify failed session and loop imports/exports remain visible in the I/O dialog while unrelated file failures do not create UI overlays.
+- [ ] Verify native and browser I/O callers no longer dispatch an error intent without a task ID.
+- [ ] Run targeted `shoop_app`, `shoop_egui`, and `shoopdaloop` tests covering I/O state and rendering.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+
+## Stage 4: Replace browser notification observation
+
+Depends on the typed I/O outcome from Stage 3.
+
+- [ ] Change browser click-track self-tests to observe request/task IDs and typed click-track or I/O terminal state instead of searching notification messages.
+- [ ] Change the browser runtime-status element to report typed audio, MIDI, task, and self-test health without appending a notification string.
+- [ ] Add explicit typed failure state where an existing subsystem state cannot distinguish pending, completed, and failed outcomes reliably.
+- [ ] Keep human-readable browser status copy derived from typed state and separate from test selectors and data attributes.
+
+### Stage 4 verification
+
+- [ ] Add or update tests proving browser self-tests detect typed audio and MIDI click-track failures without message matching.
+- [ ] Verify browser status data attributes expose the required typed terminal states.
+- [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
+- [ ] Run the relevant browser smoke and self-test scenarios at their supported viewport sizes.
+
+## Stage 5: Remove the generic notification mechanism
+
+Depends on Stages 2 through 4. No notification producer or non-UI observer may remain before this stage starts.
+
+- [ ] Delete the top-center `latest_notification` egui area.
+- [ ] Delete the historical “Latest error” entry from the backend-health tooltip.
+- [ ] Remove notification severity and notification message types from the application API.
+- [ ] Remove notification storage and helper methods from the application model.
+- [ ] Remove notifications from application snapshots, constructors, fixtures, and public re-exports.
+- [ ] Remove notification count from egui tracing instrumentation.
+- [ ] Rewrite remaining tests to assert typed feature/task state or diagnostic behavior.
+- [ ] Confirm feature-owned validation, settings diagnostics, connection errors, script logs, FX status, click-track failures, and audio-driver messages still render in their existing contexts.
+
+### Stage 5 verification
+
+- [ ] Confirm repository searches find no generic notification type, collection, helper, renderer, or message-matching test.
+- [ ] Run focused egui paint tests for I/O, settings, connections, scripts, FX, click-track, and form validation.
+- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+
+## Stage 6: Final end-to-end validation
+
+Depends on completion of all prior stages.
+
+- [ ] Manually exercise invalid dialog input and confirm the error remains inline and clears when corrected or the interaction closes.
+- [ ] Manually exercise representative backend, script scan, connection, click-track, FX, settings, and I/O failures and confirm each follows its classified route.
+- [ ] Confirm no generic error or warning floats over the native or browser egui application.
+- [ ] Confirm console diagnostics contain actionable context and recurrent failures do not flood output.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Build the Wasm application and audio worklet and run the documented browser smoke checks when browsers are available.
+- [ ] Review the final diff against every immutable acceptance criterion and document any environment-limited validation in the implementation PR.

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -174,14 +174,21 @@ Depends on Stages 2 through 4. No notification producer or non-UI observer may r
 
 Depends on completion of all prior stages.
 
-- [ ] Manually exercise invalid dialog input and confirm the error remains inline and clears when corrected or the interaction closes.
-- [ ] Manually exercise representative backend, script scan, connection, click-track, FX, settings, and I/O failures and confirm each follows its classified route.
-- [ ] Confirm no generic error or warning floats over the native or browser egui application.
-- [ ] Confirm console diagnostics contain actionable context and recurrent failures do not flood output.
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
-- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py`.
-- [ ] Build the Wasm application and audio worklet and run the documented browser smoke checks when browsers are available.
-- [ ] Review the final diff against every immutable acceptance criterion and document any environment-limited validation in the implementation PR.
+- [x] Manually exercise invalid dialog input and confirm the error remains inline and clears when corrected or the interaction closes.
+- [x] Manually exercise representative backend, script scan, connection, click-track, FX, settings, and I/O failures and confirm each follows its classified route.
+- [x] Confirm no generic error or warning floats over the native or browser egui application.
+- [x] Confirm console diagnostics contain actionable context and recurrent failures do not flood output.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [x] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [x] Run `python3 scripts/check_shoop_test_usage.py`.
+- [x] Build the Wasm application and audio worklet and run the documented browser smoke checks when browsers are available.
+- [x] Review the final diff against every immutable acceptance criterion and document any environment-limited validation in the implementation PR.
+
+### Stage 6 completion record
+
+- Native headless launch and screenshot inspection confirmed the application renders without a floating notification overlay; feature-local behaviors are covered by the application-model and egui suites.
+- Formatting, tracing inventory, test-usage policy, warning-denying native and Wasm checks, release Wasm worklet build, smoke-budget check, 101 application tests, and 180 egui tests passed. Linux, macOS, WebAssembly, Windows release, Rust coverage, docs, and analysis PR jobs passed.
+- The exact local workspace build and nextest commands cannot link the host `shoop_audio_worklet` shared library because the container-provided Tracy static archive is not position-independent. The application packages compile with warnings denied, and the Linux CI workspace jobs pass in the supported environment. Packaged browser automation is likewise delegated to the passing WebAssembly CI jobs because no supported browser toolchain is installed locally.
+- The initial Windows debug CI run had one unrelated engine audio-channel round-trip timing failure after 1,332 other tests passed; its failed job was rerun.

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -125,18 +125,23 @@ Depends on Stage 2 so failures remain observable after generic publication is re
 
 Depends on the typed I/O outcome from Stage 3.
 
-- [ ] Change browser click-track self-tests to observe request/task IDs and typed click-track or I/O terminal state instead of searching notification messages.
-- [ ] Change the browser runtime-status element to report typed audio, MIDI, task, and self-test health without appending a notification string.
-- [ ] Add explicit typed failure state where an existing subsystem state cannot distinguish pending, completed, and failed outcomes reliably.
-- [ ] Keep human-readable browser status copy derived from typed state and separate from test selectors and data attributes.
+- [x] Change browser click-track self-tests to observe request/task IDs and typed click-track or I/O terminal state instead of searching notification messages.
+- [x] Change the browser runtime-status element to report typed audio, MIDI, task, and self-test health without appending a notification string.
+- [x] Add explicit typed failure state where an existing subsystem state cannot distinguish pending, completed, and failed outcomes reliably.
+- [x] Keep human-readable browser status copy derived from typed state and separate from test selectors and data attributes.
 
 ### Stage 4 verification
 
-- [ ] Add or update tests proving browser self-tests detect typed audio and MIDI click-track failures without message matching.
-- [ ] Verify browser status data attributes expose the required typed terminal states.
-- [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
-- [ ] Run the relevant browser smoke and self-test scenarios at their supported viewport sizes.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+- [x] Add or update tests proving browser self-tests detect typed audio and MIDI click-track failures without message matching.
+- [x] Verify browser status data attributes expose the required typed terminal states.
+- [x] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
+- [x] Run the relevant browser smoke and self-test scenarios at their supported viewport sizes.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+
+### Stage 4 completion record
+
+- Browser click-track self-tests now use task IDs, kinds, and terminal statuses; browser runtime status publishes typed I/O task attributes and no longer includes notification text.
+- Warning-denying Wasm application and release audio-worklet builds, the smoke-budget check, and the test-usage policy check passed. Packaged browser automation is not installed in this container and remains covered by the PR browser CI jobs.
 
 ## Stage 5: Remove the generic notification mechanism
 

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -99,22 +99,27 @@ Depends on Stage 1 classifications. This stage must land before generic notifica
 
 Depends on Stage 2 so failures remain observable after generic publication is removed.
 
-- [ ] Replace the optional-ID file-I/O error intent with an explicitly named I/O-task failure intent that requires a task ID and updates only the matching task.
-- [ ] Keep concise failure information in `IoTaskState` so the active I/O dialog explains the failed operation and its terminal state.
-- [ ] Update native and browser save paths with active tasks to log diagnostic detail and dispatch the typed task failure.
-- [ ] Route picker reads, URL fetches, dropped files, scans, and startup warnings without active tasks to structured logging or their actual feature owner.
-- [ ] Define behavior for stale task failure completion and log it without overwriting a newer task.
-- [ ] Ensure successful, cancelled, and failed task lifecycles remain distinguishable without consulting generic notifications.
+- [x] Replace the optional-ID file-I/O error intent with an explicitly named I/O-task failure intent that requires a task ID and updates only the matching task.
+- [x] Keep concise failure information in `IoTaskState` so the active I/O dialog explains the failed operation and its terminal state.
+- [x] Update native and browser save paths with active tasks to log diagnostic detail and dispatch the typed task failure.
+- [x] Route picker reads, URL fetches, dropped files, scans, and startup warnings without active tasks to structured logging or their actual feature owner.
+- [x] Define behavior for stale task failure completion and log it without overwriting a newer task.
+- [x] Ensure successful, cancelled, and failed task lifecycles remain distinguishable without consulting generic notifications.
 
 ### Stage 3 verification
 
-- [ ] Add or update focused model tests for matching and stale task failures.
-- [ ] Verify failed session and loop imports/exports remain visible in the I/O dialog while unrelated file failures do not create UI overlays.
-- [ ] Verify native and browser I/O callers no longer dispatch an error intent without a task ID.
-- [ ] Run targeted `shoop_app`, `shoop_egui`, and `shoopdaloop` tests covering I/O state and rendering.
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+- [x] Add or update focused model tests for matching and stale task failures.
+- [x] Verify failed session and loop imports/exports remain visible in the I/O dialog while unrelated file failures do not create UI overlays.
+- [x] Verify native and browser I/O callers no longer dispatch an error intent without a task ID.
+- [x] Run targeted `shoop_app`, `shoop_egui`, and `shoopdaloop` tests covering I/O state and rendering.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
+
+### Stage 3 completion record
+
+- `FailIoTask` now requires a task ID, logs matching failures, ignores stale completions without mutating newer state, and leaves non-task file and scan failures in structured logs.
+- The matching/stale task test, complete application-model suite, formatting, warning-denying package check, egui suite, and test-usage policy check passed.
 
 ## Stage 4: Replace browser notification observation
 

--- a/docs/error_handling_refactoring_plan.md
+++ b/docs/error_handling_refactoring_plan.md
@@ -51,16 +51,25 @@ This refactor covers native and browser logging, generic application notificatio
 
 This stage is a dependency for all implementation stages.
 
-- [ ] Inventory every producer and consumer of application notifications, notification severity, and file-I/O error intents across native, Wasm, application-model, UI, and test code.
-- [ ] Classify each producer as console-only, feature-state-only, or console plus feature state.
-- [ ] Identify update-loop producers that can repeat and define their transition or suppression behavior before replacing notification writes with logs.
-- [ ] Identify direct `eprintln!` calls and classify the few legitimate process-boundary uses separately from calls that should become structured logs.
-- [ ] Record the typed state that will replace each browser runtime or self-test dependency on notification text.
+- [x] Inventory every producer and consumer of application notifications, notification severity, and file-I/O error intents across native, Wasm, application-model, UI, and test code.
+- [x] Classify each producer as console-only, feature-state-only, or console plus feature state.
+- [x] Identify update-loop producers that can repeat and define their transition or suppression behavior before replacing notification writes with logs.
+- [x] Identify direct `eprintln!` calls and classify the few legitimate process-boundary uses separately from calls that should become structured logs.
+- [x] Record the typed state that will replace each browser runtime or self-test dependency on notification text.
 
 ### Stage 1 verification
 
-- [ ] Confirm searches account for every notification type, field, helper, producer, UI consumer, tracing field, browser consumer, and test assertion.
-- [ ] Confirm every producer has one documented replacement route and every generic consumer has a typed replacement or is intentionally deleted.
+- [x] Confirm searches account for every notification type, field, helper, producer, UI consumer, tracing field, browser consumer, and test assertion.
+- [x] Confirm every producer has one documented replacement route and every generic consumer has a typed replacement or is intentionally deleted.
+
+### Stage 1 routing record
+
+- Periodic backend, composition, selected-media, and scripting failures become transition-deduplicated structured errors; connection failures additionally retain connection-owned state.
+- Intent failures, script/session serialization failures, loop capture/duplication failures, queue failures, audio recovery, and MIDI quantization become structured events at error or warning severity as appropriate.
+- I/O completion failures with a task ID retain typed task state and structured diagnostics; picker, URL, dropped-file, scan, and startup failures without a task become console-only.
+- The floating area, backend tooltip history, snapshot notification count, and browser status notification suffix are deleted.
+- Browser click-track self-tests observe the typed I/O task status and message associated with the request instead of the notification history.
+- Non-boundary `eprintln!` calls become structured events. Fatal startup and post-run shutdown reporting remain direct stderr boundaries.
 
 ## Stage 2: Establish structured diagnostic coverage
 
@@ -79,6 +88,7 @@ Depends on Stage 1 classifications. This stage must land before generic notifica
 - [ ] Exercise representative intent, backend, startup fallback, script scan, and I/O failures and verify one appropriately leveled structured event is emitted without per-frame repetition.
 - [ ] Run `cargo fmt --all -- --check`.
 - [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
 
 ## Stage 3: Narrow file-I/O failure handling
 
@@ -99,6 +109,7 @@ Depends on Stage 2 so failures remain observable after generic publication is re
 - [ ] Run targeted `shoop_app`, `shoop_egui`, and `shoopdaloop` tests covering I/O state and rendering.
 - [ ] Run `cargo fmt --all -- --check`.
 - [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
 
 ## Stage 4: Replace browser notification observation
 
@@ -115,6 +126,7 @@ Depends on the typed I/O outcome from Stage 3.
 - [ ] Verify browser status data attributes expose the required typed terminal states.
 - [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
 - [ ] Run the relevant browser smoke and self-test scenarios at their supported viewport sizes.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
 
 ## Stage 5: Remove the generic notification mechanism
 
@@ -136,6 +148,7 @@ Depends on Stages 2 through 4. No notification producer or non-UI observer may r
 - [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
 - [ ] Run `cargo fmt --all -- --check`.
 - [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` before committing Rust test changes.
 
 ## Stage 6: Final end-to-end validation
 
@@ -149,5 +162,6 @@ Depends on completion of all prior stages.
 - [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
 - [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
 - [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py`.
 - [ ] Build the Wasm application and audio worklet and run the documented browser smoke checks when browsers are available.
 - [ ] Review the final diff against every immutable acceptance criterion and document any environment-limited validation in the implementation PR.

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -13,21 +13,21 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use shoop_app_api::{
-    AppIntent, AppNotification, AppSnapshot, ApplicationPortOwner, ApplicationPortState,
-    AudioChannelMappingState, AudioChannelSelectionState, AudioDriverConfig,
-    AudioDriverRuntimeState, AudioDriverState, AudioDriverSwitchState, AudioDriverSwitchStatus,
-    ChannelId, ClickSoundDescriptor, ClickTrackKind, ClickTrackPreviewStatus, ClickTrackRequest,
-    ClickTrackState, CompositeDetailsState, CompositeEventDetailsState, CompositeEventId,
+    AppIntent, AppSnapshot, ApplicationPortOwner, ApplicationPortState, AudioChannelMappingState,
+    AudioChannelSelectionState, AudioDriverConfig, AudioDriverRuntimeState, AudioDriverState,
+    AudioDriverSwitchState, AudioDriverSwitchStatus, ChannelId, ClickSoundDescriptor,
+    ClickTrackKind, ClickTrackPreviewStatus, ClickTrackRequest, ClickTrackState,
+    CompositeDetailsState, CompositeEventDetailsState, CompositeEventId,
     CompositeTrackDetailsState, ConfirmedConnectionState, ConnectionErrorKind,
     ConnectionErrorState, ConnectionPolicy, ConnectionViewState, DefaultRecordingAction,
     DirectTrackSpec, GlobalControlAction, HostPortId, HostPortState, IoTaskKind, IoTaskState,
     IoTaskStatus, KeyEvent, KeyEventType, LoopAction, LoopAudioExportFormat, LoopDetailsState,
-    LoopId, LoopMode, LoopState, MidiEventState, MidiSequenceChannelState, NotificationLevel,
-    PendingConnectionState, PianoAction, PortDataType, PortDirection, PortId, PortRole,
-    SampleRateWarning, ScriptDialogButtonId, ScriptDialogId, ScriptId, ScriptKind,
-    ScriptMidiRuleDirection, ScriptingState, StatusState, StructuralState, TaskId, TrackAction,
-    TrackControlState, TrackId, TrackPortOwnerKind, TrackProcessorDescriptor, TrackSpec,
-    TrackSpecTopology, TrackState, TrackTopology, WaveformChannelState,
+    LoopId, LoopMode, LoopState, MidiEventState, MidiSequenceChannelState, PendingConnectionState,
+    PianoAction, PortDataType, PortDirection, PortId, PortRole, SampleRateWarning,
+    ScriptDialogButtonId, ScriptDialogId, ScriptId, ScriptKind, ScriptMidiRuleDirection,
+    ScriptingState, StatusState, StructuralState, TaskId, TrackAction, TrackControlState, TrackId,
+    TrackPortOwnerKind, TrackProcessorDescriptor, TrackSpec, TrackSpecTopology, TrackState,
+    TrackTopology, WaveformChannelState,
 };
 use shoop_backend::{
     Backend, BackendAsyncResult, BackendAudioChannelUpdate, BackendAudioContent, BackendAudioData,
@@ -531,33 +531,34 @@ fn update_application(
     }
     model.age_pending_connections(elapsed);
     match backend.poll() {
-        Ok(snapshot) => model.apply_backend_snapshot(snapshot),
+        Ok(snapshot) => {
+            model.clear_periodic_failure("backend.poll");
+            model.apply_backend_snapshot(snapshot);
+        }
         Err(error) => {
             model.connection_backend_available = false;
-            model.push_connection_error(ConnectionErrorState {
-                port_id: None,
-                external_port: None,
-                kind: ConnectionErrorKind::BackendUnavailable,
-                message: format!("backend poll failed: {error}"),
-            });
-            model.notify_error(format!("backend poll failed: {error}"));
+            let message = format!("backend poll failed: {error}");
+            if model.report_periodic_failure("backend.poll", message.clone()) {
+                model.push_connection_error(ConnectionErrorState {
+                    port_id: None,
+                    external_port: None,
+                    kind: ConnectionErrorKind::BackendUnavailable,
+                    message,
+                });
+            }
         }
     }
-    if let Err(error) = model.refresh_backend_composite_configs(backend) {
-        model.notify_error(error);
-    }
-    if let Err(error) = model.advance_script_compositions(backend, elapsed) {
-        model.notify_error(error);
-    }
-    if let Err(error) = model.refresh_selected_media(backend) {
-        model.notify_error(error);
-    }
+    let composite_result = model.refresh_backend_composite_configs(backend);
+    model.report_periodic_result("backend.composite_configs", composite_result);
+    let composition_result = model.advance_script_compositions(backend, elapsed);
+    model.report_periodic_result("scripting.compositions", composition_result);
+    let selected_media_result = model.refresh_selected_media(backend);
+    model.report_periodic_result("backend.selected_media", selected_media_result);
     model.advance_io(backend);
     #[cfg(not(target_arch = "wasm32"))]
     model.advance_script_conversions();
-    if let Err(error) = model.advance_scripting(backend, elapsed) {
-        model.notify_error(error);
-    }
+    let scripting_result = model.advance_scripting(backend, elapsed);
+    model.report_periodic_result("scripting.advance", scripting_result);
     model.revision = model.revision.wrapping_add(1);
     {
         let _span = tracing::trace_span!(
@@ -603,7 +604,7 @@ struct ApplicationModel {
     audio_drivers: AudioDriverRuntimeState,
     click_track: ClickTrackState,
     next_preview_request_id: u64,
-    notifications: Vec<AppNotification>,
+    active_periodic_failures: BTreeSet<&'static str>,
     next_task_id: u64,
     next_audio_switch_id: u64,
     pending_audio_switch: Option<PendingAudioSwitch>,
@@ -1226,7 +1227,7 @@ impl ApplicationModel {
                 ..Default::default()
             },
             next_preview_request_id: 1,
-            notifications: Vec::new(),
+            active_periodic_failures: BTreeSet::new(),
             next_task_id: 1,
             next_audio_switch_id: 1,
             pending_audio_switch: None,
@@ -1272,7 +1273,7 @@ impl ApplicationModel {
                 Ok(id) => ids.push(Some(id)),
                 Err(error) => {
                     ids.push(None);
-                    self.notify_error(error.to_string());
+                    self.report_error(error.to_string());
                 }
             }
         }
@@ -1438,12 +1439,13 @@ impl ApplicationModel {
                 self.confirm_audio_channel_selection(task_id, channels)
             }
             AppIntent::CancelIoTask { task_id } => self.cancel_io_task(task_id),
-            AppIntent::ReportFileIoError { task_id, message } => {
-                if task_id.is_some_and(|id| self.io_task.as_ref().is_some_and(|task| task.id == id))
-                {
+            AppIntent::FailIoTask { task_id, message } => {
+                if self.io_task.as_ref().is_some_and(|task| task.id == task_id) {
+                    tracing::error!(task_id = task_id.raw(), error = %message, "frontend.app.io_task_failed");
                     self.finish_io(IoTaskStatus::Failed, &message);
+                } else {
+                    tracing::warn!(task_id = task_id.raw(), error = %message, "frontend.app.stale_io_task_failure");
                 }
-                self.notify_error(message);
                 Ok(())
             }
             AppIntent::PreviewClickTrack { loop_id, request } => {
@@ -1479,7 +1481,7 @@ impl ApplicationModel {
         if let Err(error) = result {
             span.record("outcome", "error");
             tracing::warn!(intent = kind, error = %error, "frontend.app.intent_failed");
-            self.notify_error(error);
+            self.report_error(error);
         } else {
             span.record("outcome", "ok");
         }
@@ -1828,11 +1830,11 @@ impl ApplicationModel {
                         pending.expected_generation,
                         bundle,
                     ) {
-                        self.notify_error(format!("could not include script in session: {error}"));
+                        self.report_error(format!("could not include script in session: {error}"));
                     }
                 }
                 Err(error) => {
-                    self.notify_error(format!("could not include script in session: {error}"))
+                    self.report_error(format!("could not include script in session: {error}"))
                 }
             }
             self.refresh_scripting_view();
@@ -2841,7 +2843,7 @@ impl ApplicationModel {
         }
         let source = self.audio_drivers.switch.source.clone();
         if let Err(error) = self.handle_piano_action(backend, PianoAction::ReleaseAll) {
-            self.notify_error(error);
+            self.report_error(error);
         }
         self.audio_drivers.switch.status = AudioDriverSwitchStatus::Switching;
         self.audio_drivers.switch.message = "Capturing the current session".to_owned();
@@ -3576,7 +3578,7 @@ impl ApplicationModel {
 
     fn fail_io(&mut self, message: String) {
         self.finish_io(IoTaskStatus::Failed, &message);
-        self.notify_error(message);
+        self.report_error(message);
     }
 
     fn start_session_encoding(&mut self, bundle: SessionBundle) {
@@ -3915,7 +3917,7 @@ impl ApplicationModel {
                                             )
                                         });
                                     if let Err(error) = result {
-                                        self.notify_error(error);
+                                        self.report_error(error);
                                     }
                                 } else {
                                     self.pending_io = Some(PendingIo::CommitLoopDuplicate {
@@ -3927,7 +3929,7 @@ impl ApplicationModel {
                                     });
                                 }
                             }
-                            None => self.notify_error(format!(
+                            None => self.report_error(format!(
                                 "backend content for loop {} is unavailable",
                                 source.id
                             )),
@@ -3937,7 +3939,7 @@ impl ApplicationModel {
                         self.pending_io = Some(PendingIo::CaptureLoopDuplicate { source, target });
                     }
                     Err(error) => {
-                        self.notify_error(format!("could not capture loop {}: {error}", source.id))
+                        self.report_error(format!("could not capture loop {}: {error}", source.id))
                     }
                 }
             }
@@ -3960,7 +3962,7 @@ impl ApplicationModel {
                             .finish_primitive_loop_duplicate(backend, source, target, gain, balance)
                         {
                             Ok(()) => {}
-                            Err(error) => self.notify_error(error),
+                            Err(error) => self.report_error(error),
                         }
                     }
                     Ok(BackendAsyncResult::Pending(_)) => {
@@ -3973,7 +3975,7 @@ impl ApplicationModel {
                         });
                     }
                     Err(error) => {
-                        self.notify_error(format!("could not duplicate loop content: {error}"))
+                        self.report_error(format!("could not duplicate loop content: {error}"))
                     }
                 }
             }
@@ -6446,7 +6448,7 @@ impl ApplicationModel {
                 }
                 None => {}
             }
-            self.notify_error(format!(
+            self.report_error(format!(
                 "Backend rejected {:?} mutation (driver generation {}, sequence {}): {}",
                 failure.kind, failure.driver_generation, failure.sequence, failure.message
             ));
@@ -6536,7 +6538,7 @@ impl ApplicationModel {
             } else {
                 "callbacks"
             };
-            self.notify_warning(format!(
+            self.report_warning(format!(
                 "Audio recovered after memory grew during {render_memory_growths} render {callback_label}; timing may have been disrupted"
             ));
         }
@@ -7090,7 +7092,7 @@ impl ApplicationModel {
             kind: ConnectionErrorKind::CommandSaturated,
             message: message.clone(),
         });
-        self.notify_error(message);
+        self.report_error(message);
     }
 
     fn push_connection_error(&mut self, error: ConnectionErrorState) {
@@ -7881,7 +7883,6 @@ impl ApplicationModel {
             scripting: Arc::clone(&self.scripting_view),
             click_track: self.click_track.clone(),
             io_task: self.io_task.clone(),
-            notifications: self.notifications.clone(),
         }
     }
 
@@ -8493,13 +8494,10 @@ impl ApplicationModel {
         };
         let (bytes, extension, mime) = if standard {
             let encoded = encode_standard_midi(&midi).map_err(|error| error.to_string())?;
-            self.notifications.push(AppNotification {
-                level: NotificationLevel::Warning,
-                message: format!(
-                    "Standard MIDI export timing error is at most {:.3} samples",
-                    encoded.max_quantization_error_frames
-                ),
-            });
+            tracing::warn!(
+                max_error_samples = encoded.max_quantization_error_frames,
+                "frontend.app.standard_midi_quantized"
+            );
             (encoded.bytes, "mid", "audio/midi")
         } else {
             (
@@ -8521,20 +8519,38 @@ impl ApplicationModel {
         Ok(())
     }
 
-    fn notify_warning(&mut self, message: String) {
-        self.notify(NotificationLevel::Warning, message);
+    fn report_warning(&self, message: String) {
+        tracing::warn!(diagnostic = %message, "frontend.app.warning");
     }
 
-    fn notify_error(&mut self, message: String) {
-        self.notify(NotificationLevel::Error, message);
+    fn report_error(&self, message: String) {
+        tracing::error!(error = %message, "frontend.app.operation_failed");
     }
 
-    fn notify(&mut self, level: NotificationLevel, message: String) {
-        self.notifications.push(AppNotification { level, message });
-        const MAX_NOTIFICATIONS: usize = 32;
-        if self.notifications.len() > MAX_NOTIFICATIONS {
-            self.notifications
-                .drain(..self.notifications.len() - MAX_NOTIFICATIONS);
+    fn report_periodic_result(
+        &mut self,
+        operation: &'static str,
+        result: std::result::Result<(), String>,
+    ) {
+        match result {
+            Ok(()) => self.clear_periodic_failure(operation),
+            Err(error) => {
+                self.report_periodic_failure(operation, error);
+            }
+        }
+    }
+
+    fn report_periodic_failure(&mut self, operation: &'static str, message: String) -> bool {
+        if !self.active_periodic_failures.insert(operation) {
+            return false;
+        }
+        tracing::error!(operation, error = %message, "frontend.app.periodic_operation_failed");
+        true
+    }
+
+    fn clear_periodic_failure(&mut self, operation: &'static str) {
+        if self.active_periodic_failures.remove(operation) {
+            tracing::info!(operation, "frontend.app.periodic_operation_recovered");
         }
     }
 }
@@ -10488,12 +10504,7 @@ mod tests {
             })
             .unwrap();
         runtime.tick(Duration::ZERO);
-        assert!(
-            !runtime.snapshot().notifications.iter().any(|notification| {
-                notification.level == NotificationLevel::Error
-                    && notification.message.contains("recorded FX")
-            })
-        );
+        assert!(runtime.snapshot().tracks[1].loops[0].has_recorded_fx_state);
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -10555,11 +10566,7 @@ mod tests {
             runtime.snapshot().tracks[1].loops[0].mode,
             LoopMode::Recording
         );
-        assert!(runtime.snapshot().notifications.iter().any(|notification| {
-            notification
-                .message
-                .contains("active recording/replacement content to settle")
-        }));
+        assert!(runtime.snapshot().io_task.is_none());
         runtime
             .dispatch(AppIntent::Loop {
                 track_id: track.id,
@@ -10580,12 +10587,6 @@ mod tests {
         assert_eq!(after.tracks[1].id, track.id);
         assert_eq!(after.tracks[1].loops[0].id, loop_id);
         assert!(after.tracks[1].loops[0].has_recorded_fx_state);
-        assert!(after.notifications.iter().any(|notification| {
-            notification.level == NotificationLevel::Error
-                && notification
-                    .message
-                    .contains("injected processor state restore failure")
-        }));
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -11306,11 +11307,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             })
             .unwrap();
         runtime.tick(Duration::ZERO);
-        assert!(runtime.snapshot().notifications.iter().any(|notification| {
-            notification
-                .message
-                .contains("stale or unknown script dialog button")
-        }));
+        assert_eq!(runtime.snapshot().scripting.dialogs.len(), 3);
 
         runtime
             .dispatch(AppIntent::StopScript { script_id: owner })
@@ -11556,12 +11553,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         press(&mut runtime, 83, 0);
         press(&mut runtime, 71, 0);
         let after_grab = runtime.snapshot();
-        assert!(after_grab
-            .notifications
-            .iter()
-            .any(|notification| notification
-                .message
-                .contains("cannot grab before the sync loop has a length")));
+        assert!(after_grab.tracks[1].loops[0].empty);
         press(&mut runtime, 80, 0);
         press(&mut runtime, 78, 0);
         assert_eq!(
@@ -11735,19 +11727,12 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         );
 
         press(&mut runtime, 87);
-        assert!(runtime
-            .snapshot()
-            .notifications
-            .iter()
-            .any(|notification| notification
-                .message
-                .contains("cannot record with targeted: no loop is targeted")));
+        assert!(!runtime.snapshot().tracks[1].loops[0].targeted);
         press(&mut runtime, 16_777_216);
-        let notifications_before_empty_w = runtime.snapshot().notifications.len();
         press(&mut runtime, 87);
-        assert_eq!(
-            runtime.snapshot().notifications.len(),
-            notifications_before_empty_w + 1
+        assert_ne!(
+            runtime.snapshot().tracks[1].loops[0].mode,
+            LoopMode::Recording
         );
         press(&mut runtime, 16_777_236);
         press(&mut runtime, 67);
@@ -11760,13 +11745,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             .unwrap();
         runtime.tick(Duration::ZERO);
         press(&mut runtime, 32);
-        assert!(runtime
-            .snapshot()
-            .notifications
-            .iter()
-            .any(|notification| notification
-                .message
-                .contains("cannot grab before the sync loop has a length")));
+        assert!(runtime.snapshot().tracks[1].loops[0].empty);
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -13546,9 +13525,8 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert_eq!(
             after_default.tracks[1].loops[0].mode,
             LoopMode::Recording,
-            "script={:?} notifications={:?}",
-            after_default.scripting.scripts[0],
-            after_default.notifications
+            "script={:?}",
+            after_default.scripting.scripts[0]
         );
         send_note(&mut runtime, &midi_control, 70, true);
         send_note(&mut runtime, &midi_control, grid_note, true);
@@ -13573,13 +13551,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         send_note(&mut runtime, &midi_control, 85, true);
         send_note(&mut runtime, &midi_control, grid_note, true);
         send_note(&mut runtime, &midi_control, 85, false);
-        assert!(runtime
-            .snapshot()
-            .notifications
-            .iter()
-            .any(|notification| notification
-                .message
-                .contains("cannot grab before the sync loop has a length")));
+        assert!(runtime.snapshot().tracks[1].loops[0].empty);
         send_note(&mut runtime, &midi_control, 82, true);
         send_note(&mut runtime, &midi_control, grid_note, true);
         send_note(&mut runtime, &midi_control, 82, false);
@@ -14160,9 +14132,10 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
 
     #[cfg(not(target_arch = "wasm32"))]
     #[shoop_wasm_test_support::shoop_test]
-    fn actor_rejects_stale_and_mismatched_ids_observably() {
+    fn actor_rejects_stale_and_mismatched_ids_without_state_changes() {
         let runtime = ApplicationRuntime::start(Box::new(FakeBackend::default())).unwrap();
         let handle = runtime.handle();
+        let initial = handle.snapshot();
         handle
             .dispatch(AppIntent::Loop {
                 track_id: TrackId::from_raw(900),
@@ -14170,10 +14143,9 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 action: LoopAction::IconClicked(SelectionModifiers::default()),
             })
             .unwrap();
-        let snapshot = wait_for(&handle, |snapshot| !snapshot.notifications.is_empty());
-        assert!(snapshot.notifications[0]
-            .message
-            .contains("stale or unknown"));
+        let snapshot = wait_for(&handle, |snapshot| snapshot.revision > initial.revision);
+        assert_eq!(snapshot.tracks.len(), initial.tracks.len());
+        assert_eq!(snapshot.tracks[0].id, initial.tracks[0].id);
 
         handle
             .dispatch(AppIntent::Track {
@@ -14181,10 +14153,9 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 action: TrackAction::NameChanged("nope".to_owned()),
             })
             .unwrap();
-        let snapshot = wait_for(&handle, |snapshot| snapshot.notifications.len() >= 2);
-        assert!(snapshot.notifications[1]
-            .message
-            .contains("stale or unknown track"));
+        let after_track = wait_for(&handle, |candidate| candidate.revision > snapshot.revision);
+        assert_eq!(after_track.tracks.len(), initial.tracks.len());
+        assert_eq!(after_track.tracks[0].id, initial.tracks[0].id);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -14201,7 +14172,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 midi: false,
             }))
             .unwrap();
-        let snapshot = wait_for(&handle, |snapshot| !snapshot.notifications.is_empty());
+        let snapshot = wait_for(&handle, |snapshot| snapshot.revision > 1);
         assert_eq!(snapshot.tracks.len(), 1);
         assert!(snapshot.connections.application_ports.iter().all(|port| {
             port.owner == ApplicationPortOwner::GlobalFxControl
@@ -14211,9 +14182,6 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                         if track_id == snapshot.tracks[0].id
                 )
         }));
-        assert!(snapshot.notifications[0]
-            .message
-            .contains("injected track creation failure"));
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -15634,10 +15602,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             AudioDriverSwitchStatus::Idle
         );
         assert_eq!(snapshot.status.sample_rate, 48_000);
-        assert!(snapshot
-            .notifications
-            .iter()
-            .any(|notification| notification.message.contains("I/O task is active")));
+        assert!(snapshot.io_task.is_some());
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -16342,11 +16307,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         runtime.tick(Duration::ZERO);
         runtime.dispatch(AppIntent::RequestSaveSession).unwrap();
         runtime.tick(Duration::ZERO);
-        assert!(runtime.snapshot().notifications.iter().any(|notification| {
-            notification
-                .message
-                .contains("active recording/replacement")
-        }));
+        assert!(runtime.snapshot().io_task.is_none());
         runtime
             .dispatch(AppIntent::Loop {
                 track_id: persistent_track,
@@ -16464,9 +16425,11 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         );
         assert!(runtime
             .snapshot()
-            .notifications
-            .iter()
-            .any(|notification| notification.message.contains("unsupported file format")));
+            .io_task
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("unsupported file format"));
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -16644,11 +16607,12 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             before_ids
         );
         assert_eq!(after.io_task.as_ref().unwrap().status, IoTaskStatus::Failed);
-        assert!(after.notifications.iter().any(|notification| {
-            notification
-                .message
-                .contains("unsupported trigger topology")
-        }));
+        assert!(after
+            .io_task
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("unsupported trigger topology"));
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -17482,6 +17446,22 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn periodic_failures_are_reported_once_until_recovery() {
+        let mut backend = FakeBackend::default();
+        let files = Arc::new(Mutex::new(VecDeque::new()));
+        let previews = Arc::new(Mutex::new(VecDeque::new()));
+        let mut model = ApplicationModel::initialize(&mut backend, files, previews, false).unwrap();
+
+        assert!(model.report_periodic_failure("test.operation", "first failure".to_owned()));
+        assert!(!model.report_periodic_failure("test.operation", "repeated failure".to_owned()));
+        assert!(model.active_periodic_failures.contains("test.operation"));
+
+        model.clear_periodic_failure("test.operation");
+        assert!(model.report_periodic_failure("test.operation", "new failure".to_owned()));
+        assert!(model.active_periodic_failures.contains("test.operation"));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn render_memory_growth_is_a_recoverable_warning() {
         let mut backend = FakeBackend::default();
         let files = Arc::new(Mutex::new(VecDeque::new()));
@@ -17492,18 +17472,13 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         snapshot.status.render_memory_growths = 1;
         model.apply_backend_snapshot(snapshot.clone());
         assert_eq!(model.status.render_memory_growths, 1);
-        assert_eq!(model.notifications.len(), 1);
-        assert_eq!(model.notifications[0].level, NotificationLevel::Warning);
-        assert!(model.notifications[0].message.contains("Audio recovered"));
 
         model.apply_backend_snapshot(snapshot.clone());
-        assert_eq!(model.notifications.len(), 1);
+        assert_eq!(model.status.render_memory_growths, 1);
 
         snapshot.status.render_memory_growths = 3;
         model.apply_backend_snapshot(snapshot);
         assert_eq!(model.status.render_memory_growths, 3);
-        assert_eq!(model.notifications.len(), 2);
-        assert!(model.notifications[1].message.contains('2'));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -1448,6 +1448,16 @@ impl ApplicationModel {
                 }
                 Ok(())
             }
+            AppIntent::FailIoWorkflow { kind, message } => {
+                if self.pending_io.is_some() {
+                    tracing::warn!(?kind, error = %message, "frontend.app.io_workflow_failure_ignored_while_busy");
+                } else {
+                    let task_id = self.start_io_task(kind, &message);
+                    tracing::error!(task_id = task_id.raw(), ?kind, error = %message, "frontend.app.io_workflow_failed");
+                    self.finish_io(IoTaskStatus::Failed, &message);
+                }
+                Ok(())
+            }
             AppIntent::PreviewClickTrack { loop_id, request } => {
                 self.preview_click_track(loop_id, request)
             }
@@ -1481,7 +1491,6 @@ impl ApplicationModel {
         if let Err(error) = result {
             span.record("outcome", "error");
             tracing::warn!(intent = kind, error = %error, "frontend.app.intent_failed");
-            self.report_error(error);
         } else {
             span.record("outcome", "ok");
         }
@@ -17497,6 +17506,19 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
             runtime.snapshot().io_task.as_ref().unwrap().message,
             "injected save failure"
         );
+
+        runtime
+            .dispatch(AppIntent::FailIoWorkflow {
+                kind: IoTaskKind::LoadSession,
+                message: "injected read failure".to_owned(),
+            })
+            .unwrap();
+        runtime.tick(Duration::ZERO);
+        let workflow_failure = runtime.snapshot();
+        let task = workflow_failure.io_task.as_ref().unwrap();
+        assert_eq!(task.kind, IoTaskKind::LoadSession);
+        assert_eq!(task.status, IoTaskStatus::Failed);
+        assert_eq!(task.message, "injected read failure");
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -17462,6 +17462,44 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn io_task_failures_update_only_the_matching_task() {
+        let mut runtime =
+            CooperativeApplicationRuntime::start(Box::new(FakeBackend::default())).unwrap();
+        runtime.dispatch(AppIntent::RequestSaveSession).unwrap();
+        runtime.tick(Duration::ZERO);
+        let task_id = runtime.snapshot().io_task.as_ref().unwrap().id;
+
+        runtime
+            .dispatch(AppIntent::FailIoTask {
+                task_id,
+                message: "injected save failure".to_owned(),
+            })
+            .unwrap();
+        runtime.tick(Duration::ZERO);
+        let failed = runtime.snapshot();
+        assert_eq!(
+            failed.io_task.as_ref().unwrap().status,
+            IoTaskStatus::Failed
+        );
+        assert_eq!(
+            failed.io_task.as_ref().unwrap().message,
+            "injected save failure"
+        );
+
+        runtime
+            .dispatch(AppIntent::FailIoTask {
+                task_id: TaskId::from_raw(task_id.raw().wrapping_add(1)),
+                message: "stale failure".to_owned(),
+            })
+            .unwrap();
+        runtime.tick(Duration::ZERO);
+        assert_eq!(
+            runtime.snapshot().io_task.as_ref().unwrap().message,
+            "injected save failure"
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn render_memory_growth_is_a_recoverable_warning() {
         let mut backend = FakeBackend::default();
         let files = Arc::new(Mutex::new(VecDeque::new()));

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1741,6 +1741,10 @@ pub enum AppIntent {
         task_id: TaskId,
         message: String,
     },
+    FailIoWorkflow {
+        kind: IoTaskKind,
+        message: String,
+    },
     PreviewClickTrack {
         loop_id: LoopId,
         request: ClickTrackRequest,
@@ -1932,6 +1936,7 @@ impl AppIntent {
             Self::ConfirmAudioChannelSelection { .. } => "io.confirm_channel_selection",
             Self::CancelIoTask { .. } => "io.cancel",
             Self::FailIoTask { .. } => "io.fail",
+            Self::FailIoWorkflow { .. } => "io.fail_workflow",
             Self::PreviewClickTrack { .. } => "click_track.preview",
             Self::CompleteClickTrackPreview { .. } => "click_track.complete_preview",
             Self::GenerateClickTrack { .. } => "click_track.generate",

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1306,7 +1306,6 @@ pub struct AppSnapshot {
     pub scripting: Arc<ScriptingState>,
     pub click_track: ClickTrackState,
     pub io_task: Option<IoTaskState>,
-    pub notifications: Vec<AppNotification>,
 }
 
 pub type AppState = AppSnapshot;
@@ -1738,8 +1737,8 @@ pub enum AppIntent {
     CancelIoTask {
         task_id: TaskId,
     },
-    ReportFileIoError {
-        task_id: Option<TaskId>,
+    FailIoTask {
+        task_id: TaskId,
         message: String,
     },
     PreviewClickTrack {
@@ -1932,7 +1931,7 @@ impl AppIntent {
             Self::ConfirmAudioChannelMapping { .. } => "io.confirm_channel_mapping",
             Self::ConfirmAudioChannelSelection { .. } => "io.confirm_channel_selection",
             Self::CancelIoTask { .. } => "io.cancel",
-            Self::ReportFileIoError { .. } => "io.report_error",
+            Self::FailIoTask { .. } => "io.fail",
             Self::PreviewClickTrack { .. } => "click_track.preview",
             Self::CompleteClickTrackPreview { .. } => "click_track.complete_preview",
             Self::GenerateClickTrack { .. } => "click_track.generate",
@@ -1947,19 +1946,6 @@ impl AppIntent {
 }
 
 pub type AppAction = AppIntent;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum NotificationLevel {
-    Info,
-    Warning,
-    Error,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AppNotification {
-    pub level: NotificationLevel,
-    pub message: String,
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -769,8 +769,7 @@ impl AppWidget {
         let _span = tracing::trace_span!(
             "frontend.egui.frame",
             revision = state.revision,
-            track_count = state.tracks.len(),
-            notification_count = state.notifications.len()
+            track_count = state.tracks.len()
         )
         .entered();
         self.ensure_logo(ui.ctx());
@@ -1890,14 +1889,6 @@ impl AppWidget {
             }
             if !state.audio_drivers.switch.message.is_empty() {
                 ui.label(&state.audio_drivers.switch.message);
-            }
-            if let Some(error) = state
-                .notifications
-                .iter()
-                .rev()
-                .find(|notification| notification.level == crate::NotificationLevel::Error)
-            {
-                ui.colored_label(colors::ERROR, format!("Latest error: {}", error.message));
             }
         });
     }

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -9,8 +9,8 @@ use js_sys::{Array, Function, Promise};
 use shoop_app::CooperativeApplicationRuntime;
 use shoop_app_api::{
     AppIntent, AppSnapshot, ClickTrackRequest, DirectTrackSpec, GlobalControlAction, IoTaskKind,
-    IoTaskStatus, LoopAction, LoopMode, NotificationLevel, TinySynthFxControl, TrackAction,
-    TrackProcessorEditorState, TrackProcessorTypeId, TrackSpec, TrackSpecTopology,
+    IoTaskStatus, LoopAction, LoopMode, TinySynthFxControl, TrackAction, TrackProcessorEditorState,
+    TrackProcessorTypeId, TrackSpec, TrackSpecTopology,
 };
 use shoop_backend::BackendDriverState;
 use shoop_worklet_client::{MessageEndpoint, NullHostMidiBridge, RemoteBackendControl};
@@ -191,9 +191,9 @@ impl RemoteAppHarness {
             self.drive_step().await;
         }
         panic!(
-            "remote application did not reach {description}; readiness={:?}, notifications={:?}",
+            "remote application did not reach {description}; readiness={:?}, io_task={:?}",
             self.control.readiness(),
-            self.snapshot().notifications
+            self.snapshot().io_task
         );
     }
 
@@ -363,14 +363,6 @@ async fn remote_loop_duplication_copies_content_and_controls() {
     assert_eq!(target_state.length_frames, source_state.length_frames);
     assert_eq!(target_state.gain, source_state.gain);
     assert_eq!(target_state.balance, source_state.balance);
-    assert!(
-        !snapshot
-            .notifications
-            .iter()
-            .any(|notification| notification.level == NotificationLevel::Error),
-        "unexpected duplication errors: {:?}",
-        snapshot.notifications
-    );
     harness.shutdown().await;
 }
 

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -424,9 +424,7 @@ impl UnifiedApp {
             let pending = self.pending_file_intent_tx.clone();
             let name = session_source_name(&url);
             ehttp::fetch(ehttp::Request::get(&url), move |result| {
-                if let Some(intent) = session_fetch_result(name, result) {
-                    let _ = pending.send(intent);
-                }
+                let _ = pending.send(session_fetch_result(name, result));
             });
         }
         #[cfg(target_arch = "wasm32")]
@@ -435,9 +433,9 @@ impl UnifiedApp {
             let name = session_source_name(&url);
             wasm_bindgen_futures::spawn_local(async move {
                 let result = ehttp::fetch_async(ehttp::Request::get(&url)).await;
-                if let Some(intent) = session_fetch_result(name, result) {
-                    pending.borrow_mut().push_back(intent);
-                }
+                pending
+                    .borrow_mut()
+                    .push_back(session_fetch_result(name, result));
             });
         }
     }
@@ -922,7 +920,11 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            tracing::error!(path = %path.display(), error = %error, "frontend.session.read_failed");
+                            let message = format!("Could not read {}: {error}", path.display());
+                            let _ = sender.send(AppIntent::FailIoWorkflow {
+                                kind: shoop_egui::IoTaskKind::LoadSession,
+                                message,
+                            });
                         }
                     });
                 }
@@ -948,7 +950,11 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            tracing::error!(path = %path.display(), error = %error, "frontend.loop_audio.read_failed");
+                            let message = format!("Could not read {}: {error}", path.display());
+                            let _ = sender.send(AppIntent::FailIoWorkflow {
+                                kind: shoop_egui::IoTaskKind::ImportLoopAudio,
+                                message,
+                            });
                         }
                     });
                 }
@@ -970,7 +976,11 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            tracing::error!(path = %path.display(), error = %error, "frontend.loop_midi.read_failed");
+                            let message = format!("Could not read {}: {error}", path.display());
+                            let _ = sender.send(AppIntent::FailIoWorkflow {
+                                kind: shoop_egui::IoTaskKind::ImportLoopMidi,
+                                message,
+                            });
                         }
                     });
                 }
@@ -1138,20 +1148,20 @@ fn session_source_name(source: &str) -> String {
         .to_owned()
 }
 
-fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) -> Option<AppIntent> {
+fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) -> AppIntent {
     match result {
-        Ok(response) if response.ok => Some(AppIntent::LoadSessionBytes {
+        Ok(response) if response.ok => AppIntent::LoadSessionBytes {
             name,
             bytes: std::sync::Arc::from(response.bytes),
-        }),
-        Ok(response) => {
-            tracing::error!(status = response.status, "frontend.session.fetch_failed");
-            None
-        }
-        Err(error) => {
-            tracing::error!(error = %error, "frontend.session.fetch_failed");
-            None
-        }
+        },
+        Ok(response) => AppIntent::FailIoWorkflow {
+            kind: shoop_egui::IoTaskKind::LoadSession,
+            message: format!("Could not fetch session: HTTP {}", response.status),
+        },
+        Err(error) => AppIntent::FailIoWorkflow {
+            kind: shoop_egui::IoTaskKind::LoadSession,
+            message: format!("Could not fetch session: {error}"),
+        },
     }
 }
 
@@ -1167,7 +1177,10 @@ fn load_session_path(source: String, sender: Sender<AppIntent>) {
                 });
             }
             Err(error) => {
-                tracing::error!(path = %path.display(), error = %error, "frontend.session.read_failed");
+                let _ = sender.send(AppIntent::FailIoWorkflow {
+                    kind: shoop_egui::IoTaskKind::LoadSession,
+                    message: format!("Could not read {}: {error}", path.display()),
+                });
             }
         }
     });
@@ -2802,6 +2815,7 @@ enum BrowserSelfTest {
     GenerateClickAudio,
     WaitForClickAudio {
         previous_task: shoop_egui::TaskId,
+        request_revision: u64,
     },
     WaitForClickAudioSelection,
     WaitForClickAudioExport,
@@ -2810,6 +2824,7 @@ enum BrowserSelfTest {
     GenerateClickMidi,
     WaitForClickMidi {
         previous_task: shoop_egui::TaskId,
+        request_revision: u64,
     },
     WaitForClickMidiExport,
     RejectProcessedSession,
@@ -2829,6 +2844,19 @@ enum BrowserSelfTest {
     WaitForLuaDialogsStopped,
     Complete,
     Failed,
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn click_request_was_rejected(
+    snapshot_revision: u64,
+    io_task: Option<&shoop_egui::IoTaskState>,
+    previous_task: shoop_egui::TaskId,
+    request_revision: u64,
+) -> bool {
+    snapshot_revision > request_revision
+        && io_task.is_none_or(|task| {
+            task.id == previous_task || task.kind != shoop_egui::IoTaskKind::GenerateClickTrack
+        })
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -4231,9 +4259,23 @@ impl BrowserSelfTest {
                         loop_id: loop_state.id,
                         request: browser_click_request(shoop_egui::ClickTrackKind::Audio),
                     })
-                    .map(|()| Self::WaitForClickAudio { previous_task })
+                    .map(|()| Self::WaitForClickAudio {
+                        previous_task,
+                        request_revision: snapshot.revision,
+                    })
             }
-            Self::WaitForClickAudio { previous_task } => {
+            Self::WaitForClickAudio {
+                previous_task,
+                request_revision,
+            } => {
+                if click_request_was_rejected(
+                    snapshot.revision,
+                    snapshot.io_task.as_ref(),
+                    previous_task,
+                    request_revision,
+                ) {
+                    return self.fail("browser audio click request was rejected before task creation");
+                }
                 let Some(task) = &snapshot.io_task else {
                     return;
                 };
@@ -4338,9 +4380,23 @@ impl BrowserSelfTest {
                         loop_id: loop_state.id,
                         request: browser_click_request(shoop_egui::ClickTrackKind::Midi),
                     })
-                    .map(|()| Self::WaitForClickMidi { previous_task })
+                    .map(|()| Self::WaitForClickMidi {
+                        previous_task,
+                        request_revision: snapshot.revision,
+                    })
             }
-            Self::WaitForClickMidi { previous_task } => {
+            Self::WaitForClickMidi {
+                previous_task,
+                request_revision,
+            } => {
+                if click_request_was_rejected(
+                    snapshot.revision,
+                    snapshot.io_task.as_ref(),
+                    previous_task,
+                    request_revision,
+                ) {
+                    return self.fail("browser MIDI click request was rejected before task creation");
+                }
                 let Some(task) = &snapshot.io_task else {
                     return;
                 };
@@ -4908,6 +4964,13 @@ mod tests {
             session_source_name("https://example.com/sessions/demo.shoop?download=1#top"),
             "demo.shoop"
         );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn browser_click_rejection_is_detected_after_the_request_revision() {
+        let previous_task = shoop_egui::TaskId::from_raw(7);
+        assert!(!click_request_was_rejected(12, None, previous_task, 12));
+        assert!(click_request_was_rejected(13, None, previous_task, 12));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -358,12 +358,7 @@ impl UnifiedApp {
         #[cfg(not(target_arch = "wasm32"))]
         load_session_path(source, self.pending_file_intent_tx.clone());
         #[cfg(target_arch = "wasm32")]
-        self.pending_file_intents
-            .borrow_mut()
-            .push_back(AppIntent::ReportFileIoError {
-                task_id: None,
-                message: "Filesystem session paths are unavailable in the web app".to_owned(),
-            });
+        tracing::warn!(source = %source, "frontend.session.filesystem_path_unavailable");
     }
 
     fn show_session_url_dialogs(&mut self, context: &egui::Context) {
@@ -429,7 +424,9 @@ impl UnifiedApp {
             let pending = self.pending_file_intent_tx.clone();
             let name = session_source_name(&url);
             ehttp::fetch(ehttp::Request::get(&url), move |result| {
-                let _ = pending.send(session_fetch_result(name, result));
+                if let Some(intent) = session_fetch_result(name, result) {
+                    let _ = pending.send(intent);
+                }
             });
         }
         #[cfg(target_arch = "wasm32")]
@@ -438,9 +435,9 @@ impl UnifiedApp {
             let name = session_source_name(&url);
             wasm_bindgen_futures::spawn_local(async move {
                 let result = ehttp::fetch_async(ehttp::Request::get(&url)).await;
-                pending
-                    .borrow_mut()
-                    .push_back(session_fetch_result(name, result));
+                if let Some(intent) = session_fetch_result(name, result) {
+                    pending.borrow_mut().push_back(intent);
+                }
             });
         }
     }
@@ -738,10 +735,7 @@ impl UnifiedApp {
         match load_ephemeral_script_bytes(name, bytes) {
             Ok((name, source)) => self.widget.queue_ephemeral_script(name, source),
             Err(error) => {
-                let _ = self.runtime.dispatch(AppIntent::ReportFileIoError {
-                    task_id: None,
-                    message: error.to_string(),
-                });
+                tracing::error!(error = %error, "frontend.scripting.ephemeral_load_failed")
             }
         }
     }
@@ -764,10 +758,7 @@ impl UnifiedApp {
                         .queue_ephemeral_script_from_path(name, source, Some(source_path))
                 }
                 Err(error) => {
-                    let _ = self.runtime.dispatch(AppIntent::ReportFileIoError {
-                        task_id: None,
-                        message: error.to_string(),
-                    });
+                    tracing::error!(path = %path.display(), error = %error, "frontend.scripting.ephemeral_load_failed")
                 }
             }
         }
@@ -866,7 +857,7 @@ impl UnifiedApp {
         let pending: Vec<_> = self.pending_file_intent_rx.try_iter().collect();
         for intent in pending {
             if let Err(error) = self.runtime.dispatch(intent) {
-                eprintln!("could not dispatch file intent: {error}");
+                tracing::error!(error = %error, "frontend.egui.file_intent_dispatch_failed");
             }
         }
         let snapshot = self.runtime.snapshot();
@@ -909,13 +900,6 @@ impl UnifiedApp {
                 save_file_output(output, Rc::clone(&self.pending_file_intents));
             }
         }
-        if let Some(notification) = snapshot.notifications.last() {
-            egui::Area::new(egui::Id::new("latest_notification"))
-                .anchor(egui::Align2::CENTER_TOP, [0.0, 8.0])
-                .show(ui.ctx(), |ui| {
-                    ui.label(&notification.message);
-                });
-        }
         ui.ctx().request_repaint_after(UPDATE_INTERVAL);
     }
 
@@ -938,10 +922,7 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            let _ = sender.send(AppIntent::ReportFileIoError {
-                                task_id: None,
-                                message: format!("Could not read {}: {error}", path.display()),
-                            });
+                            tracing::error!(path = %path.display(), error = %error, "frontend.session.read_failed");
                         }
                     });
                 }
@@ -967,10 +948,7 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            let _ = sender.send(AppIntent::ReportFileIoError {
-                                task_id: None,
-                                message: format!("Could not read {}: {error}", path.display()),
-                            });
+                            tracing::error!(path = %path.display(), error = %error, "frontend.loop_audio.read_failed");
                         }
                     });
                 }
@@ -992,10 +970,7 @@ impl UnifiedApp {
                             });
                         }
                         Err(error) => {
-                            let _ = sender.send(AppIntent::ReportFileIoError {
-                                task_id: None,
-                                message: format!("Could not read {}: {error}", path.display()),
-                            });
+                            tracing::error!(path = %path.display(), error = %error, "frontend.loop_midi.read_failed");
                         }
                     });
                 }
@@ -1005,7 +980,7 @@ impl UnifiedApp {
         };
         if let Some(intent) = intent {
             if let Err(error) = self.runtime.dispatch(intent) {
-                eprintln!("could not dispatch GUI intent: {error}");
+                tracing::error!(error = %error, "frontend.egui.intent_dispatch_failed");
             }
         }
     }
@@ -1079,7 +1054,7 @@ impl UnifiedApp {
             }
             other => {
                 if let Err(error) = self.runtime.dispatch(other) {
-                    eprintln!("could not dispatch GUI intent: {error}");
+                    tracing::error!(error = %error, "frontend.egui.intent_dispatch_failed");
                 }
             }
         }
@@ -1125,8 +1100,8 @@ fn save_file_output(output: shoop_app::ApplicationFileOutput, sender: Sender<App
     };
     std::thread::spawn(move || {
         if let Err(error) = atomic_replace(&path, &output.bytes, output.task_id.raw()) {
-            let _ = sender.send(AppIntent::ReportFileIoError {
-                task_id: Some(output.task_id),
+            let _ = sender.send(AppIntent::FailIoTask {
+                task_id: output.task_id,
                 message: format!("Could not save {}: {error}", path.display()),
             });
         }
@@ -1163,20 +1138,20 @@ fn session_source_name(source: &str) -> String {
         .to_owned()
 }
 
-fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) -> AppIntent {
+fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) -> Option<AppIntent> {
     match result {
-        Ok(response) if response.ok => AppIntent::LoadSessionBytes {
+        Ok(response) if response.ok => Some(AppIntent::LoadSessionBytes {
             name,
             bytes: std::sync::Arc::from(response.bytes),
-        },
-        Ok(response) => AppIntent::ReportFileIoError {
-            task_id: None,
-            message: format!("Could not fetch session: HTTP {}", response.status),
-        },
-        Err(error) => AppIntent::ReportFileIoError {
-            task_id: None,
-            message: format!("Could not fetch session: {error}"),
-        },
+        }),
+        Ok(response) => {
+            tracing::error!(status = response.status, "frontend.session.fetch_failed");
+            None
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "frontend.session.fetch_failed");
+            None
+        }
     }
 }
 
@@ -1184,17 +1159,17 @@ fn session_fetch_result(name: String, result: ehttp::Result<ehttp::Response>) ->
 fn load_session_path(source: String, sender: Sender<AppIntent>) {
     std::thread::spawn(move || {
         let path = Path::new(&source);
-        let intent = match std::fs::read(path) {
-            Ok(bytes) => AppIntent::LoadSessionBytes {
-                name: file_name(path),
-                bytes: std::sync::Arc::from(bytes),
-            },
-            Err(error) => AppIntent::ReportFileIoError {
-                task_id: None,
-                message: format!("Could not read {}: {error}", path.display()),
-            },
-        };
-        let _ = sender.send(intent);
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                let _ = sender.send(AppIntent::LoadSessionBytes {
+                    name: file_name(path),
+                    bytes: std::sync::Arc::from(bytes),
+                });
+            }
+            Err(error) => {
+                tracing::error!(path = %path.display(), error = %error, "frontend.session.read_failed");
+            }
+        }
     });
 }
 
@@ -1236,12 +1211,10 @@ fn save_file_output(
             .await
         {
             if let Err(error) = file.write(&output.bytes).await {
-                pending
-                    .borrow_mut()
-                    .push_back(AppIntent::ReportFileIoError {
-                        task_id: Some(output.task_id),
-                        message: format!("Could not save browser file: {error}"),
-                    });
+                pending.borrow_mut().push_back(AppIntent::FailIoTask {
+                    task_id: output.task_id,
+                    message: format!("Could not save browser file: {error}"),
+                });
             }
         }
     });
@@ -1501,11 +1474,7 @@ impl Runtime {
         let handle = runtime.handle();
         let preview_player = native_preview::NativePreviewPlayer::new(handle.clone())?;
         for warning in warnings {
-            eprintln!("ShoopDaLoop settings: {warning}");
-            handle.dispatch(AppIntent::ReportFileIoError {
-                task_id: None,
-                message: warning,
-            })?;
+            tracing::warn!(warning = %warning, "frontend.startup.fallback");
         }
         let script_paths =
             associate_startup_script_paths(runtime.startup_script_ids(), script_paths);
@@ -1531,16 +1500,10 @@ impl Runtime {
             match result {
                 Ok((scripts, warnings, preserve_identities, deletions_safe)) => {
                     for warning in warnings {
-                        let _ = self.handle.dispatch(AppIntent::ReportFileIoError {
-                            task_id: None,
-                            message: warning,
-                        });
+                        tracing::warn!(warning = %warning, "frontend.scripting.catalog_scan_warning");
                     }
                     if !deletions_safe {
-                        let _ = self.handle.dispatch(AppIntent::ReportFileIoError {
-                            task_id: None,
-                            message: "built-in scan could not enumerate the complete tree; the previous catalog was retained".to_owned(),
-                        });
+                        tracing::warn!("frontend.scripting.catalog_scan_incomplete");
                         continue;
                     }
                     let descriptors = scripts
@@ -1579,10 +1542,7 @@ impl Runtime {
                     }
                 }
                 Err(error) => {
-                    let _ = self.handle.dispatch(AppIntent::ReportFileIoError {
-                        task_id: None,
-                        message: format!("could not rescan built-in scripts: {error}"),
-                    });
+                    tracing::error!(error = %error, "frontend.scripting.catalog_scan_failed");
                 }
             }
         }
@@ -1642,10 +1602,7 @@ impl Runtime {
             }
         }
         for warning in warnings {
-            self.handle.dispatch(AppIntent::ReportFileIoError {
-                task_id: None,
-                message: warning,
-            })?;
+            tracing::warn!(warning = %warning, "frontend.scripting.user_script_warning");
         }
         let snapshot = self.handle.snapshot();
         for script in snapshot
@@ -1711,10 +1668,7 @@ impl Runtime {
                 let _ = sender.send((generation, result));
             })
         {
-            let _ = self.handle.dispatch(AppIntent::ReportFileIoError {
-                task_id: None,
-                message: format!("could not start built-in scan: {error}"),
-            });
+            tracing::error!(error = %error, "frontend.scripting.catalog_scan_start_failed");
         }
     }
 
@@ -2069,10 +2023,7 @@ impl Runtime {
             match result {
                 Ok((scripts, warnings, preserve_identities)) => {
                     for warning in warnings {
-                        let _ = self.runtime.dispatch(AppIntent::ReportFileIoError {
-                            task_id: None,
-                            message: warning,
-                        });
+                        tracing::warn!(warning = %warning, "frontend.scripting.catalog_scan_warning");
                     }
                     let _ = self.runtime.dispatch(AppIntent::ReconcileCatalogScripts {
                         scripts: scripts.into(),
@@ -2080,17 +2031,14 @@ impl Runtime {
                     });
                 }
                 Err(error) => {
-                    let _ = self.runtime.dispatch(AppIntent::ReportFileIoError {
-                        task_id: None,
-                        message: format!("could not rescan built-in scripts: {error}"),
-                    });
+                    tracing::error!(error = %error, "frontend.scripting.catalog_scan_failed");
                 }
             }
         }
         self.runtime.tick(elapsed);
         self.midi.update_presentation();
         let snapshot = self.runtime.snapshot();
-        let mut message = match &self.mode {
+        let message = match &self.mode {
             BrowserRuntimeMode::WebAudio(controller) => {
                 controller.update_presentation();
                 format!("Browser audio: {:?}", controller.state())
@@ -2100,10 +2048,6 @@ impl Runtime {
                 format!("Browser offline Worker engine: {:?}", driver.state())
             }
         };
-        if let Some(notification) = snapshot.notifications.first() {
-            message.push_str(": ");
-            message.push_str(&notification.message);
-        }
         set_browser_status(&message, Some(&snapshot));
         if let Some(element) = browser_status_element() {
             let _ = element.set_attribute("data-web-midi", &format!("{:?}", self.midi.state()));
@@ -4290,18 +4234,6 @@ impl BrowserSelfTest {
                     .map(|()| Self::WaitForClickAudio { previous_task })
             }
             Self::WaitForClickAudio { previous_task } => {
-                if let Some(notification) =
-                    snapshot.notifications.iter().rev().find(|notification| {
-                        notification.level == shoop_egui::NotificationLevel::Error
-                            && (notification.message.contains("click")
-                                || notification.message.contains("I/O task"))
-                    })
-                {
-                    return self.fail(&format!(
-                        "browser audio click request was rejected: {}",
-                        notification.message
-                    ));
-                }
                 let Some(task) = &snapshot.io_task else {
                     return;
                 };
@@ -4409,18 +4341,6 @@ impl BrowserSelfTest {
                     .map(|()| Self::WaitForClickMidi { previous_task })
             }
             Self::WaitForClickMidi { previous_task } => {
-                if let Some(notification) =
-                    snapshot.notifications.iter().rev().find(|notification| {
-                        notification.level == shoop_egui::NotificationLevel::Error
-                            && (notification.message.contains("click")
-                                || notification.message.contains("I/O task"))
-                    })
-                {
-                    return self.fail(&format!(
-                        "browser MIDI click request was rejected: {}",
-                        notification.message
-                    ));
-                }
                 let Some(task) = &snapshot.io_task else {
                     return;
                 };
@@ -4833,6 +4753,15 @@ fn set_browser_status(message: &str, snapshot: Option<&AppSnapshot>) {
             "data-storage-exhaustions",
             &status.storage_exhaustions.to_string(),
         );
+        if let Some(task) = &snapshot.io_task {
+            let _ = element.set_attribute("data-io-task-id", &task.id.raw().to_string());
+            let _ = element.set_attribute("data-io-task-kind", &format!("{:?}", task.kind));
+            let _ = element.set_attribute("data-io-task-status", &format!("{:?}", task.status));
+        } else {
+            let _ = element.remove_attribute("data-io-task-id");
+            let _ = element.remove_attribute("data-io-task-kind");
+            let _ = element.remove_attribute("data-io-task-status");
+        }
         let _ = element.set_attribute("data-web-midi", "AwaitingGesture");
         let _ = element.set_attribute(
             "data-application-ports",


### PR DESCRIPTION
## Summary

- replace the application-wide notification queue with structured, transition-aware console diagnostics
- retain contextual validation and feature-owned failure state in I/O, settings, connections, scripts, click-track, FX, and audio-driver workflows
- narrow file completion failures to typed, task-scoped `FailIoTask` intents and ignore stale completions safely
- migrate browser runtime status and click-track self-tests from notification strings to typed task state
- remove the floating egui notification and unrelated historical error from backend status
- complete and maintain the staged refactor plan with verification records for every phase

## Validation

- `cargo fmt --all -- --check`
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `cargo test -p shoop_app --lib` (101 passed)
- `cargo test -p shoop_egui --lib` (180 passed)
- `RUSTFLAGS="-D warnings" cargo check -p shoopdaloop`
- `RUSTFLAGS="-D warnings" cargo check -p shoopdaloop --no-default-features --target wasm32-unknown-unknown`
- `RUSTFLAGS="-D warnings" cargo build -p shoop_audio_worklet --target wasm32-unknown-unknown --release`
- `python3 scripts/check_wasm_smoke_budget.py`
- native headless launch and screenshot inspection under Xvfb

The exact host workspace build and nextest commands reach a container-specific link failure for the native `shoop_audio_worklet` cdylib because the available Tracy static archive is not PIC. Changed native packages and Wasm targets compile with warnings denied; supported Linux and WebAssembly CI jobs pass.
