### PR TITLE
Add trusted startup session URL flag

### DIFF
--- a/src/rust/shoopdaloop/README.md
+++ b/src/rust/shoopdaloop/README.md
@@ -18,6 +18,16 @@ cargo run -p shoopdaloop
 cargo run -p shoopdaloop --no-default-features
 ```
 
+A startup session URL normally requires confirmation before it is fetched. Pass `--force-url-session` together with `--session` only when the URL is trusted to bypass that startup confirmation:
+
+```sh
+cargo run -p shoopdaloop -- \
+  --session https://example.com/demo.shoop \
+  --force-url-session
+```
+
+URL sessions opened later from the application still require confirmation.
+
 Native Cargo builds place a `SHOOP_SRC_TREE` marker beside the executable. The marker contains the relative path back to the repository root, so binaries run directly from `target/debug` or `target/release` load `resources/builtins` from the checkout. Runtime resolution checks only that exact sibling marker; it does not search parent directories. Packaged applications omit the marker and use their packaged `builtins` directory instead.
 
 `--tracing` captures Tracy 0.13.1-compatible profiling data in process and writes a numbered file below `./traces` after the application exits normally. It does not expose a live TCP profiler endpoint or require an external capture tool:
@@ -71,6 +81,8 @@ Serve the application from localhost:
 cd src/rust/shoopdaloop
 trunk serve --open
 ```
+
+The same startup options are available as query parameters. For example, `?session=https%3A%2F%2Fexample.com%2Fdemo.shoop&force-url-session=1` fetches that trusted startup URL without confirmation. URL sessions opened later from the application still require confirmation.
 
 For reliable browser behavior, use HTTPS or `localhost`, which browsers treat as a secure context. The browser permissions dialog opens at app startup, reports the current audio, microphone, and Web MIDI permission state, and can be reopened from **Settings → Audio**. Click **Enable microphone audio** to create one `AudioContext`, request the default microphone, and configure microphone and destination channels as visible host ports around the AudioWorklet. Click **Enable output-only audio** to skip microphone capture; destination host ports remain available while capture inventory is empty, and microphone access can be requested later from the dialog. Click **Enable Web MIDI + SysEx** independently to request MIDI and SysEx access. Permission denial, unsupported APIs, and driver failure leave the application responsive and expose truthful retry or unavailable state.
 

--- a/src/rust/shoopdaloop/src/app_args.rs
+++ b/src/rust/shoopdaloop/src/app_args.rs
@@ -16,6 +16,9 @@ pub struct AppArgs {
     /// Open a .shoop session from a filesystem path or URL on startup.
     #[arg(long)]
     pub session: Option<String>,
+    /// Fetch a startup session URL without asking for confirmation.
+    #[arg(long, requires = "session")]
+    pub force_url_session: bool,
     #[cfg(not(target_arch = "wasm32"))]
     /// Capture Tracy profiling data to ./traces.
     #[arg(long)]
@@ -138,13 +141,19 @@ mod native_tests {
 
     #[shoop_wasm_test_support::shoop_test]
     fn cli_parses_session_source() {
-        let args =
-            AppArgs::try_parse_from(["shoopdaloop", "--session", "https://example.com/demo.shoop"])
-                .unwrap();
+        let args = AppArgs::try_parse_from([
+            "shoopdaloop",
+            "--session",
+            "https://example.com/demo.shoop",
+            "--force-url-session",
+        ])
+        .unwrap();
         assert_eq!(
             args.session.as_deref(),
             Some("https://example.com/demo.shoop")
         );
+        assert!(args.force_url_session);
+        assert!(AppArgs::try_parse_from(["shoopdaloop", "--force-url-session"]).is_err());
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -160,7 +169,7 @@ mod tests {
     #[shoop_wasm_test_support::shoop_test]
     fn web_query_parses_flags_and_typed_values() {
         let args = parse_web_query(
-            "?offline=1&settings-test=verify&session-only=true&instance=2&session=https%3A%2F%2Fexample.com%2Fdemo.shoop",
+            "?offline=1&settings-test=verify&session-only=true&instance=2&session=https%3A%2F%2Fexample.com%2Fdemo.shoop&force-url-session=1",
         )
         .unwrap();
         assert!(args.offline);
@@ -171,6 +180,7 @@ mod tests {
             args.session.as_deref(),
             Some("https://example.com/demo.shoop")
         );
+        assert!(args.force_url_session);
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -182,6 +192,7 @@ mod tests {
         assert_eq!(args.settings_test, Some(SettingsTest::SaveFailure));
         assert!(!args.worker);
         assert!(parse_web_query("?offline=maybe").is_err());
+        assert!(parse_web_query("?force-url-session=1").is_err());
         assert!(parse_web_query("?settings-test=write&settings-test=verify").is_err());
     }
 }

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -215,6 +215,13 @@ struct BrowserEphemeralFile {
     bytes: Vec<u8>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum StartupSessionAction {
+    LoadPath(String),
+    ConfirmUrl(String),
+    FetchUrl(String),
+}
+
 struct UnifiedApp {
     runtime: Runtime,
     widget: AppWidget,
@@ -226,7 +233,7 @@ struct UnifiedApp {
     #[cfg(not(target_arch = "wasm32"))]
     pending_tracing_action: Option<PendingTracingAction>,
     last_update: Instant,
-    startup_session: Option<String>,
+    startup_session: Option<(String, bool)>,
     session_url_input: String,
     session_url_error: Option<String>,
     session_url_prompt_open: bool,
@@ -325,7 +332,10 @@ impl UnifiedApp {
             #[cfg(not(target_arch = "wasm32"))]
             pending_tracing_action: None,
             last_update: Instant::now(),
-            startup_session: args.session.clone(),
+            startup_session: args
+                .session
+                .clone()
+                .map(|source| (source, args.force_url_session)),
             session_url_input: String::new(),
             session_url_error: None,
             session_url_prompt_open: false,
@@ -348,17 +358,30 @@ impl UnifiedApp {
     }
 }
 
-impl UnifiedApp {
-    fn process_session_source(&mut self, source: String) {
-        if is_http_url(&source) {
-            self.session_url_confirmation = Some(source);
-            return;
-        }
+fn startup_session_action(source: String, force_url_session: bool) -> StartupSessionAction {
+    if !is_http_url(&source) {
+        StartupSessionAction::LoadPath(source)
+    } else if force_url_session {
+        StartupSessionAction::FetchUrl(source)
+    } else {
+        StartupSessionAction::ConfirmUrl(source)
+    }
+}
 
-        #[cfg(not(target_arch = "wasm32"))]
-        load_session_path(source, self.pending_file_intent_tx.clone());
-        #[cfg(target_arch = "wasm32")]
-        tracing::warn!(source = %source, "frontend.session.filesystem_path_unavailable");
+impl UnifiedApp {
+    fn process_startup_session_source(&mut self, source: String, force_url_session: bool) {
+        match startup_session_action(source, force_url_session) {
+            StartupSessionAction::ConfirmUrl(source) => {
+                self.session_url_confirmation = Some(source);
+            }
+            StartupSessionAction::FetchUrl(source) => self.fetch_session_url(source),
+            StartupSessionAction::LoadPath(source) => {
+                #[cfg(not(target_arch = "wasm32"))]
+                load_session_path(source, self.pending_file_intent_tx.clone());
+                #[cfg(target_arch = "wasm32")]
+                tracing::warn!(source = %source, "frontend.session.filesystem_path_unavailable");
+            }
+        }
     }
 
     fn show_session_url_dialogs(&mut self, context: &egui::Context) {
@@ -818,8 +841,8 @@ impl UnifiedApp {
     }
 
     fn show(&mut self, ui: &mut egui::Ui) {
-        if let Some(source) = self.startup_session.take() {
-            self.process_session_source(source);
+        if let Some((source, force_url_session)) = self.startup_session.take() {
+            self.process_startup_session_source(source, force_url_session);
         }
         let _span = tracing::trace_span!("frontend.egui.update").entered();
         self.settings.poll();
@@ -4926,6 +4949,23 @@ mod tests {
         assert_eq!(
             session_source_name("https://example.com/sessions/demo.shoop?download=1#top"),
             "demo.shoop"
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn forced_startup_url_skips_only_its_confirmation() {
+        let url = "https://example.com/session.shoop";
+        assert_eq!(
+            startup_session_action(url.to_owned(), false),
+            StartupSessionAction::ConfirmUrl(url.to_owned())
+        );
+        assert_eq!(
+            startup_session_action(url.to_owned(), true),
+            StartupSessionAction::FetchUrl(url.to_owned())
+        );
+        assert_eq!(
+            startup_session_action("session.shoop".to_owned(), true),
+            StartupSessionAction::LoadPath("session.shoop".to_owned())
         );
     }
 


### PR DESCRIPTION
## Summary
- add `--force-url-session` for trusted startup session URLs
- support the same flag as `force-url-session` in browser and standalone query strings
- bypass confirmation only for the startup URL while preserving confirmation for URL sessions opened from the UI
- document native and browser usage

## Validation
- `cargo fmt --all`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1495 passed, 2 skipped)
- `RUSTFLAGS="-D warnings" cargo check -p shoopdaloop --no-default-features --target wasm32-unknown-unknown`
- `python3 scripts/run_wasm_tests.py --runtime node --profile dev --package shoopdaloop --filter web_query` (2 passed, pinned Node 22.22.2)
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`