### PR TITLE
Upgrade tracy-extensions to 0.7.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           asset=tracy-embedded-native-linux-x86_64.tar.gz
           root="$RUNNER_TEMP/tracy-embedded-native"
-          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0
+          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.7.0
           rm -rf "$root"
           mkdir -p "$root/download" "$root/extracted"
           curl -L --fail --retry 3 "$base/$asset" -o "$root/download/$asset"
@@ -330,7 +330,7 @@ jobs:
             *) exit 1 ;;
           esac
           root="$RUNNER_TEMP/tracy-embedded-native"
-          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0
+          base=https://github.com/SanderVocke/tracy-extensions/releases/download/v0.7.0
           rm -rf "$root"
           mkdir -p "$root/download" "$root/extracted"
           curl -L --fail --retry 3 "$base/$asset" -o "$root/download/$asset"
@@ -365,7 +365,7 @@ jobs:
           $Root = Join-Path $env:RUNNER_TEMP "tracy-embedded-native"
           $Download = Join-Path $Root "download"
           $Extracted = Join-Path $Root "extracted"
-          $Base = "https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0"
+          $Base = "https://github.com/SanderVocke/tracy-extensions/releases/download/v0.7.0"
           Remove-Item $Root -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force $Download, $Extracted | Out-Null
           curl.exe --fail --location --retry 3 "$Base/$Asset" --output (Join-Path $Download $Asset)
@@ -814,7 +814,7 @@ jobs:
           ! find "$TRACY_NEXTEST_OUTPUT_DIR" -name '*.partial' -print -quit | grep -q .
           curl -L --fail --retry 3 \
             -o "$RUNNER_TEMP/tracy-query" \
-            https://github.com/SanderVocke/tracy-extensions/releases/download/v0.6.0/tracy-query-linux-x86_64
+            https://github.com/SanderVocke/tracy-extensions/releases/download/v0.7.0/tracy-query-linux-x86_64
           chmod +x "$RUNNER_TEMP/tracy-query"
           "$RUNNER_TEMP/tracy-query" check "${traces[0]}"
           "$RUNNER_TEMP/tracy-query" range "${traces[0]}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,21 +4905,17 @@ dependencies = [
 [[package]]
 name = "tracy-client-sys"
 version = "0.28.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.6.0#09837d0c25380afd3d5a4fc87f32ed7aa247e1e2"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.7.0#f7d34231cf3d57b20afa35d23d37805bedd0b699"
 dependencies = [
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "tracy-nextest-capture"
-version = "0.6.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?rev=8589c41352c41ff3fe5e9c44075f61bd1e63a72d#8589c41352c41ff3fe5e9c44075f61bd1e63a72d"
+version = "0.7.0"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.7.0#f7d34231cf3d57b20afa35d23d37805bedd0b699"
 dependencies = [
  "sha2 0.10.9",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
- "tracing-tracy",
  "tracy-client",
  "tracy-client-sys",
  "tracy-nextest-capture-macros",
@@ -4927,8 +4923,8 @@ dependencies = [
 
 [[package]]
 name = "tracy-nextest-capture-macros"
-version = "0.6.0"
-source = "git+https://github.com/SanderVocke/tracy-extensions?rev=8589c41352c41ff3fe5e9c44075f61bd1e63a72d#8589c41352c41ff3fe5e9c44075f61bd1e63a72d"
+version = "0.7.0"
+source = "git+https://github.com/SanderVocke/tracy-extensions?tag=v0.7.0#f7d34231cf3d57b20afa35d23d37805bedd0b699"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,13 +66,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-tracy = { version = "=0.11.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "manual-lifetime", "ondemand", "timer-fallback"] }
 tracy-client-sys = { version = "=0.28.0", default-features = false, features = ["embedded-capture"] }
-tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", rev = "8589c41352c41ff3fe5e9c44075f61bd1e63a72d" }
+tracy-nextest-capture = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.7.0" }
 shoop_tracing = { path = "src/rust/shoop_tracing", default-features = false }
 oxisynth = { version = "=0.1.0", default-features = false }
 soundfont = "=0.1.0"
 
 [patch.crates-io]
-tracy-client-sys = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.6.0" }
+tracy-client-sys = { git = "https://github.com/SanderVocke/tracy-extensions", tag = "v0.7.0" }
 
 [profile.release-with-debug]
 inherits = "release"


### PR DESCRIPTION
## Summary
- upgrade `tracy-nextest-capture` to the `v0.7.0` release
- use the `v0.7.0` embedded `tracy-client-sys` patch
- refresh the Tracy dependency lockfile entries

## Testing
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace --locked`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1494 passed, 2 skipped)