### PR TITLE
Keep composite child mode icons stable

### DIFF
--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -1322,6 +1322,7 @@ struct SharedSession {
     /// work, but the session itself is reached solely through the queues inside, so no
     /// audio thread ever waits on this.
     handle: Mutex<engine::EngineHandle>,
+    stats: Arc<engine::Stats>,
     /// Lock-free lifecycle observation for pending object handles.
     engine_connected: Arc<AtomicBool>,
     /// The engine, for as long as no driver has taken it.
@@ -2003,9 +2004,11 @@ impl BackendSession {
         // the steady state.
         let (engine, handle) = engine::split(s, command_queue_capacity);
         let engine_connected = handle.connected_flag();
+        let stats = Arc::clone(handle.stats());
         let shared = Arc::new(SharedSession {
             session_id: NEXT_BACKEND_SESSION_ID.fetch_add(1, Ordering::Relaxed),
             handle: Mutex::new(handle),
+            stats,
             engine_connected,
             parked: Mutex::new(Some(engine)),
             next_composite_slot: AtomicU32::new(0x8000_0000),
@@ -2198,6 +2201,7 @@ impl BackendSession {
         Ok(Loop {
             shared: self.shared.clone(),
             control,
+            desired_state: Arc::new(Mutex::new(DesiredLoopState::default())),
         })
     }
     #[tracing::instrument(
@@ -4008,9 +4012,61 @@ impl CompositeLoop {
 pub struct Loop {
     shared: Arc<SharedSession>,
     control: Arc<ObjectControl<LoopId, engine::LoopStateMirror>>,
+    desired_state: Arc<Mutex<DesiredLoopState>>,
 }
 pub type LoopState = engine::LoopState;
+
+#[derive(Default)]
+struct DesiredLoopState {
+    mode: Option<(LoopMode, CommandSequence)>,
+    length: Option<(u32, CommandSequence)>,
+    position: Option<(u32, CommandSequence)>,
+}
+
 impl Loop {
+    fn read_state(&self) -> LoopState {
+        let mut state = self.control.mirror.read();
+        let applied = self
+            .shared
+            .stats
+            .last_applied_command
+            .load(Ordering::Acquire);
+        let mut desired = self
+            .desired_state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if desired
+            .mode
+            .is_some_and(|(_, sequence)| sequence.get() <= applied)
+        {
+            desired.mode = None;
+        }
+        if desired
+            .length
+            .is_some_and(|(_, sequence)| sequence.get() <= applied)
+        {
+            desired.length = None;
+        }
+        if desired
+            .position
+            .is_some_and(|(_, sequence)| sequence.get() <= applied)
+        {
+            desired.position = None;
+        }
+        if let Some((mode, _)) = desired.mode {
+            state.mode = mode;
+            state.maybe_next_mode = None;
+            state.maybe_next_mode_delay = None;
+        }
+        if let Some((length, _)) = desired.length {
+            state.length = length;
+        }
+        if let Some((position, _)) = desired.position {
+            state.position = position;
+        }
+        state
+    }
+
     pub fn session_id(&self) -> u64 {
         self.control.session_id
     }
@@ -4183,16 +4239,22 @@ impl Loop {
                 let _ = s.set_loop_mode(idx, to_mode.into());
             }
         })?;
+        if immediate {
+            self.desired_state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .mode = Some((to_mode, sequence));
+        }
         Ok(sequence)
     }
 
     pub fn poll_state(&self) -> Option<LoopState> {
-        (self.lifecycle() == ObjectLifecycle::Ready).then(|| self.control.mirror.read())
+        (self.lifecycle() == ObjectLifecycle::Ready).then(|| self.read_state())
     }
 
     pub fn get_state(&self) -> Result<LoopState> {
         match self.lifecycle() {
-            ObjectLifecycle::Ready => Ok(self.control.mirror.read()),
+            ObjectLifecycle::Ready => Ok(self.read_state()),
             ObjectLifecycle::Pending => Err(anyhow!("loop is pending creation")),
             ObjectLifecycle::Failed => Err(anyhow!(
                 "loop creation failed: {}",
@@ -4212,6 +4274,10 @@ impl Loop {
                 }
             }
         })?;
+        self.desired_state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .length = Some((length, sequence));
         Ok(sequence)
     }
 
@@ -4224,6 +4290,10 @@ impl Loop {
                 }
             }
         })?;
+        self.desired_state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .position = Some((position, sequence));
         Ok(sequence)
     }
 
@@ -5235,6 +5305,16 @@ pub fn replace_loop_content(
             return Err(error.into());
         }
     };
+    {
+        let mut desired = loop_
+            .desired_state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        desired.mode = Some((LoopMode::Stopped, sequence));
+        if let Some(length) = length {
+            desired.length = Some((length, sequence));
+        }
+    }
     for item in audio {
         item.channel
             .desired_data
@@ -7129,6 +7209,7 @@ mod tests {
         let failed_parent = Loop {
             shared: Arc::clone(&sess.shared),
             control: failed_parent_control,
+            desired_state: Arc::new(Mutex::new(DesiredLoopState::default())),
         };
         let failed_channel = failed_parent
             .add_midi_channel(ChannelMode::Direct)
@@ -7708,6 +7789,7 @@ mod tests {
         let failed = Loop {
             shared: Arc::clone(&sess.shared),
             control: failed_control,
+            desired_state: Arc::new(Mutex::new(DesiredLoopState::default())),
         };
         let closed_control = Arc::new(ObjectControl::<LoopId, engine::LoopStateMirror>::pending(
             sess.shared.session_id,
@@ -7717,6 +7799,7 @@ mod tests {
         let closed = Loop {
             shared: Arc::clone(&sess.shared),
             control: closed_control,
+            desired_state: Arc::new(Mutex::new(DesiredLoopState::default())),
         };
 
         assert_eq!(failed.lifecycle(), ObjectLifecycle::Failed);

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -4183,9 +4183,6 @@ impl Loop {
                 let _ = s.set_loop_mode(idx, to_mode.into());
             }
         })?;
-        if immediate {
-            self.control.mirror.set_mode(to_mode);
-        }
         Ok(sequence)
     }
 
@@ -4215,7 +4212,6 @@ impl Loop {
                 }
             }
         })?;
-        self.control.mirror.set_length(length);
         Ok(sequence)
     }
 
@@ -4228,7 +4224,6 @@ impl Loop {
                 }
             }
         })?;
-        self.control.mirror.set_position(position);
         Ok(sequence)
     }
 
@@ -5240,10 +5235,6 @@ pub fn replace_loop_content(
             return Err(error.into());
         }
     };
-    loop_.control.mirror.set_mode(LoopMode::Stopped);
-    if let Some(length) = length {
-        loop_.control.mirror.set_length(length);
-    }
     for item in audio {
         item.channel
             .desired_data

--- a/src/rust/shoop_engine/src/state_mirror.rs
+++ b/src/rust/shoop_engine/src/state_mirror.rs
@@ -17,8 +17,8 @@ const NO_SAMPLE: i32 = i32::MIN;
 
 /// Lock-free loop-state publication shared by the engine and its control handle.
 ///
-/// The generation is a seqlock. Writers serialize with atomic compare-and-exchange, while readers
-/// retry if they overlap a publication instead of observing fields from different updates.
+/// The generation is a seqlock. The engine is the single writer, while readers retry if they
+/// overlap a publication instead of observing fields from different audio callbacks.
 #[derive(Debug)]
 pub struct LoopStateMirror {
     generation: AtomicU64,
@@ -46,23 +46,8 @@ impl Default for LoopStateMirror {
 
 impl LoopStateMirror {
     fn begin_write(&self) {
-        let mut generation = self.generation.load(Ordering::Relaxed);
-        loop {
-            if generation & 1 != 0 {
-                std::hint::spin_loop();
-                generation = self.generation.load(Ordering::Relaxed);
-                continue;
-            }
-            match self.generation.compare_exchange_weak(
-                generation,
-                generation.wrapping_add(1),
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return,
-                Err(observed) => generation = observed,
-            }
-        }
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        std::sync::atomic::fence(Ordering::Release);
     }
 
     fn end_write(&self) {
@@ -132,7 +117,8 @@ impl LoopStateMirror {
                     .then(|| LoopMode::try_from(next_mode).unwrap_or(LoopMode::Unknown)),
                 maybe_next_mode_delay: (next_delay != NO_DELAY).then_some(next_delay as u32),
             };
-            let after = self.generation.load(Ordering::Acquire);
+            std::sync::atomic::fence(Ordering::Acquire);
+            let after = self.generation.load(Ordering::Relaxed);
             if before == after {
                 return snapshot;
             }
@@ -956,26 +942,21 @@ mod tests {
         use std::sync::Arc;
 
         let mirror = Arc::new(LoopStateMirror::default());
-        let playing_writer = Arc::clone(&mirror);
-        let playing_writer = std::thread::spawn(move || {
+        let writer = Arc::clone(&mirror);
+        let writer = std::thread::spawn(move || {
             for _ in 0..100_000 {
-                playing_writer.publish(
+                writer.publish(
                     LoopMode::Playing,
                     128,
                     17,
                     3,
                     Some((LoopMode::Recording, 2)),
                 );
-            }
-        });
-        let stopped_writer = Arc::clone(&mirror);
-        let stopped_writer = std::thread::spawn(move || {
-            for _ in 0..100_000 {
-                stopped_writer.publish(LoopMode::Stopped, 0, 0, 4, None);
+                writer.publish(LoopMode::Stopped, 0, 0, 4, None);
             }
         });
 
-        while !playing_writer.is_finished() || !stopped_writer.is_finished() {
+        while !writer.is_finished() {
             let state = mirror.read();
             let initial_or_stopped = state.mode == LoopMode::Stopped
                 && state.length == 0
@@ -991,7 +972,6 @@ mod tests {
                 && state.maybe_next_mode_delay == Some(2);
             check!(initial_or_stopped || playing);
         }
-        playing_writer.join().unwrap();
-        stopped_writer.join().unwrap();
+        writer.join().unwrap();
     }
 }

--- a/src/rust/shoop_engine/src/state_mirror.rs
+++ b/src/rust/shoop_engine/src/state_mirror.rs
@@ -15,8 +15,13 @@ const NO_MODE: i32 = -1;
 const NO_DELAY: u64 = u64::MAX;
 const NO_SAMPLE: i32 = i32::MIN;
 
+/// Lock-free loop-state publication shared by the engine and its control handle.
+///
+/// The generation is a seqlock. Writers serialize with atomic compare-and-exchange, while readers
+/// retry if they overlap a publication instead of observing fields from different updates.
 #[derive(Debug)]
 pub struct LoopStateMirror {
+    generation: AtomicU64,
     mode: AtomicI32,
     length: AtomicU32,
     position: AtomicU32,
@@ -28,6 +33,7 @@ pub struct LoopStateMirror {
 impl Default for LoopStateMirror {
     fn default() -> Self {
         Self {
+            generation: AtomicU64::new(0),
             mode: AtomicI32::new(LoopMode::Stopped as i32),
             length: AtomicU32::new(0),
             position: AtomicU32::new(0),
@@ -39,6 +45,30 @@ impl Default for LoopStateMirror {
 }
 
 impl LoopStateMirror {
+    fn begin_write(&self) {
+        let mut generation = self.generation.load(Ordering::Relaxed);
+        loop {
+            if generation & 1 != 0 {
+                std::hint::spin_loop();
+                generation = self.generation.load(Ordering::Relaxed);
+                continue;
+            }
+            match self.generation.compare_exchange_weak(
+                generation,
+                generation.wrapping_add(1),
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) => generation = observed,
+            }
+        }
+    }
+
+    fn end_write(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
     pub fn publish(
         &self,
         mode: LoopMode,
@@ -47,6 +77,7 @@ impl LoopStateMirror {
         cycle_count: u64,
         next: Option<(LoopMode, u32)>,
     ) {
+        self.begin_write();
         self.mode.store(mode as i32, Ordering::Relaxed);
         self.length.store(length, Ordering::Relaxed);
         self.position.store(position, Ordering::Relaxed);
@@ -59,34 +90,52 @@ impl LoopStateMirror {
             next.map(|(_, delay)| delay as u64).unwrap_or(NO_DELAY),
             Ordering::Relaxed,
         );
+        self.end_write();
     }
 
     pub fn set_mode(&self, mode: LoopMode) {
+        self.begin_write();
         self.mode.store(mode as i32, Ordering::Relaxed);
         self.next_mode.store(NO_MODE, Ordering::Relaxed);
         self.next_delay.store(NO_DELAY, Ordering::Relaxed);
+        self.end_write();
     }
 
     pub fn set_length(&self, length: u32) {
+        self.begin_write();
         self.length.store(length, Ordering::Relaxed);
+        self.end_write();
     }
 
     pub fn set_position(&self, position: u32) {
+        self.begin_write();
         self.position.store(position, Ordering::Relaxed);
+        self.end_write();
     }
 
     pub fn read(&self) -> LoopState {
-        let next_mode = self.next_mode.load(Ordering::Relaxed);
-        let next_delay = self.next_delay.load(Ordering::Relaxed);
-        LoopState {
-            mode: LoopMode::try_from(self.mode.load(Ordering::Relaxed))
-                .unwrap_or(LoopMode::Unknown),
-            length: self.length.load(Ordering::Relaxed),
-            position: self.position.load(Ordering::Relaxed),
-            cycle_count: self.cycle_count.load(Ordering::Relaxed),
-            maybe_next_mode: (next_mode != NO_MODE)
-                .then(|| LoopMode::try_from(next_mode).unwrap_or(LoopMode::Unknown)),
-            maybe_next_mode_delay: (next_delay != NO_DELAY).then_some(next_delay as u32),
+        loop {
+            let before = self.generation.load(Ordering::Acquire);
+            if before & 1 != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+            let next_mode = self.next_mode.load(Ordering::Relaxed);
+            let next_delay = self.next_delay.load(Ordering::Relaxed);
+            let snapshot = LoopState {
+                mode: LoopMode::try_from(self.mode.load(Ordering::Relaxed))
+                    .unwrap_or(LoopMode::Unknown),
+                length: self.length.load(Ordering::Relaxed),
+                position: self.position.load(Ordering::Relaxed),
+                cycle_count: self.cycle_count.load(Ordering::Relaxed),
+                maybe_next_mode: (next_mode != NO_MODE)
+                    .then(|| LoopMode::try_from(next_mode).unwrap_or(LoopMode::Unknown)),
+                maybe_next_mode_delay: (next_delay != NO_DELAY).then_some(next_delay as u32),
+            };
+            let after = self.generation.load(Ordering::Acquire);
+            if before == after {
+                return snapshot;
+            }
         }
     }
 }
@@ -899,5 +948,50 @@ mod tests {
         let state = mirror.read();
         check!(state.maybe_next_mode.is_none());
         check!(state.maybe_next_mode_delay.is_none());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[shoop_wasm_test_support::shoop_test]
+    fn loop_state_reads_one_complete_publication() {
+        use std::sync::Arc;
+
+        let mirror = Arc::new(LoopStateMirror::default());
+        let playing_writer = Arc::clone(&mirror);
+        let playing_writer = std::thread::spawn(move || {
+            for _ in 0..100_000 {
+                playing_writer.publish(
+                    LoopMode::Playing,
+                    128,
+                    17,
+                    3,
+                    Some((LoopMode::Recording, 2)),
+                );
+            }
+        });
+        let stopped_writer = Arc::clone(&mirror);
+        let stopped_writer = std::thread::spawn(move || {
+            for _ in 0..100_000 {
+                stopped_writer.publish(LoopMode::Stopped, 0, 0, 4, None);
+            }
+        });
+
+        while !playing_writer.is_finished() || !stopped_writer.is_finished() {
+            let state = mirror.read();
+            let initial_or_stopped = state.mode == LoopMode::Stopped
+                && state.length == 0
+                && state.position == 0
+                && matches!(state.cycle_count, 0 | 4)
+                && state.maybe_next_mode.is_none()
+                && state.maybe_next_mode_delay.is_none();
+            let playing = state.mode == LoopMode::Playing
+                && state.length == 128
+                && state.position == 17
+                && state.cycle_count == 3
+                && state.maybe_next_mode == Some(LoopMode::Recording)
+                && state.maybe_next_mode_delay == Some(2);
+            check!(initial_or_stopped || playing);
+        }
+        playing_writer.join().unwrap();
+        stopped_writer.join().unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- make basic-loop state mirror publications coherent across all fields
- keep the realtime publisher single-writer and nonblocking
- retain immediate desired-state reads in the control API through a separate command-sequenced overlay
- add the seqlock fences required for weakly ordered targets
- add a concurrent regression test that rejects mixed transition snapshots

## Tracy analysis
The attached `0002-application.tracy` capture validates as Tracy 0.13.1 and spans 17.920 seconds. It shows the `loop.play` UI intent at 2.133791 seconds while realtime `engine.rt.state_publication` runs approximately every 2–3 ms. The basic-loop mirror previously published `mode`, `next_mode`, and `next_delay` through independent atomics with no snapshot consistency mechanism. A GUI/backend read overlapping one publication could therefore combine the transition delay from one callback with the mode from another, intermittently satisfying the hourglass condition.

The canonical realtime mirror now uses a single-writer seqlock. Control mutations retain their established immediate read behavior through a separate desired-state overlay keyed by command sequence; once the engine acknowledges that sequence, reads fall back to the coherent canonical mirror. The audio thread never touches or waits on the overlay lock.

## Testing
- `cargo test -p shoop_engine --features app_backend loop_reads_return_the_immediate_desired_mirror_without_queueing_a_query`
- `cargo test -p shoop_engine --features app_backend loop_state_`
- `cargo test -p shoop_engine --features app_backend --test control`
- `RUSTFLAGS="-D warnings" cargo build -p shoop_engine --features app_backend`
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `git diff --check`

Closes #808
