### PR TITLE
Stop all composite children when stopping a composite

### DIFF
--- a/src/rust/shoop_engine/src/composite_runtime.rs
+++ b/src/rust/shoop_engine/src/composite_runtime.rs
@@ -280,7 +280,7 @@ impl CompositeRuntime {
             return Err(CompositeRuntimeError::UnknownMode);
         }
         if mode == LoopMode::Stopped {
-            return self.stop_inner(plan, &mut target_is_current);
+            return self.stop_inner(&mut target_is_current);
         }
         if plan.n_iterations() == 0 {
             self.mode = LoopMode::Stopped;
@@ -345,7 +345,7 @@ impl CompositeRuntime {
         F: FnMut(LoopIdentity) -> bool,
     {
         self.ensure_plan_mut(plan)?;
-        self.stop_inner(plan, &mut target_is_current)
+        self.stop_inner(&mut target_is_current)
     }
 
     pub fn sync_boundary<F>(
@@ -540,7 +540,7 @@ impl CompositeRuntime {
         F: FnMut(LoopIdentity) -> bool,
     {
         self.ensure_plan_mut(plan)?;
-        let batch = self.stop_inner(plan, &mut target_is_current)?;
+        let batch = self.stop_inner(&mut target_is_current)?;
         self.target_count = 0;
         self.installed_targets.fill(EMPTY_IDENTITY);
         self.cycle_count = 0;
@@ -624,21 +624,22 @@ impl CompositeRuntime {
 
     fn stop_inner<F>(
         &mut self,
-        plan: &CompiledCompositePlan,
         target_is_current: &mut F,
     ) -> Result<CompositeTransitionBatch, CompositeRuntimeError>
     where
         F: FnMut(LoopIdentity) -> bool,
     {
         self.pending = None;
-        let batch = self.reconcile(
-            plan,
-            None,
-            LoopMode::Stopped,
-            false,
-            false,
-            target_is_current,
-        )?;
+        let mut batch = CompositeTransitionBatch::default();
+        for index in 0..self.target_count {
+            self.emit(
+                &mut batch,
+                index,
+                CompositeTargetAction::Stop,
+                target_is_current,
+            )?;
+            self.active[index] = INACTIVE_TARGET;
+        }
         self.mode = LoopMode::Stopped;
         self.iteration = 0;
         self.sync_position = 0;

--- a/src/rust/shoop_engine/tests/composite_state_machine.rs
+++ b/src/rust/shoop_engine/tests/composite_state_machine.rs
@@ -621,8 +621,15 @@ fn stop_and_clear_cancel_pending_state_and_clean_children_in_stable_order() {
     assert_eq!(runtime.pending(), None);
     assert_eq!(runtime.mode(), LoopMode::Stopped);
 
+    let stopped_again = runtime.stop(&plan, always_current).unwrap();
+    assert_eq!(stopped_again.as_slice().len(), 2);
+    assert!(stopped_again
+        .as_slice()
+        .iter()
+        .all(|transition| transition.action == CompositeTargetAction::Stop));
+
     let cleared = runtime.clear(&plan, always_current).unwrap();
-    assert!(cleared.is_empty());
+    assert_eq!(cleared.as_slice().len(), 2);
     assert_eq!(runtime.active_children().count(), 0);
     assert_eq!(runtime.cycle_count(), 0);
 }


### PR DESCRIPTION
## Summary
- stop every configured composite child when the composite receives a stop, including children started independently
- preserve stale-target filtering and deterministic target order
- add state-machine coverage for repeated stop and clear operations

## Analysis
The Tracy capture attached to #804 shows three `loop.play` intents followed by repeated `loop.stop` intents. The runtime previously emitted stop transitions only for children it tracked as active through the composite itself, so independently started configured children were left running.

## Testing
- `RUSTFLAGS="-D warnings" cargo test -p shoop_engine --test composite_state_machine --features app_backend`
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- Full warning-denying workspace build reached the final `shoop_audio_worklet` link, but this container fails there because the embedded Tracy static archive is not PIC.
- Full nextest suite could not run because cargo-nextest is not installed in the container.

Fixes #804