### PR TITLE
Adopt future composite schedule changes while playing

### DIFF
--- a/src/rust/shoop_engine/src/composite_runtime.rs
+++ b/src/rust/shoop_engine/src/composite_runtime.rs
@@ -541,18 +541,7 @@ impl CompositeRuntime {
             self.bump_plan_mismatch();
             return Err(CompositeRuntimeError::PlanMismatch);
         }
-        if self.mode == LoopMode::Stopped
-            || self.iteration.saturating_add(1) >= current_plan.n_iterations()
-            || self.iteration.saturating_add(1) >= candidate.n_iterations()
-            || current_plan.kind() != candidate.kind()
-            || current_plan.sync_length() != candidate.sync_length()
-            || !plans_match_at(
-                current_plan,
-                candidate,
-                self.iteration,
-                self.iteration.saturating_add(1),
-            )
-        {
+        if !self.can_adopt_plan_before_future_change(current_plan, candidate) {
             return Ok(false);
         }
 
@@ -569,6 +558,26 @@ impl CompositeRuntime {
             }
         }
         Ok(true)
+    }
+
+    pub(crate) fn can_adopt_plan_before_future_change(
+        &self,
+        current_plan: &CompiledCompositePlan,
+        candidate: &CompiledCompositePlan,
+    ) -> bool {
+        self.ensure_plan(current_plan).is_ok()
+            && candidate.source() == self.source
+            && self.mode != LoopMode::Stopped
+            && self.iteration.saturating_add(1) < current_plan.n_iterations()
+            && self.iteration.saturating_add(1) < candidate.n_iterations()
+            && current_plan.kind() == candidate.kind()
+            && current_plan.sync_length() == candidate.sync_length()
+            && plans_match_at(
+                current_plan,
+                candidate,
+                self.iteration,
+                self.iteration.saturating_add(1),
+            )
     }
 
     pub fn clear<F>(

--- a/src/rust/shoop_engine/src/composite_runtime.rs
+++ b/src/rust/shoop_engine/src/composite_runtime.rs
@@ -531,6 +531,46 @@ impl CompositeRuntime {
         Ok(output)
     }
 
+    pub(crate) fn adopt_plan_before_future_change(
+        &mut self,
+        current_plan: &CompiledCompositePlan,
+        candidate: &CompiledCompositePlan,
+    ) -> Result<bool, CompositeRuntimeError> {
+        self.ensure_plan_mut(current_plan)?;
+        if candidate.source() != self.source {
+            self.bump_plan_mismatch();
+            return Err(CompositeRuntimeError::PlanMismatch);
+        }
+        if self.mode == LoopMode::Stopped
+            || self.iteration.saturating_add(1) >= current_plan.n_iterations()
+            || self.iteration.saturating_add(1) >= candidate.n_iterations()
+            || current_plan.kind() != candidate.kind()
+            || current_plan.sync_length() != candidate.sync_length()
+            || !plans_match_at(
+                current_plan,
+                candidate,
+                self.iteration,
+                self.iteration.saturating_add(1),
+            )
+        {
+            return Ok(false);
+        }
+
+        let old_targets = self.installed_targets;
+        let old_active = self.active;
+        let old_target_count = self.target_count;
+        self.install_target_table(candidate);
+        self.active.fill(INACTIVE_TARGET);
+        for new_index in 0..self.target_count {
+            if let Ok(old_index) =
+                old_targets[..old_target_count].binary_search(&self.installed_targets[new_index])
+            {
+                self.active[new_index] = old_active[old_index];
+            }
+        }
+        Ok(true)
+    }
+
     pub fn clear<F>(
         &mut self,
         plan: &CompiledCompositePlan,
@@ -790,6 +830,52 @@ impl CompositeRuntime {
     fn bump_arithmetic_overflow(&mut self) {
         self.counters.arithmetic_overflows = self.counters.arithmetic_overflows.saturating_add(1);
     }
+}
+
+fn plans_match_at(
+    current: &CompiledCompositePlan,
+    candidate: &CompiledCompositePlan,
+    first_iteration: u32,
+    second_iteration: u32,
+) -> bool {
+    current.targets().iter().all(|target| {
+        target_matches_at(
+            current,
+            candidate,
+            *target,
+            first_iteration,
+            second_iteration,
+        )
+    }) && candidate.targets().iter().all(|target| {
+        target_matches_at(
+            current,
+            candidate,
+            *target,
+            first_iteration,
+            second_iteration,
+        )
+    })
+}
+
+fn target_matches_at(
+    current: &CompiledCompositePlan,
+    candidate: &CompiledCompositePlan,
+    target: LoopIdentity,
+    first_iteration: u32,
+    second_iteration: u32,
+) -> bool {
+    let current_index = current.targets().binary_search(&target).ok();
+    let candidate_index = candidate.targets().binary_search(&target).ok();
+    [first_iteration, second_iteration]
+        .into_iter()
+        .all(|iteration| {
+            [false, true].into_iter().all(|first_recording_only| {
+                current_index
+                    .and_then(|index| current.desired(iteration, index, first_recording_only))
+                    == candidate_index
+                        .and_then(|index| candidate.desired(iteration, index, first_recording_only))
+            })
+        })
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/rust/shoop_engine/src/composite_timeline.rs
+++ b/src/rust/shoop_engine/src/composite_timeline.rs
@@ -588,18 +588,19 @@ impl CompositeBoundaryTimeline {
                     .activate_plan(current_plan, next_plan, |_| true);
                 std::mem::swap(&mut current.plan, &mut next.plan);
                 std::mem::swap(&mut current.active_version, &mut next.active_version);
-            } else if current
-                .runtime
-                .adopt_plan_before_future_change(
-                    current
-                        .plan
-                        .as_ref()
-                        .expect("installed timelines always have an active plan"),
-                    next.plan
-                        .as_ref()
-                        .expect("prepared replacement nodes have a plan"),
-                )
-                .expect("replacement plans have matching composite identities")
+            } else if current.pending_plan.is_none()
+                && current
+                    .runtime
+                    .adopt_plan_before_future_change(
+                        current
+                            .plan
+                            .as_ref()
+                            .expect("installed timelines always have an active plan"),
+                        next.plan
+                            .as_ref()
+                            .expect("prepared replacement nodes have a plan"),
+                    )
+                    .expect("replacement plans have matching composite identities")
             {
                 std::mem::swap(&mut current.plan, &mut next.plan);
                 std::mem::swap(&mut current.active_version, &mut next.active_version);

--- a/src/rust/shoop_engine/src/composite_timeline.rs
+++ b/src/rust/shoop_engine/src/composite_timeline.rs
@@ -545,6 +545,18 @@ impl CompositeBoundaryTimeline {
         if self.nodes.len() != candidate.nodes.len() {
             return false;
         }
+        if !self
+            .nodes
+            .iter()
+            .zip(&candidate.nodes)
+            .all(|(current, next)| {
+                current.plan().source() == next.plan().source()
+                    && current.sync_source == next.sync_source
+                    && composite_targets(current.plan()).eq(composite_targets(next.plan()))
+            })
+        {
+            return false;
+        }
         let additional_retirements = self
             .nodes
             .iter()
@@ -553,19 +565,12 @@ impl CompositeBoundaryTimeline {
                 current.plan() != next.plan()
                     && current.runtime.mode() != LoopMode::Stopped
                     && current.pending_plan.is_none()
+                    && !current
+                        .runtime
+                        .can_adopt_plan_before_future_change(current.plan(), next.plan())
             })
             .count();
-        if self.retired_plans.len() + additional_retirements > self.retired_plans.capacity() {
-            return false;
-        }
-        self.nodes
-            .iter()
-            .zip(&candidate.nodes)
-            .all(|(current, next)| {
-                current.plan().source() == next.plan().source()
-                    && current.sync_source == next.sync_source
-                    && composite_targets(current.plan()).eq(composite_targets(next.plan()))
-            })
+        self.retired_plans.len() + additional_retirements <= self.retired_plans.capacity()
     }
 
     pub fn queue_runtime_preserving_replacement(&mut self, mut candidate: Self) -> Self {

--- a/src/rust/shoop_engine/src/composite_timeline.rs
+++ b/src/rust/shoop_engine/src/composite_timeline.rs
@@ -588,6 +588,21 @@ impl CompositeBoundaryTimeline {
                     .activate_plan(current_plan, next_plan, |_| true);
                 std::mem::swap(&mut current.plan, &mut next.plan);
                 std::mem::swap(&mut current.active_version, &mut next.active_version);
+            } else if current
+                .runtime
+                .adopt_plan_before_future_change(
+                    current
+                        .plan
+                        .as_ref()
+                        .expect("installed timelines always have an active plan"),
+                    next.plan
+                        .as_ref()
+                        .expect("prepared replacement nodes have a plan"),
+                )
+                .expect("replacement plans have matching composite identities")
+            {
+                std::mem::swap(&mut current.plan, &mut next.plan);
+                std::mem::swap(&mut current.active_version, &mut next.active_version);
             } else {
                 let next_plan = next
                     .plan

--- a/src/rust/shoop_engine/tests/composite_control.rs
+++ b/src/rust/shoop_engine/tests/composite_control.rs
@@ -597,6 +597,44 @@ fn compatible_replacement_supersedes_an_older_deferred_candidate() {
 }
 
 #[shoop_wasm_test_support::shoop_test]
+fn future_change_adopts_when_retirement_storage_is_full() {
+    let Fixture {
+        session,
+        timeline,
+        source,
+        ..
+    } = fixture();
+    let mut version_two = fixture_with_entry(3, 1).timeline;
+    version_two.prepare_install(2, &[None, None]).unwrap();
+    let mut version_three = fixture_with_entry(2, 1).timeline;
+    version_three.prepare_install(3, &[None, None]).unwrap();
+    let (mut engine, mut handle) = split(session, 8);
+    let mut install = handle.send_composite_timeline(timeline).unwrap();
+    engine.process(1);
+    assert!(install.pop().unwrap().is_ok());
+    let mut start = handle
+        .send_composite_immediate_transition(source, LoopMode::Playing, 0)
+        .unwrap();
+    engine.process(1);
+    assert!(start.pop().unwrap().is_ok());
+    let mut second = handle.send_composite_timeline(version_two).unwrap();
+    engine.pump();
+    assert!(second.pop().unwrap().is_ok());
+    engine.process(2);
+    assert_eq!(engine.session().composite_timeline().n_retired_plans(), 1);
+
+    let mut third = handle.send_composite_timeline(version_three).unwrap();
+    engine.pump();
+
+    assert!(third.pop().unwrap().is_ok());
+    let active = engine.session().composite_timeline().node_state(0).unwrap();
+    assert_eq!(active.active_version, 3);
+    assert_eq!(active.pending_version, None);
+    assert_eq!(active.runtime.mode(), LoopMode::Playing);
+    assert_eq!(engine.session().composite_timeline().n_retired_plans(), 1);
+}
+
+#[shoop_wasm_test_support::shoop_test]
 fn running_dependency_topology_change_restarts_at_the_install_boundary() {
     let Fixture {
         session,

--- a/src/rust/shoop_engine/tests/composite_control.rs
+++ b/src/rust/shoop_engine/tests/composite_control.rs
@@ -21,6 +21,10 @@ fn fixture() -> Fixture {
 }
 
 fn fixture_with_cycles(n_cycles: i64) -> Fixture {
+    fixture_with_entry(0, n_cycles)
+}
+
+fn fixture_with_entry(delay: i64, n_cycles: i64) -> Fixture {
     let mut session = Session::default();
     let sync = session.create_loop();
     let child = session.create_loop();
@@ -59,7 +63,7 @@ fn fixture_with_cycles(n_cycles: i64) -> Fixture {
                 sections: vec![CompositeSection {
                     entries: vec![CompositeEntry {
                         target: child_identity,
-                        delay: 0,
+                        delay,
                         n_cycles: Some(n_cycles),
                         mode: None,
                     }],
@@ -87,6 +91,41 @@ fn fixture_with_cycles(n_cycles: i64) -> Fixture {
         source,
         child: child_identity,
     }
+}
+
+#[shoop_wasm_test_support::shoop_test]
+fn running_timeline_adopts_changes_more_than_one_cycle_ahead() {
+    let Fixture {
+        session,
+        timeline,
+        source,
+        child,
+    } = fixture_with_entry(3, 1);
+    let mut replacement = fixture_with_entry(2, 1).timeline;
+    replacement.prepare_install(2, &[None, None]).unwrap();
+    let (mut engine, mut handle) = split(session, 8);
+    let mut install = handle.send_composite_timeline(timeline).unwrap();
+    engine.process(1);
+    assert!(install.pop().unwrap().is_ok());
+    let mut start = handle
+        .send_composite_immediate_transition(source, LoopMode::Playing, 0)
+        .unwrap();
+    engine.process(1);
+    assert!(start.pop().unwrap().is_ok());
+
+    let mut replace = handle.send_composite_timeline(replacement).unwrap();
+    engine.pump();
+
+    assert!(replace.pop().unwrap().is_ok());
+    let node = engine.session().composite_timeline().node_state(0).unwrap();
+    assert_eq!(node.active_version, 2);
+    assert_eq!(node.pending_version, None);
+    assert_eq!(node.runtime.iteration(), 0);
+    engine.process(7);
+    assert_eq!(
+        engine.session().loop_(child.slot as usize).unwrap().mode(),
+        LoopMode::Playing
+    );
 }
 
 #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/tests/composite_control.rs
+++ b/src/rust/shoop_engine/tests/composite_control.rs
@@ -558,6 +558,45 @@ fn newest_running_replacement_supersedes_older_candidate() {
 }
 
 #[shoop_wasm_test_support::shoop_test]
+fn compatible_replacement_supersedes_an_older_deferred_candidate() {
+    let Fixture {
+        session,
+        timeline,
+        source,
+        ..
+    } = fixture_with_entry(3, 1);
+    let mut version_two = fixture_with_entry(0, 2).timeline;
+    version_two.prepare_install(2, &[None, None]).unwrap();
+    let mut version_three = fixture_with_entry(2, 1).timeline;
+    version_three.prepare_install(3, &[None, None]).unwrap();
+    let (mut engine, mut handle) = split(session, 8);
+    let mut install = handle.send_composite_timeline(timeline).unwrap();
+    engine.process(1);
+    assert!(install.pop().unwrap().is_ok());
+    let mut start = handle
+        .send_composite_immediate_transition(source, LoopMode::Playing, 0)
+        .unwrap();
+    engine.process(1);
+    assert!(start.pop().unwrap().is_ok());
+
+    let mut second = handle.send_composite_timeline(version_two).unwrap();
+    engine.pump();
+    assert!(second.pop().unwrap().is_ok());
+    let mut third = handle.send_composite_timeline(version_three).unwrap();
+    engine.pump();
+    assert!(third.pop().unwrap().is_ok());
+
+    let pending = engine.session().composite_timeline().node_state(0).unwrap();
+    assert_eq!(pending.active_version, 1);
+    assert_eq!(pending.pending_version, Some(3));
+    engine.process(14);
+    let active = engine.session().composite_timeline().node_state(0).unwrap();
+    assert_eq!(active.active_version, 3);
+    assert_eq!(active.pending_version, None);
+    assert_eq!(active.runtime.length_samples(active.plan), Ok(12));
+}
+
+#[shoop_wasm_test_support::shoop_test]
 fn running_dependency_topology_change_restarts_at_the_install_boundary() {
     let Fixture {
         session,


### PR DESCRIPTION
## Summary
- adopt compatible composite plan replacements immediately when their changes are more than one sync cycle ahead of the playhead
- preserve active child runtime state while remapping the replacement target table
- cover on-the-fly future schedule adoption with an engine regression test

Closes #805

## Testing
- `cargo test -p shoop_engine --test composite_control --no-default-features`
- `cargo test -p shoop_engine --no-default-features`
- `RUSTFLAGS="-D warnings" cargo build -p shoop_engine --no-default-features`
- `python3 scripts/check_shoop_test_usage.py`
- `git diff --check`