### PR TITLE
Allow application-only browser tracing without COOP/COEP

### DIFF
--- a/.agents/skills/perfetto/SKILL.md
+++ b/.agents/skills/perfetto/SKILL.md
@@ -24,11 +24,12 @@ start in the same process. Detailed engine recording increases callback overhead
 
 ## Browser capture
 
-Hosted Chromium exposes the same developer controls. Multirealm engine tracing
-requires `SharedArrayBuffer` and therefore COOP `same-origin` plus COEP
-`require-corp`. Save downloads one `.pftrace` containing Window and the active
-Engine Worker or AudioWorklet realm. Direct-file or unsupported browsers report
-tracing unavailable rather than silently omitting an active realm.
+Hosted Chromium exposes the same developer controls. Application-only capture
+works without shared browser memory. Full engine capture requires
+`SharedArrayBuffer`, normally through COOP `same-origin` plus COEP
+`require-corp`. Save downloads one `.pftrace` containing either Window alone or
+Window and the active Engine Worker or AudioWorklet realm. The selected scope is
+explicit; full capture never silently omits an active realm.
 
 AudioWorklet timestamps are exact logical sample frames. They do not measure
 callback CPU-entry/exit duration. Inspect clock snapshots, calibration events,

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -881,10 +881,12 @@ jobs:
         working-directory: src/rust/shoopdaloop
         run: OUTPUT_ONLY=1 BROWSER_SIZE=900,600 node --experimental-websocket browser_smoke.mjs
 
-      - name: Run hosted Chromium multirealm Perfetto smokes
+      - name: Run Chromium browser Perfetto smokes
         if: matrix.target == 'web' && matrix.profile == 'debug' && env.ACT != 'true'
         working-directory: src/rust/shoopdaloop
         run: |
+          TRACE_REALM=application WEB_PORT=19888 DEBUG_PORT=19889 \
+            node --experimental-websocket browser_tracing_smoke.mjs
           TRACE_REALM=worker WEB_PORT=19890 DEBUG_PORT=19891 \
             node --experimental-websocket browser_tracing_smoke.mjs
           TRACE_REALM=audio TRACE_REBUILD=1 WEB_PORT=19892 DEBUG_PORT=19893 \
@@ -908,6 +910,18 @@ jobs:
             grep '1,1,' "$trace.query.txt"
             grep ',1,1,0$' "$trace.query.txt"
           done
+          cat > "$RUNNER_TEMP/browser-application-perfetto.sql" <<'SQL'
+          SELECT
+            (SELECT COUNT(*) FROM track WHERE name = 'Window') AS window_tracks,
+            (SELECT COUNT(*) FROM track WHERE name IN ('Engine Worker', 'AudioWorklet')) AS engine_tracks,
+            (SELECT COUNT(*) > 0 FROM slice) AS has_slices,
+            (SELECT COALESCE(SUM(value), 0) FROM stats WHERE severity = 'error') AS import_errors;
+          SQL
+          application_trace=../../../target/perfetto-validation/browser-application.pftrace
+          ../../../scripts/trace_processor \
+            --query-file "$RUNNER_TEMP/browser-application-perfetto.sql" \
+            "$application_trace" | tee "$application_trace.query.txt"
+          grep '1,0,1,0' "$application_trace.query.txt"
 
       - name: Run retained self-contained Chrome AudioWorklet smoke
         if: matrix.target == 'web' && matrix.profile == 'debug' && env.ACT != 'true'

--- a/docs/perfetto_migration_report.md
+++ b/docs/perfetto_migration_report.md
@@ -39,10 +39,11 @@ and preservation of equal-timestamp producer ordering.
 - Integer counts, identifiers, occupancy, generations, and reason codes are i64
   counters. Fractional values use f64 counters.
 
-Hosted browser multirealm capture requires COOP `same-origin`, COEP
-`require-corp`, and `SharedArrayBuffer`. `scripts/serve_web.py` supplies those
-headers. Unsupported/direct-file deployments keep running and report tracing as
-unavailable.
+Hosted browser application-only capture needs no shared memory. Multirealm
+capture requires `SharedArrayBuffer`, normally enabled by COOP `same-origin` and
+COEP `require-corp`; `scripts/serve_web.py` supplies those headers. Deployments
+without shared memory keep application-only capture available and explain how
+to enable the full option.
 
 ## Test capture
 

--- a/docs/source/developers.tracing.rst
+++ b/docs/source/developers.tracing.rst
@@ -11,13 +11,19 @@ Modes
 Disabled
   Omit tracing options. Gated realtime helpers do not call a backend.
 
-Coarse
-  Use ``--tracing`` or **Settings > Developer**. This includes GUI/application
-  spans, engine control/graph work, and bounded callback/session categories.
+Application only
+  Browser Window capture includes GUI and application spans without requiring
+  shared browser memory. Select it under **Settings > Developer** or use
+  ``?tracing=1&tracing-scope=application``.
+
+Full
+  Use ``--tracing`` or select **Application + engine** under
+  **Settings > Developer**. This includes GUI/application spans, engine
+  control/graph work, and bounded callback/session categories.
 
 Engine detail
-  Add ``--tracing-engine-detail`` for per-stage realtime records. This increases
-  callback overhead and capture size.
+  Add ``--tracing-engine-detail`` to full capture for per-stage realtime
+  records. This increases callback overhead and capture size.
 
 Capture natively::
 
@@ -30,10 +36,11 @@ A normal Save or application shutdown atomically publishes a numbered
 are supported. Use the pinned ``scripts/trace_processor`` wrapper for queries.
 
 Hosted Chromium exposes the same controls and downloads application-owned trace
-bytes. One capture combines Window with the active Engine Worker or
-AudioWorklet. Multirealm audio tracing requires cross-origin isolation and
-``SharedArrayBuffer``; serve COOP ``same-origin`` and COEP ``require-corp``.
-Unsupported deployments remain functional and report why tracing is unavailable.
+bytes. Application-only capture retains the Window realm on ordinary static
+hosts. Full capture combines Window with the active Engine Worker or
+AudioWorklet and requires ``SharedArrayBuffer``. Normally, serve COOP
+``same-origin`` and COEP ``require-corp``. The disabled full-capture option links
+to concise hosting and local test-browser instructions.
 
 Trace structure
 ~~~~~~~~~~~~~~~

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -1810,16 +1810,17 @@ impl AppWidget {
             state.status.buffer_size
         ));
         self.show_backend_status(ui, state);
-        if self.tracing_status.active {
+        if let Some(mode) = self.tracing_status.active_mode {
             ui.separator();
             ui.horizontal(|ui| {
                 if self.tracing_status.buffer_capacity_bytes > 0 {
                     ui.label(format!(
-                        "Tracing active ({} buffer capacity)",
+                        "Tracing active: {} ({} buffer capacity)",
+                        mode.label(),
                         format_memory_usage(self.tracing_status.buffer_capacity_bytes)
                     ));
                 } else {
-                    ui.label("Tracing active");
+                    ui.label(format!("Tracing active: {}", mode.label()));
                 }
                 let save = ui.small_button("Save");
                 let discard = ui.small_button("Discard");
@@ -2100,7 +2101,11 @@ mod tests {
         widget.set_tracing_status(TracingStatus {
             available: true,
             unavailable_reason: None,
-            active: true,
+            engine_available: true,
+            engine_unavailable_reason: None,
+            active_mode: Some(crate::TracingMode::Full {
+                engine_detail: false,
+            }),
             buffer_capacity_bytes: 3 * 1024 * 1024,
         });
         let state = AppState::default();

--- a/src/rust/shoop_egui/src/lib.rs
+++ b/src/rust/shoop_egui/src/lib.rs
@@ -51,7 +51,8 @@ pub use loop_widget::{LoopWidget, LoopWidgetResponse};
 pub use midi_sequence_widget::MidiSequenceWidget;
 pub use piano_pane::{c_label, is_black, PianoLayout, PianoPane, MIDDLE_C, MIDI_NOTE_COUNT};
 pub use settings_dialog::{
-    SettingsAction, SettingsDialog, SettingsDialogResponse, TracingStatus, TracingStopped,
+    SettingsAction, SettingsDialog, SettingsDialogResponse, TracingMode, TracingStatus,
+    TracingStopped,
 };
 pub use shoop_app_api::*;
 pub use shoop_settings::*;

--- a/src/rust/shoop_egui/src/settings_dialog.rs
+++ b/src/rust/shoop_egui/src/settings_dialog.rs
@@ -22,12 +22,46 @@ use crate::{
     BUILTINS_LOCATION, BUILTIN_SCRIPTS, TOUCH_MODE, UI_SCALE_FACTOR, USER_SCRIPTS,
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TracingMode {
+    Application,
+    Full { engine_detail: bool },
+}
+
+impl TracingMode {
+    pub const fn includes_engine(self) -> bool {
+        matches!(self, Self::Full { .. })
+    }
+
+    pub const fn engine_detail(self) -> bool {
+        match self {
+            Self::Application => false,
+            Self::Full { engine_detail } => engine_detail,
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Application => "application only",
+            Self::Full { .. } => "application + engine",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TracingStatus {
     pub available: bool,
     pub unavailable_reason: Option<&'static str>,
-    pub active: bool,
+    pub engine_available: bool,
+    pub engine_unavailable_reason: Option<&'static str>,
+    pub active_mode: Option<TracingMode>,
     pub buffer_capacity_bytes: u64,
+}
+
+impl TracingStatus {
+    pub const fn active(self) -> bool {
+        self.active_mode.is_some()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -55,7 +89,7 @@ pub enum SettingsAction {
         script_id: ScriptId,
     },
     StartTracing {
-        engine_detail: bool,
+        mode: TracingMode,
     },
     StopTracing {
         save: bool,
@@ -99,9 +133,13 @@ pub struct SettingsDialog {
     script_status_windows: BTreeSet<ScriptId>,
     markdown_cache: CommonMarkCache,
     tracing_status: TracingStatus,
+    tracing_include_engine: bool,
     tracing_engine_detail: bool,
+    tracing_requirements_open: bool,
     #[cfg(test)]
     tracing_start_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    tracing_requirements_rect: Option<egui::Rect>,
     #[cfg(test)]
     setting_card_rects: Vec<egui::Rect>,
     #[cfg(test)]
@@ -142,9 +180,13 @@ impl SettingsDialog {
             script_status_windows: BTreeSet::new(),
             markdown_cache: CommonMarkCache::default(),
             tracing_status: TracingStatus::default(),
+            tracing_include_engine: true,
             tracing_engine_detail: false,
+            tracing_requirements_open: false,
             #[cfg(test)]
             tracing_start_rect: None,
+            #[cfg(test)]
+            tracing_requirements_rect: None,
             #[cfg(test)]
             setting_card_rects: Vec::new(),
             #[cfg(test)]
@@ -183,6 +225,9 @@ impl SettingsDialog {
     }
 
     pub fn set_tracing_status(&mut self, status: TracingStatus) {
+        if !status.engine_available {
+            self.tracing_include_engine = false;
+        }
         self.tracing_status = status;
     }
 
@@ -377,11 +422,13 @@ impl SettingsDialog {
             self.script_log_windows.clear();
             self.script_documentation_windows.clear();
             self.script_status_windows.clear();
+            self.tracing_requirements_open = false;
         } else {
             self.open = open;
         }
         self.show_audio_confirmation(context, audio_drivers, &mut response);
         self.show_script_windows(context, scripting, script_paths);
+        self.show_tracing_requirements(context);
         response
     }
 
@@ -466,12 +513,48 @@ impl SettingsDialog {
             "Capture performance data or investigate UI/audio bugs. Tracing can be stopped again, but capturing may degrade performance.",
         );
         ui.add_space(8.0);
-        ui.checkbox(
-            &mut self.tracing_engine_detail,
-            "include detailed engine events",
+        #[cfg(any(target_arch = "wasm32", test))]
+        {
+            ui.strong("Trace contents");
+            ui.radio_value(&mut self.tracing_include_engine, false, "Application only");
+            ui.weak("Captures the UI and application, but not audio-engine processing.");
+            ui.add_enabled_ui(self.tracing_status.engine_available, |ui| {
+                ui.radio_value(
+                    &mut self.tracing_include_engine,
+                    true,
+                    "Application + engine",
+                );
+            });
+            if !self.tracing_status.engine_available {
+                let requirements = ui
+                    .link("COOP/COEP is needed for application + engine tracing. Learn more.")
+                    .on_hover_text(
+                        self.tracing_status
+                            .engine_unavailable_reason
+                            .unwrap_or("Engine tracing is unavailable"),
+                    );
+                #[cfg(test)]
+                {
+                    self.tracing_requirements_rect = Some(requirements.rect);
+                }
+                if requirements.clicked() {
+                    self.tracing_requirements_open = true;
+                }
+            }
+        }
+        #[cfg(not(any(target_arch = "wasm32", test)))]
+        ui.label("Application and engine events are included.");
+        ui.add_enabled_ui(
+            self.tracing_include_engine && self.tracing_status.engine_available,
+            |ui| {
+                ui.checkbox(
+                    &mut self.tracing_engine_detail,
+                    "Include detailed engine events",
+                );
+            },
         );
         let start = ui.add_enabled(
-            self.tracing_status.available && !self.tracing_status.active,
+            self.tracing_status.available && !self.tracing_status.active(),
             egui::Button::new("Start tracing"),
         );
         #[cfg(test)]
@@ -479,13 +562,18 @@ impl SettingsDialog {
             self.tracing_start_rect = Some(start.rect);
         }
         if start.clicked() {
+            let mode = if self.tracing_include_engine {
+                TracingMode::Full {
+                    engine_detail: self.tracing_engine_detail,
+                }
+            } else {
+                TracingMode::Application
+            };
             response
                 .settings_actions
-                .push(SettingsAction::StartTracing {
-                    engine_detail: self.tracing_engine_detail,
-                });
+                .push(SettingsAction::StartTracing { mode });
         }
-        if self.tracing_status.active {
+        if self.tracing_status.active() {
             ui.colored_label(colors::WARNING, "Tracing is already active");
         } else if !self.tracing_status.available {
             ui.colored_label(
@@ -495,6 +583,42 @@ impl SettingsDialog {
                     .unwrap_or("Tracing is unavailable in this build."),
             );
         }
+    }
+
+    fn show_tracing_requirements(&mut self, context: &egui::Context) {
+        if !self.tracing_requirements_open {
+            return;
+        }
+        let mut open = true;
+        let mut close = false;
+        egui::Window::new("Enable application + engine tracing")
+            .id(egui::Id::new("tracing_requirements"))
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(480.0)
+            .show(context, |ui| {
+                ui.label(
+                    "The audio engine runs separately from the app. Full tracing needs browser shared memory to collect its trace without disrupting audio.",
+                );
+                ui.add_space(6.0);
+                ui.label("Recommended: host the app over HTTPS or localhost and return these headers:");
+                ui.monospace("Cross-Origin-Opener-Policy: same-origin");
+                ui.monospace("Cross-Origin-Embedder-Policy: require-corp");
+                ui.add_space(6.0);
+                ui.label("For local testing only:");
+                ui.monospace("Chrome: --shared-array-buffer-unrestricted-access-allowed");
+                ui.label("Firefox Developer Edition or Nightly: set this to true in about:config:");
+                ui.monospace(
+                    "dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled",
+                );
+                ui.add_space(6.0);
+                ui.label("Restart or reload the browser after changing this. Test overrides weaken browser security, so use a separate test profile.");
+                if ui.button("Close").clicked() {
+                    close = true;
+                }
+            });
+        self.tracing_requirements_open = open && !close;
     }
 
     fn show_appearance(&mut self, ui: &mut egui::Ui) {
@@ -1677,7 +1801,9 @@ mod tests {
         dialog.set_tracing_status(TracingStatus {
             available: true,
             unavailable_reason: None,
-            active: false,
+            engine_available: true,
+            engine_unavailable_reason: None,
+            active_mode: None,
             buffer_capacity_bytes: 0,
         });
         dialog.tracing_engine_detail = true;
@@ -1727,7 +1853,94 @@ mod tests {
         assert!(response.settings_actions.iter().any(|action| matches!(
             action,
             SettingsAction::StartTracing {
-                engine_detail: true
+                mode: TracingMode::Full {
+                    engine_detail: true
+                }
+            }
+        )));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn unavailable_engine_tracing_selects_application_and_links_requirements() {
+        let (registry, _) = fixture();
+        let context = egui::Context::default();
+        let mut dialog = SettingsDialog::new(registry);
+        dialog.set_tracing_status(TracingStatus {
+            available: true,
+            unavailable_reason: None,
+            engine_available: false,
+            engine_unavailable_reason: Some("Shared browser memory is unavailable"),
+            active_mode: None,
+            buffer_capacity_bytes: 0,
+        });
+        let frame = |dialog: &mut SettingsDialog, events: Vec<egui::Event>| {
+            let mut response = SettingsDialogResponse::default();
+            let mut output = context.run_ui(
+                egui::RawInput {
+                    screen_rect: Some(egui::Rect::from_min_size(
+                        egui::Pos2::ZERO,
+                        egui::vec2(600.0, 400.0),
+                    )),
+                    events,
+                    ..Default::default()
+                },
+                |ui| dialog.show_developer(ui, &mut response),
+            );
+            output.textures_delta.clear();
+            response
+        };
+
+        frame(&mut dialog, Vec::new());
+        let requirements = dialog.tracing_requirements_rect.unwrap().center();
+        frame(
+            &mut dialog,
+            vec![
+                egui::Event::PointerMoved(requirements),
+                egui::Event::PointerButton {
+                    pos: requirements,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+                egui::Event::PointerButton {
+                    pos: requirements,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        assert!(dialog.tracing_requirements_open);
+
+        let start = dialog.tracing_start_rect.unwrap().center();
+        frame(
+            &mut dialog,
+            vec![
+                egui::Event::PointerMoved(start),
+                egui::Event::PointerButton {
+                    pos: start,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        let response = frame(
+            &mut dialog,
+            vec![
+                egui::Event::PointerMoved(start),
+                egui::Event::PointerButton {
+                    pos: start,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        assert!(response.settings_actions.iter().any(|action| matches!(
+            action,
+            SettingsAction::StartTracing {
+                mode: TracingMode::Application
             }
         )));
     }

--- a/src/rust/shoop_egui/src/settings_dialog.rs
+++ b/src/rust/shoop_egui/src/settings_dialog.rs
@@ -1794,6 +1794,21 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn tracing_modes_report_scope_detail_and_labels() {
+        let application = TracingMode::Application;
+        assert!(!application.includes_engine());
+        assert!(!application.engine_detail());
+        assert_eq!(application.label(), "application only");
+
+        let full = TracingMode::Full {
+            engine_detail: true,
+        };
+        assert!(full.includes_engine());
+        assert!(full.engine_detail());
+        assert_eq!(full.label(), "application + engine");
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn developer_category_starts_tracing_with_engine_detail() {
         let (registry, _) = fixture();
         let context = egui::Context::default();
@@ -1911,7 +1926,20 @@ mod tests {
             ],
         );
         assert!(dialog.tracing_requirements_open);
+        let mut requirements_output = context.run_ui(
+            egui::RawInput {
+                screen_rect: Some(egui::Rect::from_min_size(
+                    egui::Pos2::ZERO,
+                    egui::vec2(700.0, 500.0),
+                )),
+                ..Default::default()
+            },
+            |ui| dialog.show_tracing_requirements(ui.ctx()),
+        );
+        requirements_output.textures_delta.clear();
+        assert!(!requirements_output.shapes.is_empty());
 
+        frame(&mut dialog, Vec::new());
         let start = dialog.tracing_start_rect.unwrap().center();
         frame(
             &mut dialog,

--- a/src/rust/shoopdaloop/README.md
+++ b/src/rust/shoopdaloop/README.md
@@ -82,14 +82,23 @@ cd src/rust/shoopdaloop
 trunk serve --open
 ```
 
-Multirealm Perfetto tracing additionally requires cross-origin isolation. Build
-and serve the hosted output with the repository header-aware server:
+Application-only browser tracing works without cross-origin isolation. Select it
+under **Settings > Developer**, or start it with
+`?tracing=1&tracing-scope=application`. Full tracing additionally captures the
+active AudioWorklet or Worker and needs `SharedArrayBuffer`, normally enabled by
+cross-origin isolation. Build and serve the hosted output with the repository
+header-aware server:
 
 ```sh
 trunk build
 cd ../../..
 python3 scripts/serve_web.py src/rust/shoopdaloop/dist --port 8080
 ```
+
+The in-app tracing help lists the required COOP/COEP headers and local-only
+Chrome and Firefox test overrides. `?tracing=1` retains full tracing by default;
+`?tracing-scope=full&tracing-engine-detail=1` also enables detailed engine
+events.
 
 The same startup options are available as query parameters. For example, `?session=https%3A%2F%2Fexample.com%2Fdemo.shoop&force-url-session=1` fetches that trusted startup URL without confirmation. URL sessions opened later from the application still require confirmation.
 

--- a/src/rust/shoopdaloop/browser_tracing_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_tracing_smoke.mjs
@@ -10,6 +10,7 @@ const debugPort = Number(process.env.DEBUG_PORT || 19891);
 const root = path.resolve('../../..');
 const downloads = path.join(root, 'target/browser-tracing-smoke');
 const realm = process.env.TRACE_REALM || 'worker';
+const applicationOnly = realm === 'application';
 const output = path.join(root, `target/perfetto-validation/browser-${realm}.pftrace`);
 const processes = [];
 
@@ -46,10 +47,16 @@ try {
   await rm(downloads, {recursive: true, force: true});
   await mkdir(downloads, {recursive: true});
   await mkdir(path.dirname(output), {recursive: true});
-  start('python3', [
-    path.join(root, 'scripts/serve_web.py'),
-    'dist', '--port', String(webPort),
-  ], {cwd: path.resolve('.')});
+  if (applicationOnly) {
+    start('python3', [
+      '-m', 'http.server', String(webPort), '--bind', '127.0.0.1', '--directory', 'dist',
+    ], {cwd: path.resolve('.')});
+  } else {
+    start('python3', [
+      path.join(root, 'scripts/serve_web.py'),
+      'dist', '--port', String(webPort),
+    ], {cwd: path.resolve('.')});
+  }
   await waitForHttp(`http://127.0.0.1:${webPort}/`, 100);
   start(chrome, [
     '--headless=new', '--no-sandbox', '--disable-dev-shm-usage',
@@ -58,7 +65,7 @@ try {
     '--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream',
     `--remote-debugging-port=${debugPort}`,
     `--user-data-dir=${path.join(downloads, 'profile')}`,
-    `http://127.0.0.1:${webPort}/?${realm === 'worker' ? 'worker=1&' : ''}tracing=1&tracing-smoke-test=1`,
+    `http://127.0.0.1:${webPort}/?${realm === 'worker' ? 'worker=1&' : ''}tracing=1&${applicationOnly ? 'tracing-scope=application&' : ''}tracing-smoke-test=1`,
   ], {env: {...process.env, HOME: process.env.HOME}});
   const targets = await waitForJson(`http://127.0.0.1:${debugPort}/json/list`);
   const page = targets.find(target => target.type === 'page');

--- a/src/rust/shoopdaloop/src/app_args.rs
+++ b/src/rust/shoopdaloop/src/app_args.rs
@@ -10,6 +10,13 @@ pub enum SettingsTest {
     Unavailable,
 }
 
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum BrowserTracingScope {
+    Application,
+    Full,
+}
+
 #[derive(Clone, Debug, Default, Parser)]
 #[command(name = "shoopdaloop", about = "ShoopDaLoop application")]
 pub struct AppArgs {
@@ -25,6 +32,10 @@ pub struct AppArgs {
     /// Add detailed per-node engine zones. Requires tracing.
     #[arg(long, requires = "tracing")]
     pub tracing_engine_detail: bool,
+    #[cfg(target_arch = "wasm32")]
+    /// Select application-only or full browser tracing. Defaults to full.
+    #[arg(long, value_enum, requires = "tracing")]
+    pub tracing_scope: Option<BrowserTracingScope>,
     #[arg(long, hide = true, requires = "tracing")]
     pub tracing_smoke_test: bool,
     #[cfg(not(target_arch = "wasm32"))]
@@ -73,7 +84,7 @@ pub struct AppArgs {
 #[cfg(target_arch = "wasm32")]
 pub fn parse_web_query(query: &str) -> Result<AppArgs, clap::Error> {
     use clap::CommandFactory;
-    let command = AppArgs::command();
+    let mut command = AppArgs::command();
     let mut argv = vec!["shoopdaloop".to_owned()];
     for pair in query
         .trim_start_matches('?')
@@ -99,7 +110,14 @@ pub fn parse_web_query(query: &str) -> Result<AppArgs, clap::Error> {
             }
         }
     }
-    AppArgs::try_parse_from(argv)
+    let args = AppArgs::try_parse_from(argv)?;
+    if args.tracing_scope == Some(BrowserTracingScope::Application) && args.tracing_engine_detail {
+        return Err(command.error(
+            clap::error::ErrorKind::ArgumentConflict,
+            "--tracing-engine-detail requires --tracing-scope=full",
+        ));
+    }
+    Ok(args)
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -178,6 +196,27 @@ mod tests {
             Some("https://example.com/demo.shoop")
         );
         assert!(args.force_url_session);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn web_query_parses_tracing_scope_and_rejects_application_engine_detail() {
+        let application = parse_web_query("?tracing=1&tracing-scope=application").unwrap();
+        assert_eq!(
+            application.tracing_scope,
+            Some(BrowserTracingScope::Application)
+        );
+        assert!(!application.tracing_engine_detail);
+
+        let full =
+            parse_web_query("?tracing=1&tracing-scope=full&tracing-engine-detail=1").unwrap();
+        assert_eq!(full.tracing_scope, Some(BrowserTracingScope::Full));
+        assert!(full.tracing_engine_detail);
+
+        assert!(
+            parse_web_query("?tracing=1&tracing-scope=application&tracing-engine-detail=1")
+                .is_err()
+        );
+        assert!(parse_web_query("?tracing-scope=application").is_err());
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -45,7 +45,7 @@ use shoop_egui::{
     register_audio_settings, register_settings_with_appearance_defaults, AppIntent, AppSnapshot,
     AppWidget, ScriptKind, SettingsAction, SettingsRegistryBuilder, UI_SCALE_FACTOR,
 };
-use shoop_egui::{TracingStatus, TracingStopped};
+use shoop_egui::{TracingMode, TracingStatus, TracingStopped};
 
 #[cfg(target_arch = "wasm32")]
 use shoop_app::CooperativeApplicationRuntime;
@@ -64,6 +64,8 @@ mod browser_worker;
 mod native_preview;
 mod settings;
 use app_args::AppArgs;
+#[cfg(target_arch = "wasm32")]
+use app_args::BrowserTracingScope;
 #[cfg(not(target_arch = "wasm32"))]
 use shoop_app::StartupScript;
 #[cfg(not(target_arch = "wasm32"))]
@@ -87,6 +89,7 @@ fn application_icon() -> egui::IconData {
 #[cfg(not(target_arch = "wasm32"))]
 struct NativeTracing {
     capture: Option<shoop_common::tracing_capture::ReusableCaptureSession>,
+    active_engine_detail: bool,
     start_on_app_init: Option<bool>,
 }
 
@@ -99,6 +102,7 @@ impl NativeTracing {
         shoop_common::init()?;
         Ok(Self {
             capture: None,
+            active_engine_detail: false,
             start_on_app_init: cli.tracing.then_some(cli.tracing_engine_detail),
         })
     }
@@ -129,6 +133,7 @@ impl NativeTracing {
             "frontend.egui.tracing_started"
         );
         self.capture = Some(capture);
+        self.active_engine_detail = engine_detail;
         Ok(())
     }
 
@@ -148,6 +153,7 @@ impl NativeTracing {
             anyhow::bail!("tracing is not active");
         };
         shoop_common::tracing_helpers::set_engine_detail_enabled(false);
+        self.active_engine_detail = false;
         let disposition = if save {
             CaptureDisposition::Save
         } else {
@@ -167,7 +173,11 @@ impl NativeTracing {
         TracingStatus {
             available: true,
             unavailable_reason: None,
-            active: status.active,
+            engine_available: true,
+            engine_unavailable_reason: None,
+            active_mode: status.active.then_some(TracingMode::Full {
+                engine_detail: self.active_engine_detail,
+            }),
             buffer_capacity_bytes: status.event_storage_bytes,
         }
     }
@@ -187,7 +197,7 @@ type SharedNativeTracing = Arc<Mutex<NativeTracing>>;
 
 #[derive(Clone, Copy)]
 enum PendingTracingAction {
-    Start { engine_detail: bool },
+    Start { mode: TracingMode },
     Stop { save: bool },
     FinishStop { save: bool },
 }
@@ -195,39 +205,44 @@ enum PendingTracingAction {
 #[cfg(target_arch = "wasm32")]
 struct BrowserTracing {
     capture: Option<shoop_tracing::BrowserCapture>,
+    active_mode: Option<TracingMode>,
     window_calibrations: Vec<shoop_tracing::BrowserCalibration>,
-    unavailable_reason: Option<&'static str>,
+    engine_unavailable_reason: Option<&'static str>,
 }
 
 #[cfg(target_arch = "wasm32")]
 impl BrowserTracing {
     fn new() -> Self {
         let global = js_sys::global();
-        let isolated = js_sys::Reflect::get(&global, &"crossOriginIsolated".into())
-            .ok()
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
         let has_shared_buffer = js_sys::Reflect::get(&global, &"SharedArrayBuffer".into())
             .is_ok_and(|value| value.is_function());
-        let unavailable_reason = (!isolated || !has_shared_buffer)
-            .then_some("Multirealm tracing requires COOP/COEP cross-origin isolation");
         Self {
             capture: None,
+            active_mode: None,
             window_calibrations: Vec::new(),
-            unavailable_reason,
+            engine_unavailable_reason: (!has_shared_buffer)
+                .then_some("Shared browser memory is unavailable"),
         }
     }
 
-    fn start_capture(&mut self, engine_detail: bool) -> anyhow::Result<()> {
-        if let Some(reason) = self.unavailable_reason {
-            anyhow::bail!(reason);
+    fn start_capture(&mut self, mode: TracingMode) -> anyhow::Result<()> {
+        if mode.includes_engine() {
+            if let Some(reason) = self.engine_unavailable_reason {
+                anyhow::bail!(reason);
+            }
         }
         if self.capture.is_none() {
-            self.capture = Some(
-                shoop_tracing::BrowserCapture::start(engine_detail).map_err(anyhow::Error::msg)?,
+            let capture = shoop_tracing::BrowserCapture::start(mode.engine_detail())
+                .map_err(anyhow::Error::msg)?;
+            let calibration = browser_window_calibration()?;
+            self.capture = Some(capture);
+            self.active_mode = Some(mode);
+            self.window_calibrations = vec![calibration];
+            tracing::info!(
+                scope = mode.label(),
+                engine_detail = mode.engine_detail(),
+                "frontend.egui.tracing_started"
             );
-            self.window_calibrations = vec![browser_window_calibration()?];
-            tracing::info!(engine_detail, "frontend.egui.tracing_started");
         }
         Ok(())
     }
@@ -240,11 +255,17 @@ impl BrowserTracing {
     }
 
     fn discard_active(&mut self) -> anyhow::Result<()> {
-        if let Some(capture) = self.capture.take() {
+        let capture = self.capture.take();
+        self.active_mode = None;
+        self.window_calibrations.clear();
+        if let Some(capture) = capture {
             capture.discard().map_err(anyhow::Error::msg)?;
         }
-        self.window_calibrations.clear();
         Ok(())
+    }
+
+    fn active_mode(&self) -> Option<TracingMode> {
+        self.active_mode
     }
 
     fn stop_capture(
@@ -256,6 +277,7 @@ impl BrowserTracing {
             .capture
             .take()
             .ok_or_else(|| anyhow::anyhow!("tracing is not active"))?;
+        self.active_mode = None;
         if !save {
             capture.discard().map_err(anyhow::Error::msg)?;
             self.window_calibrations.clear();
@@ -273,9 +295,11 @@ impl BrowserTracing {
 
     fn status(&self) -> TracingStatus {
         TracingStatus {
-            available: self.unavailable_reason.is_none(),
-            unavailable_reason: self.unavailable_reason,
-            active: self.capture.is_some(),
+            available: true,
+            unavailable_reason: None,
+            engine_available: self.engine_unavailable_reason.is_none(),
+            engine_unavailable_reason: self.engine_unavailable_reason,
+            active_mode: self.active_mode,
             buffer_capacity_bytes: 0,
         }
     }
@@ -472,9 +496,20 @@ impl UnifiedApp {
             #[cfg(target_arch = "wasm32")]
             tracing_smoke_started: None,
             pending_tracing_action: if cfg!(target_arch = "wasm32") && args.tracing {
-                Some(PendingTracingAction::Start {
-                    engine_detail: args.tracing_engine_detail,
-                })
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let mode = match args.tracing_scope.unwrap_or(BrowserTracingScope::Full) {
+                        BrowserTracingScope::Application => TracingMode::Application,
+                        BrowserTracingScope::Full => TracingMode::Full {
+                            engine_detail: args.tracing_engine_detail,
+                        },
+                    };
+                    Some(PendingTracingAction::Start { mode })
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    None
+                }
             } else {
                 None
             },
@@ -622,9 +657,14 @@ impl UnifiedApp {
                 .lock()
                 .map_err(|_| anyhow::anyhow!("tracing controller lock is poisoned"))
                 .and_then(|mut tracing| match action {
-                    PendingTracingAction::Start { engine_detail } => {
-                        tracing.start_capture(engine_detail).map(|()| None)
-                    }
+                    PendingTracingAction::Start { mode } => match mode {
+                        TracingMode::Full { engine_detail } => {
+                            tracing.start_capture(engine_detail).map(|()| None)
+                        }
+                        TracingMode::Application => {
+                            anyhow::bail!("application-only tracing is browser-only")
+                        }
+                    },
                     PendingTracingAction::Stop { save } => {
                         tracing.quiesce_capture()?;
                         self.pending_tracing_action =
@@ -652,25 +692,34 @@ impl UnifiedApp {
     fn process_tracing(&mut self) {
         if let Some(action) = self.pending_tracing_action.take() {
             let result: anyhow::Result<Option<TracingStopped>> = (|| match action {
-                PendingTracingAction::Start { engine_detail } => {
-                    self.tracing.start_capture(engine_detail)?;
-                    if let Err(error) = self.runtime.start_tracing(engine_detail) {
-                        self.runtime.cancel_tracing_request();
-                        if let Err(discard_error) = self.tracing.discard_active() {
-                            tracing::error!(
-                                error = %discard_error,
-                                "frontend.egui.tracing_start_rollback_failed"
-                            );
+                PendingTracingAction::Start { mode } => {
+                    self.tracing.start_capture(mode)?;
+                    if mode.includes_engine() {
+                        if let Err(error) = self.runtime.start_tracing(mode.engine_detail()) {
+                            self.runtime.cancel_tracing_request();
+                            if let Err(discard_error) = self.tracing.discard_active() {
+                                tracing::error!(
+                                    error = %discard_error,
+                                    "frontend.egui.tracing_start_rollback_failed"
+                                );
+                            }
+                            return Err(error);
                         }
-                        return Err(error);
                     }
                     Ok(None)
                 }
-                PendingTracingAction::Stop { save } => {
-                    self.runtime.request_stop_tracing()?;
-                    self.pending_tracing_action = Some(PendingTracingAction::FinishStop { save });
-                    Ok(None)
-                }
+                PendingTracingAction::Stop { save } => match self.tracing.active_mode() {
+                    Some(TracingMode::Application) => {
+                        self.tracing.stop_capture(save, Vec::new()).map(Some)
+                    }
+                    Some(TracingMode::Full { .. }) => {
+                        self.runtime.request_stop_tracing()?;
+                        self.pending_tracing_action =
+                            Some(PendingTracingAction::FinishStop { save });
+                        Ok(None)
+                    }
+                    None => anyhow::bail!("tracing is not active"),
+                },
                 PendingTracingAction::FinishStop { save } => {
                     match self.runtime.take_trace_realms()? {
                         Some(realms) => self.tracing.stop_capture(save, realms).map(Some),
@@ -694,12 +743,12 @@ impl UnifiedApp {
         if let Err(error) = self.tracing.poll() {
             self.settings.report_action_error(error.to_string());
         }
-        if let Err(error) = self.runtime.poll_tracing() {
-            tracing::error!(error = %error, "frontend.egui.tracing_realm_poll_failed");
-            self.settings.report_action_error(error.to_string());
-        }
         let mut status = self.tracing.status();
-        if status.active {
+        if status.active_mode.is_some_and(TracingMode::includes_engine) {
+            if let Err(error) = self.runtime.poll_tracing() {
+                tracing::error!(error = %error, "frontend.egui.tracing_realm_poll_failed");
+                self.settings.report_action_error(error.to_string());
+            }
             if let Err(error) = self.runtime.ensure_tracing_realm() {
                 self.runtime.cancel_tracing_request();
                 if let Err(discard_error) = self.tracing.discard_active() {
@@ -713,7 +762,12 @@ impl UnifiedApp {
                 status = self.tracing.status();
             }
         }
-        if self.args.tracing_smoke_test && status.active && self.runtime.tracing_realm_ready() {
+        let tracing_smoke_ready = match status.active_mode {
+            Some(TracingMode::Application) => true,
+            Some(TracingMode::Full { .. }) => self.runtime.tracing_realm_ready(),
+            None => false,
+        };
+        if self.args.tracing_smoke_test && tracing_smoke_ready {
             let started = self.tracing_smoke_started.get_or_insert_with(|| {
                 tracing::info!("frontend.egui.tracing_smoke_realm_ready");
                 Instant::now()
@@ -731,10 +785,9 @@ impl UnifiedApp {
     #[cfg(not(target_arch = "wasm32"))]
     fn handle_settings_action(&mut self, action: SettingsAction) {
         let action = match action {
-            SettingsAction::StartTracing { engine_detail } => {
+            SettingsAction::StartTracing { mode } => {
                 if self.tracing.is_some() {
-                    self.pending_tracing_action =
-                        Some(PendingTracingAction::Start { engine_detail });
+                    self.pending_tracing_action = Some(PendingTracingAction::Start { mode });
                 } else {
                     self.settings
                         .report_action_error("Tracing is unavailable in this build");
@@ -836,8 +889,8 @@ impl UnifiedApp {
     #[cfg(target_arch = "wasm32")]
     fn handle_settings_action(&mut self, action: SettingsAction) {
         let action = match action {
-            SettingsAction::StartTracing { engine_detail } => {
-                self.pending_tracing_action = Some(PendingTracingAction::Start { engine_detail });
+            SettingsAction::StartTracing { mode } => {
+                self.pending_tracing_action = Some(PendingTracingAction::Start { mode });
                 return;
             }
             SettingsAction::StopTracing { save } => {
@@ -1502,7 +1555,7 @@ impl eframe::App for UnifiedApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         self.process_tracing();
         #[cfg(target_arch = "wasm32")]
-        if self.tracing.status().active || self.pending_tracing_action.is_some() {
+        if self.tracing.status().active() || self.pending_tracing_action.is_some() {
             ui.ctx().request_repaint_after(Duration::from_millis(50));
         }
         self.show(ui);


### PR DESCRIPTION
## Summary
- add explicit application-only and full browser tracing modes while preserving full capture as the CLI default
- keep application-only Perfetto capture available when `SharedArrayBuffer` is unavailable and retain all-or-nothing engine realm capture
- add a clickable COOP/COEP help dialog with hosting headers and local Chrome/Firefox test overrides
- add a non-isolated Chromium application-only capture smoke and document the new scope

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `RUSTFLAGS="-D warnings" cargo build -p shoopdaloop -p shoop_audio_worklet --target wasm32-unknown-unknown --no-default-features`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1524 passed, 4 skipped)
- `python3 scripts/run_wasm_tests.py --runtime node --profile dev` (all packages passed)
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `python3 scripts/check_wasm_smoke_budget.py`
- `trunk build`

The local environment has no Chrome executable; the packaged application-only, Worker, and AudioWorklet browser smokes run in the web debug CI job.
