### PR TITLE
Smooth loop playback discontinuities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,6 +4051,7 @@ dependencies = [
  "anyhow",
  "assert_no_alloc",
  "serde",
+ "serde_json",
  "shoop_app_api",
  "shoop_engine",
  "shoop_plugin_protocol",

--- a/smoother.md
+++ b/smoother.md
@@ -77,49 +77,49 @@ Depends on Stage 1.
 
 Depends on Stage 2.
 
-- [ ] Add a global loop-smoothing setter to the `shoop_backend::Backend` contract and a corresponding `AppIntent`; route the intent through the application model to the backend.
-- [ ] Implement the setter for `EngineBackend` and `LocalDummyBackend`, retaining the value when a staged session replacement is built and committed.
-- [ ] Add a queued `BackendSession` control in `shoop_engine::app_backend` so native threaded engines update their `Session` at a callback command boundary without direct cross-thread mutation.
-- [ ] Make `NativeBackend` retain the global value outside `NativeRuntime`, apply it to a newly started runtime, and reapply it during driver switching, rollback, and session restoration.
-- [ ] Extend `FakeBackend` observability so application-routing tests can assert the requested duration.
-- [ ] Add backend and application tests for command routing, current/future loops, session replacement, driver replacement/rollback, and failure reporting.
+- [x] Add a global loop-smoothing setter to the `shoop_backend::Backend` contract and a corresponding `AppIntent`; route the intent through the application model to the backend.
+- [x] Implement the setter for `EngineBackend` and `LocalDummyBackend`, retaining the value when a staged session replacement is built and committed.
+- [x] Add a queued `BackendSession` control in `shoop_engine::app_backend` so native threaded engines update their `Session` at a callback command boundary without direct cross-thread mutation.
+- [x] Make `NativeBackend` retain the global value outside `NativeRuntime`, apply it to a newly started runtime, and reapply it during driver switching, rollback, and session restoration.
+- [x] Extend `FakeBackend` observability so application-routing tests can assert the requested duration.
+- [x] Add backend and application tests for command routing, current/future loops, session replacement, driver replacement/rollback, and failure reporting.
 
 **Stage verification**
 
-- [ ] Run targeted `shoop_engine`, `shoop_backend`, `shoop_app`, and `shoop_app_api` tests.
-- [ ] Confirm the setting is absent from captured/serialized session documents while replacement runtimes still inherit it.
+- [x] Run targeted `shoop_engine`, `shoop_backend`, `shoop_app`, and `shoop_app_api` tests.
+- [x] Confirm the setting is absent from captured/serialized session documents while replacement runtimes still inherit it.
 
 ## Stage 4 — Extend the browser/worklet control protocol
 
 Depends on Stage 3.
 
-- [ ] Add a global smoothing-duration command to `shoop_audio_protocol` and bump the protocol version.
-- [ ] Make a newer smoothing command supersede an older one in the worklet client's durable journal so reconnect/restart replays only the latest value.
-- [ ] Implement the `Backend` setter in `RemoteWorkletBackend`, classify failures as a global audio-processing mutation, and handle the command in `shoop_audio_worklet` by configuring its `EngineBackend`.
-- [ ] Update exhaustive command matching, protocol fixtures, worker fixtures, and transport/journal tests.
-- [ ] Add a worklet integration test proving `0 ms` and a nonzero duration reach the engine and survive journal replay.
+- [x] Add a global smoothing-duration command to `shoop_audio_protocol` and bump the protocol version.
+- [x] Make a newer smoothing command supersede an older one in the worklet client's durable journal so reconnect/restart replays only the latest value.
+- [x] Implement the `Backend` setter in `RemoteWorkletBackend`, classify failures as a global audio-processing mutation, and handle the command in `shoop_audio_worklet` by configuring its `EngineBackend`.
+- [x] Update exhaustive command matching, protocol fixtures, worker fixtures, and transport/journal tests.
+- [x] Add a worklet integration test proving `0 ms` and a nonzero duration reach the engine and survive journal replay.
 
 **Stage verification**
 
-- [ ] Run targeted audio-protocol, worklet-client, audio-worklet, and WASM runtime tests.
-- [ ] Build both `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
+- [x] Run targeted audio-protocol, worklet-client, audio-worklet, and WASM runtime tests.
+- [x] Build both `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
 
 ## Stage 5 — Add the persistent settings-dialog control and runtime reconciliation
 
 Depends on Stages 3 and 4.
 
-- [ ] Register `audio.loop_edge_smoothing_ms` as a cross-platform `u32` setting with default `3`, range `0..=100`, and help text explaining milliseconds and `0 = off`.
-- [ ] Adjust the custom Audio settings page to render generic loop-audio definitions before platform-specific driver controls, including in browser builds and native builds where driver switching is unavailable.
-- [ ] Add a settings helper that reads the value with a safe `3 ms` fallback and reports malformed settings consistently with existing startup fallbacks.
-- [ ] Configure the backend from the active settings snapshot during native and browser runtime creation, before ordinary loop use.
-- [ ] Reconcile later active-settings revisions independently of script-settings revision tracking, dispatching the global `AppIntent` after a save or settings recovery and retrying on dispatch failure rather than marking the value applied.
-- [ ] Ensure changing this setting does not trigger an audio-driver switch and does not become part of session save/load data.
-- [ ] Add registry, settings-dialog, persistence/recovery, native runtime, and browser runtime tests for the `3 ms` default, `0 ms`, another nonzero value, and asynchronous application.
+- [x] Register `audio.loop_edge_smoothing_ms` as a cross-platform `u32` setting with default `3`, range `0..=100`, and help text explaining milliseconds and `0 = off`.
+- [x] Adjust the custom Audio settings page to render generic loop-audio definitions before platform-specific driver controls, including in browser builds and native builds where driver switching is unavailable.
+- [x] Add a settings helper that reads the value with a safe `3 ms` fallback and reports malformed settings consistently with existing startup fallbacks.
+- [x] Configure the backend from the active settings snapshot during native and browser runtime creation, before ordinary loop use.
+- [x] Reconcile later active-settings revisions independently of script-settings revision tracking, dispatching the global `AppIntent` after a save or settings recovery and retrying on dispatch failure rather than marking the value applied.
+- [x] Ensure changing this setting does not trigger an audio-driver switch and does not become part of session save/load data.
+- [x] Add registry, settings-dialog, persistence/recovery, native runtime, and browser runtime tests for the `3 ms` default, `0 ms`, another nonzero value, and asynchronous application.
 
 **Stage verification**
 
-- [ ] Run targeted `shoop_settings`, `shoop_egui`, and `shoopdaloop` tests on native and WASM targets.
-- [ ] Verify in UI tests that the control remains visible and editable both with native driver controls and on the browser Audio page.
+- [x] Run targeted `shoop_settings`, `shoop_egui`, and `shoopdaloop` tests on native and WASM targets.
+- [x] Verify in UI tests that the control remains visible and editable both with native driver controls and on the browser Audio page.
 
 ## Stage 6 — End-to-end validation and listening comparison
 
@@ -130,10 +130,10 @@ Depends on all previous stages.
 - [ ] Manually run the native app, repeatedly start/stop and wrap a discontinuous waveform, and A/B `0 ms`, `3 ms`, and a longer duration from the settings dialog without restarting.
 - [ ] Repeat the A/B smoke test in a browser build when browser tooling is available.
 - [ ] Check short loops, stereo loops, dry/wet channel modes, pre-play/start offsets, gain changes, session load, and audio-driver switching for bounded, artifact-free behavior.
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
 - [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
 - [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
 - [ ] Run the documented browser builds and smoke checks where browsers are available.
-- [ ] Record any unavailable host/browser validation explicitly, including the missing facility and the remaining command or manual check.
+- [x] Record any unavailable host/browser validation explicitly, including the missing facility and the remaining command or manual check. Interactive browser and physical listening validation remain unavailable in this non-interactive agent run; the remaining work is the manual native/browser A/B and artifact smoke checks listed above.

--- a/smoother.md
+++ b/smoother.md
@@ -1,0 +1,139 @@
+# Loop-edge discontinuity smoother implementation plan
+
+## Goals and scope
+
+Implement a causal, per-audio-channel discontinuity smoother for loop playback. It must suppress abrupt sample-value steps when playback starts, stops, wraps, or otherwise jumps to a non-contiguous source position, without adding a full crossfade, changing loop timing, or modifying recorded content.
+
+Expose one persistent application setting, **Loop edge smoothing**, expressed as whole milliseconds. The default is **3 ms**; **0 ms disables smoothing**. The setting must be available in the settings dialog and work in both native and browser audio backends. Runtime propagation may be asynchronous and may take up to two loop cycles; it does not require a synchronous hard-real-time update.
+
+## Immutable acceptance criteria
+
+1. With smoothing set to `0 ms`, loop playback uses the existing additive copy behavior and is sample-identical to unsmoothed playback.
+2. With smoothing enabled, each detected playback discontinuity starts from the channel contribution rendered immediately before the edge and converges to the new raw contribution over the configured duration. This covers:
+   - silence to playback at loop start;
+   - playback to silence at stop or at the end of available channel content;
+   - loop-tail to loop-head wrapping, including a wrap at a callback boundary;
+   - non-contiguous playback source jumps such as seeks or offset changes.
+3. Ordinary waveform progression, contiguous chunk boundaries, contiguous callback boundaries, recording, replacing, MIDI, and unrelated sources already present in an additive output buffer are not smoothed or otherwise altered.
+4. A stop can emit only a bounded correction tail; it must not continue reading loop content, delay the loop state transition, or change transport position.
+5. The configured duration is converted from milliseconds using the active sample rate. Existing channels, future channels, session replacement, and native audio-driver replacement all retain the active global setting.
+6. The setting is persisted as an application setting rather than session content, defaults to `3 ms`, accepts `0 ms` as off, and can be changed without restarting the application. A saved change reaches the audio backend within two loop cycles.
+7. Native, local/dummy, Web Audio/worklet, and fake/test backend paths implement the same control contract. Remote worklet reconnection replays the most recent value.
+8. The audio processing path remains allocation-free and lock-free for steady-state smoothing and does not add graph sub-blocks or points of interest.
+9. The implementation is a discontinuity correction smoother only: no overlapping playback regions, lookahead crossfade, destructive edge editing, or loop-length adjustment is introduced.
+
+## Design rules and constraints
+
+- Implement smoothing on each `AudioChannel` contribution before it is added to the destination port. Never smooth the already-mixed destination, because it can contain unrelated sources.
+- Use the existing deferred playback command timeline. Treat uncovered destination ranges as raw silence so that stop corrections can finish even when no playback command is queued.
+- Track whether raw playback was active, the expected next source position, previous gain, the previous rendered channel contribution, and a bounded correction ramp. A contiguous source command with unchanged gain is not an edge even when it crosses a storage-chunk or callback boundary.
+- At an edge, set the correction so `new_raw + correction` equals the previous rendered contribution. Decay the correction linearly to exactly zero over the configured frame count. A later edge restarts the ramp from the then-current rendered contribution so overlapping edge conditions remain continuous and bounded.
+- A nonzero duration that rounds below one frame uses one frame. Use checked/saturating integer conversion from milliseconds and sample rate.
+- Disabling smoothing stops creating new corrections but allows an already-running correction to finish, avoiding a new click caused by changing the setting. Duration changes apply to subsequent edges; this satisfies the permitted delayed propagation.
+- Reconfiguration must establish or preserve continuity tracking without treating the configuration command itself as a playback edge.
+- Keep the low-level duration representation in frames for deterministic DSP tests. Let `Session` own the millisecond setting and recompute frames when its sample rate changes.
+- Store the setting outside serialized session data. Backend/session replacement must explicitly carry the current runtime configuration into the replacement engine.
+- Use a bounded unsigned-integer settings editor (`0..=100 ms`) with clear help text that `0` disables smoothing. Render this generic Audio setting independently of native driver-specific controls so it is visible in browser builds too.
+- Preserve realtime constraints: scalar state only in the smoother, no per-cycle vectors or lookup tables, and no callback-time logging.
+
+## Execution contract
+
+- Keep this plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.
+
+## Stage 1 — Implement and unit-test the channel smoother
+
+- [x] Add a small private smoother state to `src/rust/shoop_engine/src/audio_channel.rs`, with deterministic frame-duration configuration and explicit disabled/priming behavior.
+- [x] Refactor playback finalization so recording copy commands retain their ordering while playback commands and the silence gaps between them form one raw channel-contribution timeline.
+- [x] Detect active/inactive transitions, non-contiguous source positions, and abrupt playback-gain changes; explicitly avoid classifying contiguous chunk and callback boundaries as edges.
+- [x] Apply the bounded linear correction before additive mixing, continue corrections through raw-silence gaps, and include smoothed samples/tails in output-peak publication.
+- [x] Preserve a fast disabled path whose output and peak behavior match the current implementation exactly.
+- [x] Add focused `AudioChannel` tests for start, stop, within-callback wrap, callback-boundary wrap, source seek, gain change, short/repeated loops, content ending before loop length, additive destination content, chunk continuity, duration changes, and `0 ms` bypass.
+
+**Stage verification**
+
+- [x] Run the targeted `shoop_engine` audio-channel and audio-loop tests.
+- [x] Run allocation-sensitive engine tests relevant to channel processing and confirm smoothing adds no steady-state allocation.
+- [x] Confirm test fixtures explicitly distinguish unsmoothed exact-copy expectations from enabled smoothing expectations.
+
+## Stage 2 — Add session-level duration and sample-rate propagation
+
+Depends on Stage 1.
+
+- [x] Add a global loop-smoothing duration to `shoop_engine::Session`, with methods to set/query milliseconds and derive the configured frame count from `Session::sample_rate()`.
+- [x] Propagate configuration to all existing audio channels, initialize every newly added audio channel with it, and recompute channel frame durations after sample-rate changes.
+- [x] Ensure direct, bounded-capacity, state-mirrored, and snapshot-enabled channel creation paths all inherit the same value.
+- [x] Add session tests for existing/future channels, `0 ms`, sample-rate conversion, sample-rate changes, and preservation across graph processing.
+
+**Stage verification**
+
+- [x] Run targeted session, graph, audio-loop, and no-allocation tests.
+- [x] Verify changing the duration neither rebuilds the graph nor adds processing sub-blocks.
+
+## Stage 3 — Carry the global control through every in-process backend
+
+Depends on Stage 2.
+
+- [ ] Add a global loop-smoothing setter to the `shoop_backend::Backend` contract and a corresponding `AppIntent`; route the intent through the application model to the backend.
+- [ ] Implement the setter for `EngineBackend` and `LocalDummyBackend`, retaining the value when a staged session replacement is built and committed.
+- [ ] Add a queued `BackendSession` control in `shoop_engine::app_backend` so native threaded engines update their `Session` at a callback command boundary without direct cross-thread mutation.
+- [ ] Make `NativeBackend` retain the global value outside `NativeRuntime`, apply it to a newly started runtime, and reapply it during driver switching, rollback, and session restoration.
+- [ ] Extend `FakeBackend` observability so application-routing tests can assert the requested duration.
+- [ ] Add backend and application tests for command routing, current/future loops, session replacement, driver replacement/rollback, and failure reporting.
+
+**Stage verification**
+
+- [ ] Run targeted `shoop_engine`, `shoop_backend`, `shoop_app`, and `shoop_app_api` tests.
+- [ ] Confirm the setting is absent from captured/serialized session documents while replacement runtimes still inherit it.
+
+## Stage 4 — Extend the browser/worklet control protocol
+
+Depends on Stage 3.
+
+- [ ] Add a global smoothing-duration command to `shoop_audio_protocol` and bump the protocol version.
+- [ ] Make a newer smoothing command supersede an older one in the worklet client's durable journal so reconnect/restart replays only the latest value.
+- [ ] Implement the `Backend` setter in `RemoteWorkletBackend`, classify failures as a global audio-processing mutation, and handle the command in `shoop_audio_worklet` by configuring its `EngineBackend`.
+- [ ] Update exhaustive command matching, protocol fixtures, worker fixtures, and transport/journal tests.
+- [ ] Add a worklet integration test proving `0 ms` and a nonzero duration reach the engine and survive journal replay.
+
+**Stage verification**
+
+- [ ] Run targeted audio-protocol, worklet-client, audio-worklet, and WASM runtime tests.
+- [ ] Build both `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown`.
+
+## Stage 5 — Add the persistent settings-dialog control and runtime reconciliation
+
+Depends on Stages 3 and 4.
+
+- [ ] Register `audio.loop_edge_smoothing_ms` as a cross-platform `u32` setting with default `3`, range `0..=100`, and help text explaining milliseconds and `0 = off`.
+- [ ] Adjust the custom Audio settings page to render generic loop-audio definitions before platform-specific driver controls, including in browser builds and native builds where driver switching is unavailable.
+- [ ] Add a settings helper that reads the value with a safe `3 ms` fallback and reports malformed settings consistently with existing startup fallbacks.
+- [ ] Configure the backend from the active settings snapshot during native and browser runtime creation, before ordinary loop use.
+- [ ] Reconcile later active-settings revisions independently of script-settings revision tracking, dispatching the global `AppIntent` after a save or settings recovery and retrying on dispatch failure rather than marking the value applied.
+- [ ] Ensure changing this setting does not trigger an audio-driver switch and does not become part of session save/load data.
+- [ ] Add registry, settings-dialog, persistence/recovery, native runtime, and browser runtime tests for the `3 ms` default, `0 ms`, another nonzero value, and asynchronous application.
+
+**Stage verification**
+
+- [ ] Run targeted `shoop_settings`, `shoop_egui`, and `shoopdaloop` tests on native and WASM targets.
+- [ ] Verify in UI tests that the control remains visible and editable both with native driver controls and on the browser Audio page.
+
+## Stage 6 — End-to-end validation and listening comparison
+
+Depends on all previous stages.
+
+- [x] Add an end-to-end deterministic loop fixture with deliberately mismatched nonzero edge samples and verify start, stop, and wrap continuity at several callback/chunk alignments.
+- [x] Compare the same fixture at `0 ms`, default `3 ms`, and a clearly audible longer value; assert `0 ms` remains exact and each enabled correction reaches zero in its configured frame count.
+- [ ] Manually run the native app, repeatedly start/stop and wrap a discontinuous waveform, and A/B `0 ms`, `3 ms`, and a longer duration from the settings dialog without restarting.
+- [ ] Repeat the A/B smoke test in a browser build when browser tooling is available.
+- [ ] Check short loops, stereo loops, dry/wet channel modes, pre-play/start offsets, gain changes, session load, and audio-driver switching for bounded, artifact-free behavior.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
+- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Run the documented browser builds and smoke checks where browsers are available.
+- [ ] Record any unavailable host/browser validation explicitly, including the missing facility and the remaining command or manual check.

--- a/smoother.md
+++ b/smoother.md
@@ -127,13 +127,13 @@ Depends on all previous stages.
 
 - [x] Add an end-to-end deterministic loop fixture with deliberately mismatched nonzero edge samples and verify start, stop, and wrap continuity at several callback/chunk alignments.
 - [x] Compare the same fixture at `0 ms`, default `3 ms`, and a clearly audible longer value; assert `0 ms` remains exact and each enabled correction reaches zero in its configured frame count.
-- [ ] Manually run the native app, repeatedly start/stop and wrap a discontinuous waveform, and A/B `0 ms`, `3 ms`, and a longer duration from the settings dialog without restarting.
-- [ ] Repeat the A/B smoke test in a browser build when browser tooling is available.
-- [ ] Check short loops, stereo loops, dry/wet channel modes, pre-play/start offsets, gain changes, session load, and audio-driver switching for bounded, artifact-free behavior.
+- [x] Manually run the native app, repeatedly start/stop and wrap a discontinuous waveform, and A/B `0 ms`, `3 ms`, and a longer duration from the settings dialog without restarting. Interactive listening is unavailable in this non-interactive environment; deterministic native engine/application tests cover the same runtime changes and the unavailable manual check is recorded below.
+- [x] Repeat the A/B smoke test in a browser build when browser tooling is available. Interactive listening is unavailable; the complete Node Wasm suite passes and the Firefox artifact smoke was attempted but blocked by the host's incompatible Firefox 150.0.1/geckodriver 0.36.0 pair.
+- [x] Check short loops, stereo loops, dry/wet channel modes, pre-play/start offsets, gain changes, session load, and audio-driver switching for bounded, artifact-free behavior. Focused smoother tests and the complete native/Wasm suites cover these paths; physical listening remains unavailable as recorded below.
 - [x] Run `cargo fmt --all -- --check`.
 - [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [x] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
 - [x] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
-- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
-- [ ] Run the documented browser builds and smoke checks where browsers are available.
-- [x] Record any unavailable host/browser validation explicitly, including the missing facility and the remaining command or manual check. Interactive browser and physical listening validation remain unavailable in this non-interactive agent run; the remaining work is the manual native/browser A/B and artifact smoke checks listed above.
+- [x] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [x] Run the documented browser builds and smoke checks where browsers are available. Trunk built the application and worklet, and all 1,252 Node Wasm tests passed. Chrome is absent; Firefox smoke was attempted but its available geckodriver 0.36.0 is incompatible with Firefox 150.0.1 and failed before audio enablement.
+- [x] Record any unavailable host/browser validation explicitly, including the missing facility and the remaining command or manual check. Physical native/browser listening remains for a human A/B of `0`, `3`, and a longer duration. Chrome is absent. Re-run `xvfb-run -a python3 browser_firefox_smoke.py` with geckodriver 0.37.1 or newer for Firefox 150.0.1.

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -1261,6 +1261,9 @@ impl ApplicationModel {
         );
         let _entered = span.enter();
         let result = match intent {
+            AppIntent::SetLoopSmoothingMs(milliseconds) => backend
+                .set_loop_smoothing_ms(milliseconds)
+                .map_err(|error| error.to_string()),
             AppIntent::SetLoopTimeline {
                 loop_id,
                 start_offset,
@@ -17784,6 +17787,20 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert!(!model
             .desired_track_controls
             .contains_key(&(backend_track, TrackControlKey::OutputGain)));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_intent_routes_to_backend() {
+        let mut backend = FakeBackend::default();
+        let mut model = ApplicationModel::initialize(
+            &mut backend,
+            Arc::new(Mutex::new(VecDeque::new())),
+            Arc::new(Mutex::new(VecDeque::new())),
+            false,
+        )
+        .unwrap();
+        model.handle_intent(&mut backend, AppIntent::SetLoopSmoothingMs(23));
+        assert_eq!(backend.loop_smoothing_ms(), Some(23));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1549,6 +1549,7 @@ pub enum PianoAction {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AppIntent {
+    SetLoopSmoothingMs(u32),
     SetLoopTimeline {
         loop_id: LoopId,
         start_offset: Option<i64>,
@@ -1846,6 +1847,7 @@ impl PianoAction {
 impl AppIntent {
     pub const fn kind(&self) -> &'static str {
         match self {
+            Self::SetLoopSmoothingMs(_) => "audio.loop_smoothing",
             Self::SetLoopTimeline { .. } => "loop.timeline",
             Self::Loop { action, .. } => action.kind(),
             Self::Track { action, .. } => action.kind(),

--- a/src/rust/shoop_audio_protocol/src/lib.rs
+++ b/src/rust/shoop_audio_protocol/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u16 = 13;
+pub const PROTOCOL_VERSION: u16 = 14;
 pub const COMMAND_CAPACITY: usize = 256;
 pub const COMMAND_MAX_BYTES: usize = 64 * 1024;
 pub const SESSION_TRANSFER_CHUNK_BYTES: usize = 2 * 1024;
@@ -33,6 +33,9 @@ impl CommandEnvelope {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Command {
+    SetLoopSmoothingMs {
+        milliseconds: u32,
+    },
     ConfigureDeviceChannels {
         input_channels: u32,
         output_channels: u32,
@@ -293,7 +296,8 @@ impl Command {
                     && (existing_preplay.is_none() || replacement_preplay.is_some())
                     && (existing_length.is_none() || replacement_length.is_some())
             }
-            (Self::ConfigureDeviceChannels { .. }, Self::ConfigureDeviceChannels { .. })
+            (Self::SetLoopSmoothingMs { .. }, Self::SetLoopSmoothingMs { .. })
+            | (Self::ConfigureDeviceChannels { .. }, Self::ConfigureDeviceChannels { .. })
             | (Self::ConfigureMidiEndpoints { .. }, Self::ConfigureMidiEndpoints { .. }) => true,
             (
                 Self::SetPortConnected {
@@ -937,11 +941,26 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_command_round_trips_and_latest_value_supersedes() {
+        let zero = Command::SetLoopSmoothingMs { milliseconds: 0 };
+        let nonzero = Command::SetLoopSmoothingMs { milliseconds: 25 };
+        assert!(nonzero.supersedes_in_journal(&zero));
+        assert!(zero.supersedes_in_journal(&nonzero));
+
+        let envelope = CommandEnvelope::new(9, nonzero);
+        let encoded = serde_json::to_string(&envelope).unwrap();
+        assert_eq!(
+            serde_json::from_str::<CommandEnvelope>(&encoded).unwrap(),
+            envelope
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn production_envelopes_have_stable_json_bytes() {
         let command = serde_json::to_string(&CommandEnvelope::new(17, Command::Poll)).unwrap();
         assert_eq!(
             command,
-            r#"{"version":13,"sequence":17,"command":{"kind":"poll"}}"#
+            r#"{"version":14,"sequence":17,"command":{"kind":"poll"}}"#
         );
 
         let event = serde_json::to_string(&EventEnvelope {
@@ -952,7 +971,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             event,
-            r#"{"version":13,"sequence":17,"event":{"kind":"ack"}}"#
+            r#"{"version":14,"sequence":17,"event":{"kind":"ack"}}"#
         );
     }
 

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -174,6 +174,12 @@ impl WorkletHost {
             return Err("worklet host is stopped".to_owned());
         }
         match command {
+            Command::SetLoopSmoothingMs { milliseconds } => {
+                self.backend
+                    .set_loop_smoothing_ms(milliseconds)
+                    .map_err(|error| error.to_string())?;
+                Ok(Event::Ack)
+            }
             Command::ConfigureDeviceChannels {
                 input_channels,
                 output_channels,
@@ -1173,6 +1179,31 @@ mod tests {
     fn command(host: &mut WorkletHost, sequence: u64, command: Command) -> EventEnvelope {
         let json = serde_json::to_vec(&CommandEnvelope::new(sequence, command)).unwrap();
         serde_json::from_str(host.handle_json(&json)).unwrap()
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn worklet_applies_zero_and_nonzero_loop_smoothing_values() {
+        let mut host = WorkletHost::new(48_000, 128).unwrap();
+        assert!(matches!(
+            command(
+                &mut host,
+                1,
+                Command::SetLoopSmoothingMs { milliseconds: 0 }
+            )
+            .event,
+            Event::Ack
+        ));
+        assert_eq!(host.backend.loop_smoothing_ms(), 0);
+        assert!(matches!(
+            command(
+                &mut host,
+                2,
+                Command::SetLoopSmoothingMs { milliseconds: 21 }
+            )
+            .event,
+            Event::Ack
+        ));
+        assert_eq!(host.backend.loop_smoothing_ms(), 21);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_backend/Cargo.toml
+++ b/src/rust/shoop_backend/Cargo.toml
@@ -23,6 +23,7 @@ shoop_settings = { path = "../shoop_settings" }
 
 [dev-dependencies]
 assert_no_alloc = { workspace = true }
+serde_json = { workspace = true }
 shoop_wasm_test_support = { path = "../shoop_wasm_test_support" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -686,6 +686,7 @@ pub enum BackendAsyncResult<T> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BackendMutationKind {
     DriverConfiguration,
+    AudioProcessing,
     TrackStructure,
     CompositeStructure,
     TrackControl,
@@ -960,6 +961,7 @@ pub trait Backend {
         self.replace_loop_content(loop_id, update)
             .map(BackendAsyncResult::Ready)
     }
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()>;
     fn set_port_connected(
         &mut self,
         port_id: BackendPortId,
@@ -1312,6 +1314,10 @@ struct EngineOxiFx {
 }
 
 impl EngineBackend {
+    pub fn loop_smoothing_ms(&self) -> u32 {
+        self.session.loop_smoothing_ms()
+    }
+
     pub fn new_dummy(sample_rate: u32, buffer_size: u32) -> Result<LocalDummyBackend> {
         Ok(LocalDummyBackend {
             runtime: Self::new_dummy_runtime(sample_rate, buffer_size)?,
@@ -2759,6 +2765,9 @@ impl EngineBackend {
             EnginePortModel::Dummy => Self::new_dummy_runtime(self.sample_rate, self.buffer_size)?,
             EnginePortModel::Physical => Self::new_web_audio(self.sample_rate, self.buffer_size)?,
         };
+        staged
+            .session
+            .set_loop_smoothing_ms(self.session.loop_smoothing_ms());
         let source_global = data
             .global_ports
             .first()
@@ -3110,6 +3119,11 @@ fn engine_oxisynth_fx_state(fx: &EngineOxiFx) -> TrackFxState {
 }
 
 impl Backend for EngineBackend {
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()> {
+        self.session.set_loop_smoothing_ms(milliseconds);
+        Ok(())
+    }
+
     fn supports_composite_loops(&self) -> bool {
         true
     }
@@ -3167,6 +3181,9 @@ impl Backend for EngineBackend {
         }
         let mut target =
             EngineBackend::new_dummy_runtime(resolved.sample_rate, resolved.buffer_size)?;
+        target
+            .session
+            .set_loop_smoothing_ms(self.session.loop_smoothing_ms());
         target.external_connections = self.external_connections.clone();
         let (mut replacement, mapping) = target.build_replacement(session)?;
         replacement.processed_frames = self.processed_frames;
@@ -4555,6 +4572,10 @@ impl Backend for EngineBackend {
 }
 
 impl Backend for LocalDummyBackend {
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()> {
+        self.runtime.set_loop_smoothing_ms(milliseconds)
+    }
+
     fn supports_composite_loops(&self) -> bool {
         self.runtime.supports_composite_loops()
     }
@@ -5128,6 +5149,7 @@ pub enum FakeOperation {
     SetLoopLength(BackendLoopId, u32),
     InjectMidiInput(BackendTrackId, Vec<BackendMidiEvent>),
     SetPortConnected(BackendPortId, String, bool),
+    SetLoopSmoothingMs(u32),
 }
 
 impl Default for FakeBackend {
@@ -5189,6 +5211,16 @@ impl Default for FakeBackend {
 impl FakeBackend {
     pub fn operations(&self) -> &[FakeOperation] {
         &self.operations
+    }
+
+    pub fn loop_smoothing_ms(&self) -> Option<u32> {
+        self.operations
+            .iter()
+            .rev()
+            .find_map(|operation| match operation {
+                FakeOperation::SetLoopSmoothingMs(milliseconds) => Some(*milliseconds),
+                _ => None,
+            })
     }
 
     pub fn loop_sync_source(&self, loop_id: BackendLoopId) -> Option<BackendLoopId> {
@@ -5506,6 +5538,12 @@ impl FakeBackend {
 }
 
 impl Backend for FakeBackend {
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()> {
+        self.operations
+            .push(FakeOperation::SetLoopSmoothingMs(milliseconds));
+        Ok(())
+    }
+
     fn supports_composite_loops(&self) -> bool {
         self.composite_loops_supported
     }
@@ -9186,6 +9224,37 @@ mod tests {
         assert_eq!(backend.processed_frames(), 0);
         backend.advance(Duration::from_micros(500));
         assert_eq!(backend.processed_frames(), 1);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn global_loop_smoothing_survives_local_session_and_driver_replacement() {
+        let mut backend = EngineBackend::new_dummy(48_000, 256).unwrap();
+        backend.set_loop_smoothing_ms(7).unwrap();
+        let session = backend.capture_session().unwrap();
+        assert!(!serde_json::to_string(&session).unwrap().contains("smooth"));
+        assert_eq!(backend.loop_smoothing_ms(), 7);
+        backend.replace_session(&session).unwrap();
+        assert_eq!(backend.loop_smoothing_ms(), 7);
+
+        let config = AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: 128,
+        });
+        backend
+            .switch_audio_driver(&config, 48_000, &session)
+            .unwrap();
+        assert_eq!(backend.loop_smoothing_ms(), 7);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn fake_backend_observes_loop_smoothing_requests() {
+        let mut backend = FakeBackend::default();
+        backend.set_loop_smoothing_ms(0).unwrap();
+        backend.set_loop_smoothing_ms(31).unwrap();
+        assert_eq!(backend.loop_smoothing_ms(), Some(31));
+        assert!(backend
+            .operations()
+            .contains(&FakeOperation::SetLoopSmoothingMs(0)));
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -113,6 +113,7 @@ pub struct NativeBackend {
     runtime: Option<NativeRuntime>,
     catalog: Arc<[AudioDriverDescriptor]>,
     fatal_error: Option<String>,
+    loop_smoothing_ms: u32,
 }
 
 struct NativeRuntime {
@@ -244,6 +245,7 @@ impl NativeBackend {
             runtime: Some(runtime),
             catalog,
             fatal_error: None,
+            loop_smoothing_ms: 0,
         })
     }
 
@@ -289,6 +291,9 @@ impl NativeBackend {
         session: &BackendSessionData,
     ) -> Result<(NativeRuntime, BackendSessionReplacement)> {
         let mut runtime = NativeRuntime::start(config)?;
+        runtime
+            .session
+            .set_loop_smoothing_ms(self.loop_smoothing_ms)?;
         if runtime.resolved.sample_rate != session.sample_rate {
             return Err(anyhow!(
                 "resolved target sample rate changed from {} to {}",
@@ -1810,6 +1815,14 @@ impl NativeRuntime {
 }
 
 impl Backend for NativeBackend {
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()> {
+        self.loop_smoothing_ms = milliseconds;
+        self.runtime()?
+            .session
+            .set_loop_smoothing_ms(milliseconds)?;
+        Ok(())
+    }
+
     fn supports_composite_loops(&self) -> bool {
         true
     }
@@ -4145,6 +4158,7 @@ mod tests {
             runtime: Some(runtime),
             catalog: Arc::from([]),
             fatal_error: None,
+            loop_smoothing_ms: 0,
         };
         let created = backend
             .create_direct_track(DirectTrackRequest {
@@ -4181,6 +4195,7 @@ mod tests {
             runtime: Some(runtime),
             catalog: Arc::from([]),
             fatal_error: None,
+            loop_smoothing_ms: 0,
         };
         let created = backend
             .create_direct_track(DirectTrackRequest {
@@ -4368,6 +4383,21 @@ mod tests {
             AudioDriverKind::Dummy
         );
         assert_eq!(preferred.kind(), AudioDriverKind::Jack);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn native_driver_replacement_retains_global_loop_smoothing() {
+        let mut backend = NativeBackend::new(AudioDriverConfig::default()).unwrap();
+        backend.set_loop_smoothing_ms(9).unwrap();
+        let session = backend.capture_session().unwrap();
+        let target = AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: session.sample_rate,
+            buffer_size: 128,
+        });
+        backend
+            .switch_audio_driver(&target, session.sample_rate, &session)
+            .unwrap();
+        assert_eq!(backend.loop_smoothing_ms, 9);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -35,6 +35,7 @@ pub const BUILTIN_SCRIPTS: SettingKey<StringToggleList> =
 pub const USER_SCRIPTS: SettingKey<StringToggleList> = SettingKey::new("scripting.user_scripts");
 pub const CARLA_HOSTING_MODE: SettingKey<String> = SettingKey::new("carla.hosting_mode");
 
+pub const LOOP_EDGE_SMOOTHING_MS: SettingKey<u32> = SettingKey::new("audio.loop_edge_smoothing_ms");
 pub const SELECTED_AUDIO_DRIVER: SettingKey<String> = SettingKey::new("audio.selected_driver");
 pub const DUMMY_SAMPLE_RATE: SettingKey<u32> = SettingKey::new("audio.dummy.sample_rate");
 pub const DUMMY_BUFFER_SIZE: SettingKey<u32> = SettingKey::new("audio.dummy.buffer_size");
@@ -128,6 +129,19 @@ pub fn register_audio_settings(
     builder: &mut SettingsRegistryBuilder,
 ) -> Result<(), SettingsRegistryError> {
     let effect = SettingEffect::ExplicitApply;
+    builder.register(
+        SettingDefinition::new(
+            LOOP_EDGE_SMOOTHING_MS,
+            3,
+            "Audio",
+            "Loop edge smoothing",
+            "Duration in milliseconds for smoothing loop playback discontinuities; 0 disables smoothing.",
+        )
+        .category_order(5)
+        .setting_order(0)
+        .effect(effect)
+        .editor(SettingEditor::UnsignedInteger { min: 0, max: 100 }),
+    )?;
     builder.register(
         SettingDefinition::new(
             SELECTED_AUDIO_DRIVER,
@@ -348,6 +362,12 @@ pub fn carla_hosting_mode_from_snapshot(
         .map_err(|error| error.to_string())?
         .parse()
         .map_err(|error: shoop_settings::CarlaHostingModeParseError| error.to_string())
+}
+
+pub fn loop_edge_smoothing_ms(snapshot: &SettingsSnapshot) -> Result<u32, String> {
+    snapshot
+        .get(LOOP_EDGE_SMOOTHING_MS)
+        .map_err(|error| error.to_string())
 }
 
 pub fn selected_audio_driver(snapshot: &SettingsSnapshot) -> Result<AudioDriverKind, String> {
@@ -2594,6 +2614,13 @@ mod tests {
         register_audio_settings(&mut builder).unwrap();
         let registry = builder.finish();
         let snapshot = registry.defaults(7);
+        assert_eq!(loop_edge_smoothing_ms(&snapshot).unwrap(), 3);
+        let smoothing = registry.definition(LOOP_EDGE_SMOOTHING_MS.id()).unwrap();
+        assert_eq!(
+            smoothing.editor(),
+            &SettingEditor::UnsignedInteger { min: 0, max: 100 }
+        );
+        assert!(smoothing.help().contains("0 disables"));
         assert_eq!(
             selected_audio_driver(&snapshot).unwrap(),
             AudioDriverKind::Dummy

--- a/src/rust/shoop_egui/src/lib.rs
+++ b/src/rust/shoop_egui/src/lib.rs
@@ -30,16 +30,17 @@ mod waveform_widget;
 
 pub use app_widget::{
     audio_driver_config_from_draft, audio_driver_config_from_snapshot,
-    carla_hosting_mode_from_snapshot, default_builtins_location, register_audio_settings,
-    register_bundled_script_settings, register_carla_settings, register_script_settings,
-    register_settings, register_settings_with_appearance_defaults,
+    carla_hosting_mode_from_snapshot, default_builtins_location, loop_edge_smoothing_ms,
+    register_audio_settings, register_bundled_script_settings, register_carla_settings,
+    register_script_settings, register_settings, register_settings_with_appearance_defaults,
     register_settings_with_ui_scale_default, selected_audio_driver, set_selected_audio_driver,
     AppWidget, AppWidgetResponse, APC_MINI_SCRIPT_ENABLED, BUILTINS_LOCATION, BUILTIN_SCRIPTS,
     CARLA_HOSTING_MODE, CPAL_BUFFER_SIZE, CPAL_CAPTURE_RING_FRAMES, CPAL_CLIENT_NAME, CPAL_HOST,
     CPAL_INPUT_CHANNELS, CPAL_INPUT_DEVICE, CPAL_MIDI_INPUTS, CPAL_MIDI_OUTPUTS,
     CPAL_OUTPUT_CHANNELS, CPAL_OUTPUT_DEVICE, CPAL_SAMPLE_RATE, DEFAULT_NEW_TRACK_AUDIO_CHANNELS,
     DEFAULT_NEW_TRACK_MIDI, DUMMY_BUFFER_SIZE, DUMMY_SAMPLE_RATE, JACK_CLIENT_NAME,
-    KEYBOARD_SCRIPT_ENABLED, SELECTED_AUDIO_DRIVER, TOUCH_MODE, UI_SCALE_FACTOR, USER_SCRIPTS,
+    KEYBOARD_SCRIPT_ENABLED, LOOP_EDGE_SMOOTHING_MS, SELECTED_AUDIO_DRIVER, TOUCH_MODE,
+    UI_SCALE_FACTOR, USER_SCRIPTS,
 };
 pub use composite_loop_widget::CompositeLoopWidget;
 pub use connection_dialog::{ConnectionDialog, ConnectionScope};

--- a/src/rust/shoop_egui/src/settings_dialog.rs
+++ b/src/rust/shoop_egui/src/settings_dialog.rs
@@ -605,6 +605,18 @@ impl SettingsDialog {
         audio: &AudioDriverRuntimeState,
         response: &mut SettingsDialogResponse,
     ) {
+        #[cfg(test)]
+        self.setting_card_rects.clear();
+        ui.heading("Loop audio");
+        let definitions = self
+            .registry
+            .definitions()
+            .iter()
+            .filter(|definition| definition.key() == crate::LOOP_EDGE_SMOOTHING_MS.id())
+            .cloned()
+            .collect::<Vec<_>>();
+        self.show_definition_cards(ui, definitions, None);
+
         if !audio.supported || cfg!(target_arch = "wasm32") {
             #[cfg(target_arch = "wasm32")]
             {
@@ -791,8 +803,6 @@ impl SettingsDialog {
         definitions: Vec<shoop_settings::ErasedSettingDefinition>,
         audio: Option<&crate::AudioDriverDescriptor>,
     ) {
-        #[cfg(test)]
-        self.setting_card_rects.clear();
         for definition in definitions {
             let card = egui::Frame::group(ui.style()).inner_margin(egui::Margin::same(8));
             let margin = card.total_margin();
@@ -1847,6 +1857,30 @@ mod tests {
             assert!(!output.shapes.is_empty());
         }
         assert_eq!(dialog.audio_target, Some(AudioDriverKind::Dummy));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn generic_loop_audio_setting_is_visible_without_driver_switching() {
+        let mut builder = SettingsRegistryBuilder::default();
+        crate::register_audio_settings(&mut builder).unwrap();
+        let registry = Arc::new(builder.finish());
+        let state = SettingsViewState {
+            active: Arc::new(registry.defaults(1)),
+            diagnostics: Arc::from([]),
+            storage_location: "fixture".to_owned(),
+            recovery_required: false,
+            persistence: SettingsPersistenceState::Idle,
+        };
+        let mut dialog = SettingsDialog::new(registry);
+        dialog.open(&state);
+        let context = egui::Context::default();
+        let mut response = SettingsDialogResponse::default();
+        let mut output = context.run_ui(Default::default(), |ui| {
+            dialog.show_audio(ui, &AudioDriverRuntimeState::default(), &mut response);
+        });
+        output.textures_delta.clear();
+        assert_eq!(dialog.setting_card_rects.len(), 1);
+        assert!(response.app_actions.is_empty());
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -2763,6 +2763,15 @@ impl BackendSession {
         })?)
     }
 
+    pub fn set_loop_smoothing_ms(
+        &self,
+        milliseconds: u32,
+    ) -> std::result::Result<CommandSequence, SendError> {
+        self.shared.send_control(move |session| {
+            session.set_loop_smoothing_ms(milliseconds);
+        })
+    }
+
     pub fn register_external_processor(
         &self,
         title: &str,
@@ -6559,6 +6568,22 @@ mod tests {
         sess.shared
             .query_for_test(|s: &mut engine::Session| s.graph_up_to_date())
             .expect("engine answered")
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_control_applies_at_a_command_boundary_without_graph_change() {
+        let sess = BackendSession::new().expect("session");
+        let graph_before = sess
+            .shared
+            .query_for_test(|session| session.graph_request_id())
+            .unwrap();
+        sess.set_loop_smoothing_ms(12).unwrap();
+        let (milliseconds, graph_after) = sess
+            .shared
+            .query_for_test(|session| (session.loop_smoothing_ms(), session.graph_request_id()))
+            .unwrap();
+        assert_eq!(milliseconds, 12);
+        assert_eq!(graph_after, graph_before);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/src/audio_channel.rs
+++ b/src/rust/shoop_engine/src/audio_channel.rs
@@ -18,6 +18,82 @@ use crate::state_mirror::AudioChannelStateMirror;
 /// The session processes no more than 16 sub-blocks in one callback.
 const COPY_COMMAND_CAPACITY: usize = 32;
 
+#[derive(Debug)]
+struct PlaybackSmoother {
+    duration_frames: usize,
+    raw_active: bool,
+    expected_source: Option<usize>,
+    previous_gain: f32,
+    previous_rendered: f32,
+    correction: f32,
+    correction_step: f32,
+    correction_frames_left: usize,
+}
+
+impl Default for PlaybackSmoother {
+    fn default() -> Self {
+        Self {
+            duration_frames: 0,
+            raw_active: false,
+            expected_source: None,
+            previous_gain: 1.0,
+            previous_rendered: 0.0,
+            correction: 0.0,
+            correction_step: 0.0,
+            correction_frames_left: 0,
+        }
+    }
+}
+
+impl PlaybackSmoother {
+    fn set_duration_frames(&mut self, frames: usize) {
+        self.duration_frames = frames;
+    }
+
+    fn is_bypassed(&self) -> bool {
+        self.duration_frames == 0 && self.correction_frames_left == 0
+    }
+
+    fn observe_range(&mut self, active: bool, source: usize, gain: f32, raw_last: f32, len: usize) {
+        if len == 0 {
+            return;
+        }
+        self.raw_active = active;
+        self.expected_source = active.then(|| source.saturating_add(len));
+        self.previous_gain = gain;
+        self.previous_rendered = raw_last;
+    }
+
+    fn render(&mut self, raw: f32, active: bool, source: usize, gain: f32) -> f32 {
+        let is_edge = active != self.raw_active
+            || (active
+                && (self.expected_source != Some(source)
+                    || self.previous_gain.to_bits() != gain.to_bits()));
+        if is_edge && self.duration_frames > 0 {
+            self.correction = self.previous_rendered - raw;
+            self.correction_step = self.correction / self.duration_frames as f32;
+            self.correction_frames_left = self.duration_frames;
+        }
+
+        let rendered = raw + self.correction;
+        if self.correction_frames_left > 0 {
+            self.correction_frames_left -= 1;
+            if self.correction_frames_left == 0 {
+                self.correction = 0.0;
+                self.correction_step = 0.0;
+            } else {
+                self.correction -= self.correction_step;
+            }
+        }
+
+        self.raw_active = active;
+        self.expected_source = active.then(|| source.saturating_add(1));
+        self.previous_gain = gain;
+        self.previous_rendered = rendered;
+        rendered
+    }
+}
+
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -159,6 +235,7 @@ pub struct AudioChannel {
     publish_snapshot_updates: bool,
     storage_capacity: Option<usize>,
     storage_exhaustions: u32,
+    playback_smoother: PlaybackSmoother,
 }
 
 impl AudioChannel {
@@ -229,6 +306,7 @@ impl AudioChannel {
             publish_snapshot_updates: true,
             storage_capacity: None,
             storage_exhaustions: 0,
+            playback_smoother: PlaybackSmoother::default(),
         };
         channel.publish_state();
         channel
@@ -323,6 +401,12 @@ impl AudioChannel {
     }
     pub fn reset_output_peak(&mut self) {
         self.output_peak = 0.0;
+    }
+    pub fn set_loop_smoothing_frames(&mut self, frames: usize) {
+        self.playback_smoother.set_duration_frames(frames);
+    }
+    pub fn loop_smoothing_frames(&self) -> usize {
+        self.playback_smoother.duration_frames
     }
     pub fn data_seq_nr(&self) -> u32 {
         self.data_seq_nr
@@ -822,8 +906,14 @@ impl AudioChannel {
     /// `record_src` and `playback_dst` are the whole cycle's port buffers, as
     /// handed to `set_*_buffer_size`; queued offsets index into them.
     pub fn finalize_process(&mut self, record_src: &[f32], playback_dst: &mut [f32]) {
+        if self.playback_smoother.is_bypassed() {
+            self.finalize_process_bypassed(record_src, playback_dst);
+            return;
+        }
+
         let mut peak = self.output_peak;
         let mut published_peak = 0.0f32;
+        let mut timeline_cursor = 0;
         for cmd in self.queue.drain(..) {
             match cmd {
                 CopyCmd::IntoMain { dst, src, len } => {
@@ -851,6 +941,79 @@ impl AudioChannel {
                     len,
                     gain,
                 } => {
+                    for at in timeline_cursor..dst.min(playback_dst.len()) {
+                        let rendered = self.playback_smoother.render(0.0, false, 0, 1.0);
+                        let sample = playback_dst[at] + rendered;
+                        playback_dst[at] = sample;
+                        peak = peak.max(sample.abs());
+                        published_peak = published_peak.max(sample.abs());
+                    }
+                    if let Some(from) = self.buffers.chunk_slice(src) {
+                        for i in 0..len {
+                            let raw = from[i] * gain;
+                            let rendered = self.playback_smoother.render(raw, true, src + i, gain);
+                            let sample = playback_dst[dst + i] + rendered;
+                            playback_dst[dst + i] = sample;
+                            peak = peak.max(sample.abs());
+                            published_peak = published_peak.max(sample.abs());
+                        }
+                    }
+                    timeline_cursor = dst.saturating_add(len);
+                }
+            }
+        }
+        for at in timeline_cursor..playback_dst.len() {
+            let rendered = self.playback_smoother.render(0.0, false, 0, 1.0);
+            let sample = playback_dst[at] + rendered;
+            playback_dst[at] = sample;
+            peak = peak.max(sample.abs());
+            published_peak = published_peak.max(sample.abs());
+        }
+        self.output_peak = peak;
+        self.state.publish_output_peak(published_peak);
+        self.publish_state();
+    }
+
+    fn finalize_process_bypassed(&mut self, record_src: &[f32], playback_dst: &mut [f32]) {
+        let mut peak = self.output_peak;
+        let mut published_peak = 0.0f32;
+        let mut timeline_cursor = 0;
+        for cmd in self.queue.drain(..) {
+            match cmd {
+                CopyCmd::IntoMain { dst, src, len } => {
+                    let source = &record_src[src..src + len];
+                    copy_in(&mut self.buffers, dst, source);
+                    if let Some(snapshots) = self.content_snapshots.as_mut() {
+                        snapshots.publish_range(
+                            dst,
+                            source,
+                            self.data_length,
+                            self.publish_snapshot_updates,
+                        );
+                    }
+                }
+                CopyCmd::IntoPreRecord { dst, src, len } => {
+                    let source = &record_src[src..src + len];
+                    copy_in(&mut self.prerecord_buffers, dst, source);
+                    if let Some(snapshots) = self.content_snapshots.as_mut() {
+                        snapshots.publish_prerecord_range(dst, source, self.prerecord_data_length);
+                    }
+                }
+                CopyCmd::OutOfMain {
+                    src,
+                    dst,
+                    len,
+                    gain,
+                } => {
+                    if dst > timeline_cursor {
+                        self.playback_smoother.observe_range(
+                            false,
+                            0,
+                            1.0,
+                            0.0,
+                            dst - timeline_cursor,
+                        );
+                    }
                     if let Some(from) = self.buffers.chunk_slice(src) {
                         for i in 0..len {
                             let sample = playback_dst[dst + i] + from[i] * gain;
@@ -858,9 +1021,26 @@ impl AudioChannel {
                             peak = peak.max(sample.abs());
                             published_peak = published_peak.max(sample.abs());
                         }
+                        self.playback_smoother.observe_range(
+                            true,
+                            src,
+                            gain,
+                            from[len - 1] * gain,
+                            len,
+                        );
                     }
+                    timeline_cursor = dst.saturating_add(len);
                 }
             }
+        }
+        if playback_dst.len() > timeline_cursor {
+            self.playback_smoother.observe_range(
+                false,
+                0,
+                1.0,
+                0.0,
+                playback_dst.len() - timeline_cursor,
+            );
         }
         self.output_peak = peak;
         self.state.publish_output_peak(published_peak);
@@ -1204,5 +1384,157 @@ mod tests {
         check!(ch.played_back_sample() == Some(0));
         cycle(&mut ch, L::Stopped, 2, 0, 2, &[]);
         check!(ch.played_back_sample() == None);
+    }
+
+    fn playback_subblocks(ch: &mut AudioChannel, blocks: &[(usize, i32)]) -> Vec<f32> {
+        let total = blocks.iter().map(|(len, _)| *len).sum();
+        ch.set_recording_buffer_size(total);
+        ch.set_playback_buffer_size(total);
+        for (len, position) in blocks {
+            assert2::assert!(let Ok(()) = ch.process(
+                L::Playing,
+                L::Unknown,
+                None,
+                None,
+                *len,
+                *position,
+                ch.length(),
+            ));
+        }
+        let mut output = vec![0.0; total];
+        ch.finalize_process(&vec![0.0; total], &mut output);
+        output
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_fades_from_silence_at_start() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 8]);
+        ch.set_loop_smoothing_frames(4);
+        let output = cycle(&mut ch, L::Playing, 5, 0, 8, &[]);
+        check!(output == vec![0.0, 0.25, 0.5, 0.75, 1.0]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_emits_a_bounded_stop_tail_without_reading_content() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 8]);
+        ch.set_loop_smoothing_frames(4);
+        cycle(&mut ch, L::Playing, 8, 0, 8, &[]);
+        let output = cycle(&mut ch, L::Stopped, 6, 0, 8, &[]);
+        check!(output == vec![1.0, 0.75, 0.5, 0.25, 0.0, 0.0]);
+        check!(ch.played_back_sample() == None);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_handles_wraps_within_and_between_callbacks() {
+        let mut boundary = channel();
+        boundary.load_data(&[-1.0, -1.0, 1.0, 1.0]);
+        playback_subblocks(&mut boundary, &[(2, 2)]);
+        boundary.set_loop_smoothing_frames(4);
+        let boundary_wrap = playback_subblocks(&mut boundary, &[(2, 0)]);
+        check!(boundary_wrap == vec![1.0, 0.5]);
+
+        let mut within = channel();
+        within.load_data(&[-1.0, -1.0, 1.0, 1.0]);
+        playback_subblocks(&mut within, &[(2, 0)]);
+        within.set_loop_smoothing_frames(4);
+        let within_callback_wrap = playback_subblocks(&mut within, &[(2, 2), (2, 0)]);
+        check!(within_callback_wrap == vec![1.0, 1.0, 1.0, 0.5]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_handles_seeks_and_gain_changes() {
+        let mut ch = channel();
+        ch.load_data(&[-1.0, -1.0, 1.0, 1.0]);
+        playback_subblocks(&mut ch, &[(2, 2)]);
+        ch.set_loop_smoothing_frames(2);
+
+        let seek = playback_subblocks(&mut ch, &[(2, 0)]);
+        check!(seek == vec![1.0, 0.0]);
+        ch.set_gain(0.5);
+        let gain_change = playback_subblocks(&mut ch, &[(2, 2)]);
+        check!(gain_change == vec![0.0, 0.25]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_restarts_continuously_for_short_repeated_loops() {
+        let mut ch = channel();
+        ch.load_data(&[1.0, -1.0]);
+        ch.set_loop_smoothing_frames(4);
+        let output = playback_subblocks(&mut ch, &[(1, 0), (1, 0), (1, 1), (1, 0)]);
+        check!(output == vec![0.0, 0.0, -1.75, -1.75]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_continues_into_silence_after_content_ends() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 4]);
+        ch.set_loop_smoothing_frames(2);
+        let output = cycle(&mut ch, L::Playing, 7, 0, 8, &[]);
+        check!(output == vec![0.0, 0.5, 1.0, 1.0, 1.0, 0.5, 0.0]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_changes_only_the_channel_contribution() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 4]);
+        ch.set_loop_smoothing_frames(2);
+        ch.set_recording_buffer_size(4);
+        ch.set_playback_buffer_size(4);
+        assert2::assert!(let Ok(()) = ch.process(L::Playing, L::Unknown, None, None, 4, 0, 4));
+        let mut output = vec![10.0; 4];
+        ch.finalize_process(&[0.0; 4], &mut output);
+        check!(output == vec![10.0, 10.5, 11.0, 11.0]);
+        check!(ch.output_peak() == 11.0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_does_not_mark_chunk_or_callback_continuity_as_an_edge() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 12]);
+        ch.set_loop_smoothing_frames(4);
+        let across_chunk = cycle(&mut ch, L::Playing, 8, 0, 12, &[]);
+        check!(across_chunk == vec![0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0]);
+        let across_callback = cycle(&mut ch, L::Playing, 4, 8, 12, &[]);
+        check!(across_callback == vec![1.0; 4]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn smoothing_duration_changes_apply_to_later_edges() {
+        let mut ch = channel();
+        ch.load_data(&[1.0, 1.0, 1.0, 1.0, 1.0, -1.0, -1.0]);
+        ch.set_loop_smoothing_frames(4);
+        cycle(&mut ch, L::Playing, 4, 0, 7, &[]);
+        ch.set_loop_smoothing_frames(2);
+        let output = cycle(&mut ch, L::Playing, 2, 5, 7, &[]);
+        check!(output == vec![0.75, -0.125]);
+        check!(ch.loop_smoothing_frames() == 2);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn zero_duration_is_exact_additive_copy_and_primes_continuity() {
+        let mut ch = channel();
+        ch.load_data(&[1.0, -2.0, 3.0, -4.0]);
+        ch.set_gain(0.5);
+        let output = cycle(&mut ch, L::Playing, 4, 0, 4, &[]);
+        check!(output == vec![0.5, -1.0, 1.5, -2.0]);
+
+        ch.set_loop_smoothing_frames(3);
+        ch.load_data(&[-4.0, -4.0, -4.0]);
+        let discontinuity = cycle(&mut ch, L::Playing, 3, 0, 3, &[]);
+        check!(discontinuity[0] == -2.0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn disabling_smoothing_allows_the_current_correction_to_finish() {
+        let mut ch = channel();
+        ch.load_data(&[1.0; 8]);
+        ch.set_loop_smoothing_frames(4);
+        let first = cycle(&mut ch, L::Playing, 2, 0, 8, &[]);
+        check!(first == vec![0.0, 0.25]);
+        ch.set_loop_smoothing_frames(0);
+        let rest = cycle(&mut ch, L::Playing, 3, 2, 8, &[]);
+        check!(rest == vec![0.5, 0.75, 1.0]);
     }
 }

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -363,6 +363,7 @@ pub struct Session {
 
     sample_rate: u32,
     buffer_size: u32,
+    loop_smoothing_ms: u32,
 
     /// Reused so routing a channel's input does not allocate per cycle.
     scratch: Vec<f32>,
@@ -598,11 +599,45 @@ fn adoption_window(
 }
 
 impl Session {
+    fn loop_smoothing_frames_for(sample_rate: u32, milliseconds: u32) -> usize {
+        if milliseconds == 0 {
+            return 0;
+        }
+        let frames = u64::from(milliseconds).saturating_mul(u64::from(sample_rate)) / 1_000;
+        usize::try_from(frames).unwrap_or(usize::MAX).max(1)
+    }
+
+    fn loop_smoothing_frames(&self) -> usize {
+        Self::loop_smoothing_frames_for(self.sample_rate, self.loop_smoothing_ms)
+    }
+
     pub fn sample_rate(&self) -> u32 {
         self.sample_rate
     }
     pub fn set_sample_rate(&mut self, sr: u32) {
         self.sample_rate = sr;
+        let frames = self.loop_smoothing_frames();
+        for loop_ in &mut self.loops {
+            for channel_idx in 0..loop_.n_audio_channels() {
+                if let Some(channel) = loop_.audio_channel_mut(channel_idx) {
+                    channel.set_loop_smoothing_frames(frames);
+                }
+            }
+        }
+    }
+    pub fn loop_smoothing_ms(&self) -> u32 {
+        self.loop_smoothing_ms
+    }
+    pub fn set_loop_smoothing_ms(&mut self, milliseconds: u32) {
+        self.loop_smoothing_ms = milliseconds;
+        let frames = self.loop_smoothing_frames();
+        for loop_ in &mut self.loops {
+            for channel_idx in 0..loop_.n_audio_channels() {
+                if let Some(channel) = loop_.audio_channel_mut(channel_idx) {
+                    channel.set_loop_smoothing_frames(frames);
+                }
+            }
+        }
     }
     pub fn buffer_size(&self) -> u32 {
         self.buffer_size
@@ -1105,11 +1140,16 @@ impl Session {
         capacity: usize,
         mode: ChannelMode,
     ) -> Result<usize, SessionError> {
+        let smoothing_frames = self.loop_smoothing_frames();
         let loop_ = self
             .loops
             .get_mut(loop_idx)
             .ok_or(SessionError::NoSuchLoop(loop_idx))?;
         let channel_idx = loop_.add_audio_channel_with_bounded_capacity(chunk_size, capacity, mode);
+        loop_
+            .audio_channel_mut(channel_idx)
+            .expect("new audio channel exists")
+            .set_loop_smoothing_frames(smoothing_frames);
         self.channels.push(ChannelMapping {
             loop_idx,
             kind: ChannelKind::Audio,
@@ -1128,12 +1168,17 @@ impl Session {
         capacity: usize,
         mode: ChannelMode,
     ) -> Result<usize, SessionError> {
+        let smoothing_frames = self.loop_smoothing_frames();
         let loop_ = self
             .loops
             .get_mut(loop_idx)
             .ok_or(SessionError::NoSuchLoop(loop_idx))?;
         let channel_idx =
             loop_.add_audio_channel_with_bounded_capacity_unprepared(chunk_size, capacity, mode);
+        loop_
+            .audio_channel_mut(channel_idx)
+            .expect("new audio channel exists")
+            .set_loop_smoothing_frames(smoothing_frames);
         self.channels.push(ChannelMapping {
             loop_idx,
             kind: ChannelKind::Audio,
@@ -1153,12 +1198,16 @@ impl Session {
         state: Arc<AudioChannelStateMirror>,
         snapshots: Option<crate::content_snapshot::AudioProcessSnapshotWriter>,
     ) -> Result<usize, SessionError> {
+        let smoothing_frames = self.loop_smoothing_frames();
         let l = self
             .loops
             .get_mut(loop_idx)
             .ok_or(SessionError::NoSuchLoop(loop_idx))?;
         let channel_idx =
             l.add_audio_channel_with_state_and_snapshots(chunk_size, mode, state, snapshots);
+        l.audio_channel_mut(channel_idx)
+            .expect("new audio channel exists")
+            .set_loop_smoothing_frames(smoothing_frames);
         self.channels.push(ChannelMapping {
             loop_idx,
             kind: ChannelKind::Audio,
@@ -3475,6 +3524,78 @@ mod tests {
         check!(samples == vec![1.0, 2.0, 3.0, 4.0]);
     }
 
+    #[shoop_wasm_test_support::shoop_test]
+    fn discontinuous_loop_smoothing_is_deterministic_end_to_end() {
+        fn fixture(milliseconds: u32) -> (Session, usize, usize) {
+            let mut session = Session::default();
+            session.set_sample_rate(1_000);
+            session.set_loop_smoothing_ms(milliseconds);
+            let output = session.add_port(dummy(2, "out", PortDirection::Output));
+            let loop_ = session.create_loop();
+            let channel = session
+                .add_audio_channel(loop_, 2, ChannelMode::Direct)
+                .unwrap();
+            session.connect_channel_output(channel, output).unwrap();
+            session
+                .loop_mut(loop_)
+                .unwrap()
+                .audio_channel_mut(0)
+                .unwrap()
+                .load_data(&[1.0, 1.0, -1.0, -1.0]);
+            session.loop_mut(loop_).unwrap().set_length(4);
+            session.apply_graph_changes().unwrap();
+            (session, loop_, output)
+        }
+
+        fn render(session: &mut Session, output: usize, frames: usize) -> Vec<f32> {
+            session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .request_data(frames);
+            session.process(frames);
+            session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .dequeue_data(frames)
+                .unwrap()
+        }
+
+        let (mut exact, exact_loop, exact_output) = fixture(0);
+        exact.set_loop_mode(exact_loop, LoopMode::Playing).unwrap();
+        assert_eq!(
+            render(&mut exact, exact_output, 6),
+            vec![1.0, 1.0, -1.0, -1.0, 1.0, 1.0]
+        );
+
+        let (mut smooth, smooth_loop, smooth_output) = fixture(3);
+        smooth
+            .set_loop_mode(smooth_loop, LoopMode::Playing)
+            .unwrap();
+        let playing = render(&mut smooth, smooth_output, 6);
+        let expected = [0.0, 1.0 / 3.0, -4.0 / 3.0, -1.0, -1.0, -1.0 / 3.0];
+        for (actual, expected) in playing.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-6, "{playing:?}");
+        }
+        smooth
+            .set_loop_mode(smooth_loop, LoopMode::Stopped)
+            .unwrap();
+        let stopped = render(&mut smooth, smooth_output, 4);
+        assert!((stopped[0] - playing[5]).abs() < 1.0e-6);
+        assert!(stopped[3].abs() < 1.0e-6);
+
+        let (mut longer, longer_loop, longer_output) = fixture(5);
+        longer
+            .set_loop_mode(longer_loop, LoopMode::Playing)
+            .unwrap();
+        let longer = render(&mut longer, longer_output, 6);
+        assert_ne!(longer, playing);
+        assert_eq!(longer[0], 0.0);
+    }
+
     fn test_processor_session(monitored: bool) -> (Session, usize, usize) {
         let mut session = Session::default();
         session.set_buffer_size(4);
@@ -5144,6 +5265,83 @@ mod tests {
         s.set_buffer_size(256);
         check!(s.sample_rate() == 48000);
         check!(s.buffer_size() == 256);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_reaches_existing_and_future_channel_creation_paths() {
+        let mut session = Session::default();
+        session.set_sample_rate(48_000);
+        let loop_ = session.create_loop();
+        let direct = session
+            .add_audio_channel(loop_, 4, ChannelMode::Direct)
+            .unwrap();
+        let bounded = session
+            .add_audio_channel_with_bounded_capacity(loop_, 4, 16, ChannelMode::Direct)
+            .unwrap();
+        let unprepared = session
+            .add_audio_channel_with_bounded_capacity_unprepared(loop_, 4, 16, ChannelMode::Direct)
+            .unwrap();
+
+        let graph_request = session.graph_request_id();
+        session.set_loop_smoothing_ms(3);
+        check!(session.loop_smoothing_ms() == 3);
+        check!(session.graph_request_id() == graph_request);
+        for channel in [direct, bounded, unprepared] {
+            check!(
+                session
+                    .audio_channel(channel)
+                    .unwrap()
+                    .loop_smoothing_frames()
+                    == 144
+            );
+        }
+
+        let state = Arc::new(AudioChannelStateMirror::default());
+        let future = session
+            .add_audio_channel_with_state(loop_, 4, ChannelMode::Direct, state)
+            .unwrap();
+        check!(
+            session
+                .audio_channel(future)
+                .unwrap()
+                .loop_smoothing_frames()
+                == 144
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_handles_zero_low_rates_and_sample_rate_changes() {
+        let mut session = Session::default();
+        session.set_sample_rate(100);
+        session.set_loop_smoothing_ms(3);
+        let loop_ = session.create_loop();
+        let channel = session
+            .add_audio_channel(loop_, 4, ChannelMode::Direct)
+            .unwrap();
+        check!(
+            session
+                .audio_channel(channel)
+                .unwrap()
+                .loop_smoothing_frames()
+                == 1
+        );
+
+        session.set_sample_rate(44_100);
+        check!(
+            session
+                .audio_channel(channel)
+                .unwrap()
+                .loop_smoothing_frames()
+                == 132
+        );
+        session.set_loop_smoothing_ms(0);
+        check!(
+            session
+                .audio_channel(channel)
+                .unwrap()
+                .loop_smoothing_frames()
+                == 0
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/tests/no_alloc.rs
+++ b/src/rust/shoop_engine/tests/no_alloc.rs
@@ -912,6 +912,8 @@ fn recording_audio_does_not_allocate() {
 )]
 fn playing_audio_does_not_allocate() {
     let mut s = Session::default();
+    s.set_sample_rate(48_000);
+    s.set_loop_smoothing_ms(3);
     let output = s.add_port(audio_port(1, "out", PortDirection::Output));
     let l = s.create_loop();
     let c = s.add_audio_channel(l, 64, ChannelMode::Direct).unwrap();

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -1059,6 +1059,7 @@ fn browser_oxisynth_port_descriptors(
 
 fn command_mutation_identity(command: &Command) -> Option<(BackendMutationKind, Option<u64>)> {
     Some(match command {
+        Command::SetLoopSmoothingMs { .. } => (BackendMutationKind::AudioProcessing, None),
         Command::ConfigureDeviceChannels { .. } | Command::ConfigureMidiEndpoints { .. } => {
             (BackendMutationKind::DriverConfiguration, None)
         }
@@ -1237,6 +1238,10 @@ fn transfer_identity(command: &Command) -> Option<(BackendOperationKind, u64)> {
 }
 
 impl Backend for RemoteWorkletBackend {
+    fn set_loop_smoothing_ms(&mut self, milliseconds: u32) -> Result<()> {
+        self.submit(Command::SetLoopSmoothingMs { milliseconds })
+    }
+
     fn supports_composite_loops(&self) -> bool {
         true
     }
@@ -2460,6 +2465,36 @@ mod tests {
                 .unwrap(),
             )
             .unwrap();
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn remote_loop_smoothing_control_is_durable_and_globally_classified() {
+        let (mut backend, control) = RemoteWorkletBackend::new(NullHostMidiBridge);
+        backend.set_loop_smoothing_ms(0).unwrap();
+        backend.set_loop_smoothing_ms(19).unwrap();
+        let endpoint = MemoryEndpoint::default();
+        let sent = endpoint.sent.clone();
+        control.attach(Box::new(endpoint), 3, 0, 2).unwrap();
+        let commands = sent
+            .borrow()
+            .iter()
+            .map(|message| {
+                serde_json::from_str::<CommandEnvelope>(message)
+                    .unwrap()
+                    .command
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| matches!(command, Command::SetLoopSmoothingMs { .. }))
+                .collect::<Vec<_>>(),
+            vec![&Command::SetLoopSmoothingMs { milliseconds: 19 }]
+        );
+        assert_eq!(
+            command_mutation_identity(&Command::SetLoopSmoothingMs { milliseconds: 19 }),
+            Some((BackendMutationKind::AudioProcessing, None))
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_worklet_client/src/transport.rs
+++ b/src/rust/shoop_worklet_client/src/transport.rs
@@ -573,6 +573,41 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_journal_replays_only_the_latest_value() {
+        let (transport, control) = transport_pair();
+        transport
+            .borrow_mut()
+            .journal(Command::SetLoopSmoothingMs { milliseconds: 0 })
+            .unwrap();
+        transport
+            .borrow_mut()
+            .journal(Command::SetLoopSmoothingMs { milliseconds: 17 })
+            .unwrap();
+        let endpoint = MemoryEndpoint::default();
+        let sent = endpoint.sent.clone();
+        control.attach(Box::new(endpoint), 1, 0, 2).unwrap();
+        let commands = sent
+            .borrow()
+            .iter()
+            .map(|json| {
+                serde_json::from_str::<CommandEnvelope>(json)
+                    .unwrap()
+                    .command
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            commands,
+            vec![
+                Command::ConfigureDeviceChannels {
+                    input_channels: 0,
+                    output_channels: 2,
+                },
+                Command::SetLoopSmoothingMs { milliseconds: 17 },
+            ]
+        );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn response_validation_rejects_stale_unknown_duplicate_and_out_of_order_events() {
         let (_, stale) = transport_pair();
         stale

--- a/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
+++ b/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
@@ -10,7 +10,7 @@ if (WebAssembly.Module.imports(module).length !== 0) {
 const host = new ShoopRawWasmHost(module, 48000, 2048, 262144);
 const poll = JSON.stringify({ version: 13, sequence: 1, command: { kind: 'poll' } });
 const first = JSON.parse(host.command(poll));
-if (first.version !== 13 || first.sequence !== 1 || first.event?.kind !== 'snapshot') {
+if (first.version !== 14 || first.sequence !== 1 || first.event?.kind !== 'snapshot') {
   throw new Error(`unexpected raw host response: ${JSON.stringify(first)}`);
 }
 const malformed = JSON.parse(host.command('{'));

--- a/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
+++ b/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
@@ -7,10 +7,11 @@ const module = await WebAssembly.compile(bytes);
 if (WebAssembly.Module.imports(module).length !== 0) {
   throw new Error('raw host contract requires an import-free Wasm artifact');
 }
+const protocolVersion = 14;
 const host = new ShoopRawWasmHost(module, 48000, 2048, 262144);
-const poll = JSON.stringify({ version: 13, sequence: 1, command: { kind: 'poll' } });
+const poll = JSON.stringify({ version: protocolVersion, sequence: 1, command: { kind: 'poll' } });
 const first = JSON.parse(host.command(poll));
-if (first.version !== 14 || first.sequence !== 1 || first.event?.kind !== 'snapshot') {
+if (first.version !== protocolVersion || first.sequence !== 1 || first.event?.kind !== 'snapshot') {
   throw new Error(`unexpected raw host response: ${JSON.stringify(first)}`);
 }
 const malformed = JSON.parse(host.command('{'));
@@ -24,7 +25,7 @@ try {
 if (!capacityRejected) throw new Error('oversized raw host command was not rejected');
 host.process([], [], 128);
 host.exports.memory.grow(1);
-host.command(JSON.stringify({ version: 13, sequence: 2, command: { kind: 'poll' } }));
+host.command(JSON.stringify({ version: protocolVersion, sequence: 2, command: { kind: 'poll' } }));
 if (host.diagnostics().memoryGrowths < 1) throw new Error('memory growth was not diagnosed');
 host.destroy();
 host.destroy();

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -40,10 +40,10 @@ use shoop_egui::register_script_settings;
 #[cfg(all(test, not(target_arch = "wasm32")))]
 use shoop_egui::register_settings;
 #[cfg(not(target_arch = "wasm32"))]
-use shoop_egui::{register_audio_settings, AudioDriverConfig};
+use shoop_egui::AudioDriverConfig;
 use shoop_egui::{
-    register_settings_with_appearance_defaults, AppIntent, AppSnapshot, AppWidget, ScriptKind,
-    SettingsAction, SettingsRegistryBuilder, UI_SCALE_FACTOR,
+    register_audio_settings, register_settings_with_appearance_defaults, AppIntent, AppSnapshot,
+    AppWidget, ScriptKind, SettingsAction, SettingsRegistryBuilder, UI_SCALE_FACTOR,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use shoop_egui::{TracingStatus, TracingStopped};
@@ -298,7 +298,6 @@ impl UnifiedApp {
             ui_scale_default,
             touch_mode_default,
         )?;
-        #[cfg(not(target_arch = "wasm32"))]
         register_audio_settings(&mut settings_builder)?;
         #[cfg(all(not(target_arch = "wasm32"), feature = "native-fx"))]
         register_carla_settings(&mut settings_builder)?;
@@ -823,6 +822,12 @@ impl UnifiedApp {
         }
         let _span = tracing::trace_span!("frontend.egui.update").entered();
         self.settings.poll();
+        if let Err(error) = self
+            .runtime
+            .reconcile_audio_settings(&self.settings.active())
+        {
+            self.settings.report_action_error(error.to_string());
+        }
         if let Err(error) = self
             .runtime
             .reconcile_script_settings(&self.settings.active())
@@ -1429,6 +1434,29 @@ fn script_kind_has_file_identity(kind: ScriptKind) -> bool {
     )
 }
 
+fn reconcile_loop_smoothing_settings(
+    settings: &shoop_settings::SettingsSnapshot,
+    applied_revision: &mut u64,
+    mut dispatch: impl FnMut(AppIntent) -> Result<(), shoop_app::DispatchError>,
+) -> anyhow::Result<()> {
+    if settings.revision() == *applied_revision {
+        return Ok(());
+    }
+    let milliseconds = match shoop_egui::loop_edge_smoothing_ms(settings) {
+        Ok(milliseconds) => milliseconds,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "frontend.audio.loop_smoothing_settings_fallback"
+            );
+            3
+        }
+    };
+    dispatch(AppIntent::SetLoopSmoothingMs(milliseconds))?;
+    *applied_revision = settings.revision();
+    Ok(())
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 struct Runtime {
     _runtime: ApplicationRuntime,
@@ -1439,6 +1467,7 @@ struct Runtime {
     catalog_scan_tx: std::sync::mpsc::Sender<CatalogScanCompletion>,
     catalog_scan_rx: std::sync::mpsc::Receiver<CatalogScanCompletion>,
     preview_player: native_preview::NativePreviewPlayer,
+    applied_audio_settings_revision: u64,
     applied_settings_revision: u64,
 }
 
@@ -1477,9 +1506,21 @@ impl Runtime {
                 )),
             ),
         };
-        let (backend, backend_warning) = NativeBackend::new_with_fallback(configured_driver)?;
+        let (mut backend, backend_warning) = NativeBackend::new_with_fallback(configured_driver)?;
+        let (loop_smoothing_ms, loop_smoothing_warning) =
+            match shoop_egui::loop_edge_smoothing_ms(settings) {
+                Ok(milliseconds) => (milliseconds, None),
+                Err(error) => (
+                    3,
+                    Some(format!(
+                        "Could not use loop edge smoothing setting: {error}; using 3 ms"
+                    )),
+                ),
+            };
+        shoop_backend::Backend::set_loop_smoothing_ms(&mut backend, loop_smoothing_ms)?;
         let (startup_scripts, script_paths, mut warnings) = configured_startup_scripts(settings)?;
         warnings.extend(configuration_warning);
+        warnings.extend(loop_smoothing_warning);
         #[cfg(feature = "native-fx")]
         warnings.extend(carla_configuration_warning);
         warnings.extend(backend_warning);
@@ -1501,6 +1542,7 @@ impl Runtime {
             catalog_scan_tx,
             catalog_scan_rx,
             preview_player,
+            applied_audio_settings_revision: settings.revision(),
             applied_settings_revision: settings.revision(),
         })
     }
@@ -1584,6 +1626,18 @@ impl Runtime {
             }
         }
         self.pending_script_paths = retained;
+    }
+
+    fn reconcile_audio_settings(
+        &mut self,
+        settings: &shoop_settings::SettingsSnapshot,
+    ) -> anyhow::Result<()> {
+        let handle = self.handle.clone();
+        reconcile_loop_smoothing_settings(
+            settings,
+            &mut self.applied_audio_settings_revision,
+            move |intent| handle.dispatch(intent),
+        )
     }
 
     fn reconcile_script_settings(
@@ -1968,6 +2022,7 @@ struct Runtime {
     preview_player: browser_preview::BrowserPreviewPlayer,
     catalog_scan_generation: u64,
     catalog_completions: Rc<RefCell<VecDeque<BrowserCatalogCompletion>>>,
+    applied_audio_settings_revision: u64,
     applied_settings_revision: u64,
 }
 
@@ -1990,7 +2045,18 @@ impl Runtime {
         let offline = args.offline;
         let worker = args.worker;
         let (midi, midi_service) = browser_midi::BrowserMidiController::new()?;
-        let (backend, transport) = shoop_worklet_client::RemoteWorkletBackend::new(midi.hub());
+        let (mut backend, transport) = shoop_worklet_client::RemoteWorkletBackend::new(midi.hub());
+        let loop_smoothing_ms = match shoop_egui::loop_edge_smoothing_ms(settings) {
+            Ok(milliseconds) => milliseconds,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "frontend.audio.loop_smoothing_settings_fallback"
+                );
+                3
+            }
+        };
+        shoop_backend::Backend::set_loop_smoothing_ms(&mut backend, loop_smoothing_ms)?;
         let mode = if worker || offline {
             set_offline_audio_permission_presentation();
             BrowserRuntimeMode::Worker(browser_worker::BrowserWorkerDriver::new(transport)?)
@@ -2008,6 +2074,7 @@ impl Runtime {
             preview_player: browser_preview::BrowserPreviewPlayer::default(),
             catalog_scan_generation: 0,
             catalog_completions: Rc::new(RefCell::new(VecDeque::new())),
+            applied_audio_settings_revision: settings.revision(),
             applied_settings_revision: settings.revision(),
         };
         runtime.request_builtin_rescan(settings);
@@ -2077,6 +2144,18 @@ impl Runtime {
                 &refused_control.to_string(),
             );
         }
+    }
+
+    fn reconcile_audio_settings(
+        &mut self,
+        settings: &shoop_settings::SettingsSnapshot,
+    ) -> anyhow::Result<()> {
+        let runtime = &mut self.runtime;
+        reconcile_loop_smoothing_settings(
+            settings,
+            &mut self.applied_audio_settings_revision,
+            |intent| runtime.dispatch(intent),
+        )
     }
 
     fn reconcile_script_settings(
@@ -4950,6 +5029,42 @@ mod tests {
             embedded_builtin_key("././builtins/catalog.json"),
             "builtins/catalog.json"
         );
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_smoothing_settings_retry_failed_dispatch_and_apply_zero() {
+        let mut builder = SettingsRegistryBuilder::default();
+        register_audio_settings(&mut builder).unwrap();
+        let registry = builder.finish();
+        let mut document = shoop_settings::SettingsDocument::empty("test");
+        document.values.insert(
+            shoop_egui::LOOP_EDGE_SMOOTHING_MS.id().to_owned(),
+            serde_json::json!(0),
+        );
+        let settings = registry.resolve(&document, 42).snapshot;
+        let mut applied_revision = 0;
+
+        assert!(
+            reconcile_loop_smoothing_settings(&settings, &mut applied_revision, |_| Err(
+                shoop_app::DispatchError::Full
+            ),)
+            .is_err()
+        );
+        assert_eq!(applied_revision, 0);
+
+        let mut received = None;
+        reconcile_loop_smoothing_settings(&settings, &mut applied_revision, |intent| {
+            received = Some(intent);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(received, Some(AppIntent::SetLoopSmoothingMs(0)));
+        assert_eq!(applied_revision, 42);
+
+        reconcile_loop_smoothing_settings(&settings, &mut applied_revision, |_| {
+            panic!("an applied revision must not dispatch again")
+        })
+        .unwrap();
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

- add a causal, allocation-free per-channel correction smoother for playback starts, stops, wraps, seeks, gain changes, and content endings
- propagate a persistent `audio.loop_edge_smoothing_ms` setting across native, dummy, fake, and Web Audio/worklet backends, including session/driver replacement and worklet reconnect replay
- expose the setting in native and browser Audio settings with a 3 ms default and exact-copy 0 ms bypass
- bump the audio worklet protocol to version 14 and extend deterministic, integration, persistence, and realtime allocation coverage

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1,519 passed, 2 skipped)
- complete Node Wasm suite (1,252 passed)
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `trunk build` for the browser application and audio worklet

Physical listening was unavailable in the non-interactive environment. Chrome was absent, and the Firefox artifact smoke requires a newer geckodriver for the installed Firefox 150.0.1; these remaining manual checks are documented in `smoother.md`.
