### PR TITLE
Format CPAL mock imports

### DIFF
--- a/src/rust/shoop_engine/src/cpal_mock.rs
+++ b/src/rust/shoop_engine/src/cpal_mock.rs
@@ -12,10 +12,10 @@
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, BuildStreamError, Data, DefaultStreamConfigError, DeviceDescription,
-    DeviceDescriptionBuilder, DeviceDirection, DeviceId, DeviceIdError, DeviceNameError, DeviceType,
-    DevicesError, InputCallbackInfo, InputStreamTimestamp, InterfaceType, OutputCallbackInfo,
-    OutputStreamTimestamp, PauseStreamError, PlayStreamError, SampleFormat, StreamConfig,
-    StreamError, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
+    DeviceDescriptionBuilder, DeviceDirection, DeviceId, DeviceIdError, DeviceNameError,
+    DeviceType, DevicesError, InputCallbackInfo, InputStreamTimestamp, InterfaceType,
+    OutputCallbackInfo, OutputStreamTimestamp, PauseStreamError, PlayStreamError, SampleFormat,
+    StreamConfig, StreamError, StreamInstant, SupportedBufferSize, SupportedStreamConfig,
     SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
## Summary
- apply rustfmt to the CPAL mock import list
- unblock the Linux debug formatting gate

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS="-D warnings" cargo build --locked --workspace` *(blocked locally because ALSA development metadata is unavailable)*