### PR TITLE
Replace browser trace shared memory with transferable chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,7 +3275,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perfetto-everywhere-collector"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 dependencies = [
  "perfetto-everywhere-core",
  "perfetto-everywhere-web",
@@ -3287,12 +3287,12 @@ dependencies = [
 [[package]]
 name = "perfetto-everywhere-core"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 
 [[package]]
 name = "perfetto-everywhere-native"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 dependencies = [
  "perfetto-everywhere-core",
  "perfetto-sdk",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "perfetto-everywhere-raw"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 dependencies = [
  "perfetto-everywhere-core",
 ]
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "perfetto-everywhere-tracing"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 dependencies = [
  "perfetto-everywhere-core",
  "tracing",
@@ -3319,10 +3319,11 @@ dependencies = [
 [[package]]
 name = "perfetto-everywhere-web"
 version = "0.1.0"
-source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=f621af951b80f702c6b710e420c8a1abf5e333c7#f621af951b80f702c6b710e420c8a1abf5e333c7"
+source = "git+https://github.com/SanderVocke/perfetto-everywhere?rev=caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4#caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4"
 dependencies = [
  "js-sys",
  "perfetto-everywhere-core",
+ "perfetto-everywhere-raw",
  "wasm-bindgen",
 ]
 

--- a/docs/perfetto_migration_report.md
+++ b/docs/perfetto_migration_report.md
@@ -28,8 +28,9 @@ equal-timestamp producer ordering.
   sample-frame timestamps, calibrations, metadata, loss, and high-water health.
   The Window continuously consumes each chunk and returns its detached buffer to
   the originating realm, so captures are not limited to one pool rotation or a
-  fixed record count. Collector allocation or storage failure makes the capture
-  incomplete and prevents save rather than silently truncating it.
+  fixed record count. A 512 MiB per-realm collector safety quota, allocation
+  failure, or storage failure makes the capture incomplete and prevents save
+  rather than silently truncating it.
 - Browser final protobuf collection currently runs during explicit finalization
   on the Window thread rather than in a separate collector Worker. This avoids a
   second generated Wasm artifact while preserving bounded realtime producers and

--- a/docs/perfetto_migration_report.md
+++ b/docs/perfetto_migration_report.md
@@ -7,11 +7,12 @@ ShoopDaLoop tracing is implemented through `shoop_tracing` with standard
 nextest, Node Wasm tests, and Chromium Wasm tests. Tracy dependencies, patches,
 prebuilt setup, workflows, active documentation, and artifacts were removed.
 
-The reviewed upstream is `SanderVocke/perfetto-everywhere` merged PR 1 at commit
-`f621af951b80f702c6b710e420c8a1abf5e333c7`. Shoop pins that exact revision.
-The upstream additions are an import-free bounded raw-Wasm producer, configurable
-browser Worker assets, wasm-bindgen 0.2.127 alignment, native static-name caching,
-and preservation of equal-timestamp producer ordering.
+The reviewed upstream is `SanderVocke/perfetto-everywhere` through merged PR 2
+at commit `caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4`. Shoop pins that exact
+revision. The upstream additions include an import-free bounded raw-Wasm
+producer, recyclable transferable browser chunks, configurable Worker assets,
+wasm-bindgen 0.2.127 alignment, native static-name caching, and preservation of
+equal-timestamp producer ordering.
 
 ## Architecture and semantics
 
@@ -23,11 +24,12 @@ and preservation of equal-timestamp producer ordering.
   can restart in one process.
 - Browser Window records use `performance.now()`. The active Worker or
   AudioWorklet writes fixed 48-byte records into preallocated raw-Wasm storage,
-  drains allocation-free into a SharedArrayBuffer ring, and publishes exact
+  drains into a preallocated transferable ArrayBuffer pool, and publishes exact
   sample-frame timestamps, calibrations, metadata, loss, and high-water health.
-  The Window continuously consumes each ring during capture, so captures are not
-  limited to one ring capacity. Retention is capped at 262,144 complete records
-  per realm; later records increment health drops instead of growing memory.
+  The Window continuously consumes each chunk and returns its detached buffer to
+  the originating realm, so captures are not limited to one pool rotation or a
+  fixed record count. Collector allocation or storage failure makes the capture
+  incomplete and prevents save rather than silently truncating it.
 - Browser final protobuf collection currently runs during explicit finalization
   on the Window thread rather than in a separate collector Worker. This avoids a
   second generated Wasm artifact while preserving bounded realtime producers and
@@ -39,9 +41,7 @@ and preservation of equal-timestamp producer ordering.
 - Integer counts, identifiers, occupancy, generations, and reason codes are i64
   counters. Fractional values use f64 counters.
 
-Hosted browser multirealm capture requires COOP `same-origin`, COEP
-`require-corp`, and `SharedArrayBuffer`. `scripts/serve_web.py` supplies those
-headers. Unsupported/direct-file deployments keep running and report tracing as
+Hosted browser multirealm capture uses recyclable transferable buffers and does not require COOP/COEP isolation headers. Unsupported/direct-file deployments keep running and report tracing as
 unavailable.
 
 ## Test capture
@@ -88,7 +88,7 @@ ChromeDriver 147.0.7727.137 included:
   emitted more than the 8,192-record ring capacity with zero drops. The audio
   smoke also rebuilt the AudioWorklet graph during capture and retained both
   synchronized realm segments. The captures were produced from the packaged
-  application through actual SharedArrayBuffer/raw-Wasm bridges.
+  application through the transferable-buffer/raw-Wasm bridges.
 - The retained hosted output-only AudioWorklet workflow passed after the tracing
   changes. Trunk debug packaging and the raw worklet artifact contract passed.
 

--- a/docs/source/developers.tracing.rst
+++ b/docs/source/developers.tracing.rst
@@ -64,8 +64,9 @@ AudioWorklet timestamps are exact logical sample frames, not callback CPU
 entry/exit measurements. Browser realms rotate preallocated transferable
 ``ArrayBuffer`` chunks and the Window recycles each buffer after consumption,
 so capture duration is not limited by the producer pool size. The collector
-retains consumed trace data until save; allocation or storage failure aborts the
-capture rather than silently producing a complete-looking trace. Always inspect
+retains consumed trace data until save, with a 512 MiB safety quota per realm;
+quota, allocation, or storage failure aborts the capture rather than silently
+producing a complete-looking trace. Always inspect
 clock calibration, producer drops, discontinuities, and health data when
 interpreting a browser trace.
 

--- a/docs/source/developers.tracing.rst
+++ b/docs/source/developers.tracing.rst
@@ -31,9 +31,9 @@ are supported. Use the pinned ``scripts/trace_processor`` wrapper for queries.
 
 Hosted Chromium exposes the same controls and downloads application-owned trace
 bytes. One capture combines Window with the active Engine Worker or
-AudioWorklet. Multirealm audio tracing requires cross-origin isolation and
-``SharedArrayBuffer``; serve COOP ``same-origin`` and COEP ``require-corp``.
-Unsupported deployments remain functional and report why tracing is unavailable.
+AudioWorklet. Multirealm audio tracing transfers recyclable ``ArrayBuffer``
+chunks and does not require cross-origin isolation. Unsupported browser APIs
+remain functional and report why tracing is unavailable.
 
 Trace structure
 ~~~~~~~~~~~~~~~
@@ -61,10 +61,12 @@ fractional loads/ratios use floating counters. Structured logs preserve level,
 target, message, and typed fields as Perfetto arguments.
 
 AudioWorklet timestamps are exact logical sample frames, not callback CPU
-entry/exit measurements. Browser collection retains at most 262,144 complete
-records per realm (12 MiB of raw records); later records are discarded and
-reported in producer health rather than growing tab memory indefinitely. Always
-inspect clock calibration, producer drops, discontinuities, and health data when
+entry/exit measurements. Browser realms rotate preallocated transferable
+``ArrayBuffer`` chunks and the Window recycles each buffer after consumption,
+so capture duration is not limited by the producer pool size. The collector
+retains consumed trace data until save; allocation or storage failure aborts the
+capture rather than silently producing a complete-looking trace. Always inspect
+clock calibration, producer drops, discontinuities, and health data when
 interpreting a browser trace.
 
 Tracing is diagnostic instrumentation, not a transparent realtime measurement.

--- a/scripts/tests/trace_chunk_transport.test.mjs
+++ b/scripts/tests/trace_chunk_transport.test.mjs
@@ -32,8 +32,12 @@ class FakeHost {
 }
 
 class FakePort {
-  constructor() { this.messages = []; }
+  constructor() {
+    this.messages = [];
+    this.sources = [];
+  }
   postMessage(message, transfer = []) {
+    this.sources.push(message);
     this.messages.push(structuredClone(message, {transfer}));
   }
 }
@@ -73,6 +77,18 @@ test('rotates and recycles chunks beyond the producer pool', () => {
   const stopped = port.messages.find(message => message.kind === 'shoop-trace-stopped');
   assert.equal(stopped.chunkCount, 8);
   assert.equal(host.stopped, true);
+  const chunkEnvelopes = port.sources.filter(message => message.kind === 'shoop-trace-chunk');
+  assert.ok(new Set(chunkEnvelopes).size <= options.poolSize);
+});
+
+test('rejects capture IDs outside the JavaScript safe integer range', () => {
+  assert.throws(
+    () => new ShoopTraceChunkTransport(new FakeHost(), new FakePort(), {
+      ...options,
+      captureId: Number.MAX_SAFE_INTEGER + 1,
+    }),
+    /capture ID/,
+  );
 });
 
 test('capture exceeds the former per-realm record retention limit', () => {

--- a/scripts/tests/trace_chunk_transport.test.mjs
+++ b/scripts/tests/trace_chunk_transport.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ShoopTraceChunkTransport } from '../../src/rust/shoopdaloop/raw_wasm_host.js';
+
+class FakeHost {
+  constructor(records = 0) {
+    this.records = records;
+    this.disabled = false;
+    this.stopped = false;
+  }
+
+  traceAvailableRecords() { return this.records; }
+  traceDropped() { return 0; }
+
+  traceDrainInto(destination, offset, maximumBytes) {
+    if (this.records === 0 || maximumBytes < 48) return 0;
+    destination.fill(this.records & 0xff, offset, offset + 48);
+    this.records -= 1;
+    return 48;
+  }
+
+  traceDisable() { this.disabled = true; }
+  traceStop() { this.stopped = true; }
+  traceHealth() {
+    return {
+      emittedRecords: 10,
+      droppedRecords: 0,
+      completedDrains: 1,
+      highWaterRecords: 4,
+    };
+  }
+}
+
+class FakePort {
+  constructor() { this.messages = []; }
+  postMessage(message, transfer = []) {
+    this.messages.push(structuredClone(message, {transfer}));
+  }
+}
+
+const options = {
+  protocolVersion: 2,
+  captureId: 9,
+  capacityRecords: 1,
+  chunkBytes: 48,
+  poolSize: 3,
+};
+
+function recycle(transport, message) {
+  const returned = structuredClone(message.buffer, {transfer: [message.buffer]});
+  transport.recycle({
+    kind: 'shoop-trace-recycle',
+    captureId: message.captureId,
+    poolToken: message.poolToken,
+    buffer: returned,
+  });
+}
+
+test('rotates and recycles chunks beyond the producer pool', () => {
+  const host = new FakeHost(8);
+  const port = new FakePort();
+  const transport = new ShoopTraceChunkTransport(host, port, options);
+  transport.drain();
+  while (host.records > 0) {
+    const chunk = port.messages.find(message => message.kind === 'shoop-trace-chunk');
+    assert.ok(chunk);
+    port.messages.splice(port.messages.indexOf(chunk), 1);
+    recycle(transport, chunk);
+    transport.drain();
+  }
+  transport.stop({sourceTicks: 8, referenceMs: 1});
+  assert.equal(transport.finished, true);
+  const stopped = port.messages.find(message => message.kind === 'shoop-trace-stopped');
+  assert.equal(stopped.chunkCount, 8);
+  assert.equal(host.stopped, true);
+});
+
+test('capture exceeds the former per-realm record retention limit', () => {
+  const host = new FakeHost(262_145);
+  const port = new FakePort();
+  const transport = new ShoopTraceChunkTransport(host, port, {
+    ...options,
+    chunkBytes: 48 * 1024,
+  });
+  transport.drain();
+  while (host.records > 0) {
+    const chunk = port.messages.find(message => message.kind === 'shoop-trace-chunk');
+    assert.ok(chunk);
+    port.messages.splice(port.messages.indexOf(chunk), 1);
+    recycle(transport, chunk);
+    transport.drain();
+  }
+  transport.stop({sourceTicks: 262_145, referenceMs: 1});
+  assert.equal(transport.finished, true);
+  assert.equal(
+    port.messages.find(message => message.kind === 'shoop-trace-stopped').chunkCount,
+    257,
+  );
+});
+
+test('stop during starvation waits for recycle before final drain', () => {
+  const host = new FakeHost(4);
+  const port = new FakePort();
+  const transport = new ShoopTraceChunkTransport(host, port, options);
+  transport.drain();
+  assert.equal(host.records, 1);
+  transport.stop({sourceTicks: 4, referenceMs: 1});
+  assert.equal(transport.finished, false);
+  assert.equal(host.disabled, true);
+  const chunk = port.messages.find(message => message.kind === 'shoop-trace-chunk');
+  recycle(transport, chunk);
+  assert.equal(host.records, 0);
+  assert.equal(transport.finished, true);
+  assert.equal(
+    port.messages.find(message => message.kind === 'shoop-trace-stopped').chunkCount,
+    4,
+  );
+});
+
+test('empty capture declares zero chunks', () => {
+  const host = new FakeHost();
+  const port = new FakePort();
+  const transport = new ShoopTraceChunkTransport(host, port, options);
+  transport.stop({sourceTicks: 0, referenceMs: 1});
+  const stopped = port.messages.find(message => message.kind === 'shoop-trace-stopped');
+  assert.equal(stopped.chunkCount, 0);
+});

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -138,6 +138,13 @@ impl WorkletHost {
     }
 
     #[cfg(target_arch = "wasm32")]
+    pub fn disable_tracing(&mut self) {
+        if let Some(trace) = &self.trace {
+            trace.set_recording(false, false);
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
     pub fn set_trace_frame(&mut self, frame: u64) {
         self.trace_frame = frame;
     }
@@ -164,6 +171,14 @@ impl WorkletHost {
             .as_ref()
             .map(shoop_tracing::RawTraceProducer::health)
             .unwrap_or_default()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn trace_available_records(&self) -> usize {
+        self.trace
+            .as_ref()
+            .map(shoop_tracing::RawTraceProducer::available_records)
+            .unwrap_or(0)
     }
 
     pub fn process(
@@ -1287,6 +1302,14 @@ pub unsafe extern "C" fn shoop_worklet_trace_stop(host: *mut WorkletHost) {
 
 #[cfg(target_arch = "wasm32")]
 #[no_mangle]
+pub unsafe extern "C" fn shoop_worklet_trace_disable(host: *mut WorkletHost) {
+    if let Some(host) = host.as_mut() {
+        host.disable_tracing();
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
 pub unsafe extern "C" fn shoop_worklet_trace_set_frame(
     host: *mut WorkletHost,
     frame_low: u32,
@@ -1322,6 +1345,38 @@ pub unsafe extern "C" fn shoop_worklet_trace_ptr(host: *const WorkletHost) -> *c
 pub unsafe extern "C" fn shoop_worklet_trace_dropped(host: *const WorkletHost) -> u64 {
     host.as_ref()
         .map(|host| host.trace_health().dropped_records)
+        .unwrap_or(0)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn shoop_worklet_trace_emitted(host: *const WorkletHost) -> u64 {
+    host.as_ref()
+        .map(|host| host.trace_health().emitted_records)
+        .unwrap_or(0)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn shoop_worklet_trace_completed_drains(host: *const WorkletHost) -> u64 {
+    host.as_ref()
+        .map(|host| host.trace_health().completed_drains)
+        .unwrap_or(0)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn shoop_worklet_trace_high_water(host: *const WorkletHost) -> usize {
+    host.as_ref()
+        .map(|host| host.trace_health().high_water_records)
+        .unwrap_or(0)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn shoop_worklet_trace_available(host: *const WorkletHost) -> usize {
+    host.as_ref()
+        .map(WorkletHost::trace_available_records)
         .unwrap_or(0)
 }
 

--- a/src/rust/shoop_tracing/Cargo.toml
+++ b/src/rust/shoop_tracing/Cargo.toml
@@ -19,14 +19,14 @@ sha2 = { workspace = true }
 tracing = { workspace = true }
 tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true }
-perfetto-everywhere-collector = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7", optional = true }
-perfetto-everywhere-core = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7" }
-perfetto-everywhere-raw = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7" }
-perfetto-everywhere-tracing = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7" }
-perfetto-everywhere-web = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7", optional = true }
+perfetto-everywhere-collector = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4", optional = true }
+perfetto-everywhere-core = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4" }
+perfetto-everywhere-raw = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4" }
+perfetto-everywhere-tracing = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4" }
+perfetto-everywhere-web = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-perfetto-everywhere-native = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "f621af951b80f702c6b710e420c8a1abf5e333c7" }
+perfetto-everywhere-native = { git = "https://github.com/SanderVocke/perfetto-everywhere", rev = "caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3", optional = true }

--- a/src/rust/shoop_tracing/examples/multirealm_trace.rs
+++ b/src/rust/shoop_tracing/examples/multirealm_trace.rs
@@ -69,6 +69,7 @@ fn raw_realm(realm_id: u32, clock_id: u32, begin: u64, end: u64) -> (Vec<u8>, Pr
             completed_batches: health.completed_drains,
             high_water_records: health.high_water_records,
             repaired_span_boundaries: 0,
+            ..ProducerHealth::default()
         },
     )
 }

--- a/src/rust/shoop_tracing/src/browser.rs
+++ b/src/rust/shoop_tracing/src/browser.rs
@@ -21,6 +21,7 @@ const WINDOW_REALM_ID: u32 = 1;
 const WINDOW_CLOCK_ID: u32 = 101;
 const WINDOW_TICKS_PER_SECOND: u64 = 1_000_000_000;
 const WINDOW_BATCH_RECORDS: usize = 16_384;
+const MAX_WINDOW_TRACE_BYTES: usize = 512 * 1024 * 1024;
 
 static BROWSER_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
 static WASM_TEST_PANIC_HOOK: Once = Once::new();
@@ -289,10 +290,18 @@ fn drain(state: &mut BrowserState) -> Result<(), String> {
         let Some(batch) = batch else {
             break;
         };
+        let next_len = state
+            .records
+            .len()
+            .checked_add(batch.len())
+            .ok_or_else(|| "browser Window trace storage size overflowed".to_owned())?;
+        if next_len > MAX_WINDOW_TRACE_BYTES {
+            return Err("browser Window trace storage quota exhausted".to_owned());
+        }
         state
             .records
             .try_reserve(batch.len())
-            .map_err(|_| "browser trace storage quota exhausted".to_owned())?;
+            .map_err(|_| "browser Window trace storage allocation failed".to_owned())?;
         state.records.extend_from_slice(&batch);
     }
     Ok(())

--- a/src/rust/shoop_tracing/src/browser.rs
+++ b/src/rust/shoop_tracing/src/browser.rs
@@ -7,9 +7,7 @@ use std::sync::Once;
 
 use base64::Engine as _;
 use perfetto_everywhere_collector::{Collector, CollectorConfig, RealmDescriptor};
-use perfetto_everywhere_core::{
-    MetadataId, Record, StaticName, TraceBackend, TrackId, FLAG_GROUP_END, RECORD_SIZE,
-};
+use perfetto_everywhere_core::{MetadataId, StaticName, TraceBackend, TrackId};
 use perfetto_everywhere_tracing::{PerfettoLayer, SharedBackend};
 use perfetto_everywhere_web::{
     ClockCalibration, MetadataEntry, OrdinaryBackend, PerformanceClock, ProducerHealth,
@@ -23,7 +21,6 @@ const WINDOW_REALM_ID: u32 = 1;
 const WINDOW_CLOCK_ID: u32 = 101;
 const WINDOW_TICKS_PER_SECOND: u64 = 1_000_000_000;
 const WINDOW_BATCH_RECORDS: usize = 16_384;
-const MAX_RETAINED_RECORDS_PER_REALM: usize = 262_144;
 
 static BROWSER_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
 static WASM_TEST_PANIC_HOOK: Once = Once::new();
@@ -31,7 +28,6 @@ static WASM_TEST_PANIC_HOOK: Once = Once::new();
 struct BrowserState {
     backend: SharedBackend<OrdinaryBackend<PerformanceClock>>,
     records: Vec<u8>,
-    retention_dropped_records: u64,
     active: bool,
 }
 
@@ -87,8 +83,14 @@ pub struct BrowserCalibration {
 pub struct BrowserHealth {
     pub emitted_records: u64,
     pub dropped_records: u64,
+    pub raw_dropped_records: u64,
+    pub pool_starvation_records: u64,
     pub completed_batches: u64,
     pub high_water_records: usize,
+    pub max_in_flight_chunks: usize,
+    pub returned_buffers: u64,
+    pub rejected_chunks: u64,
+    pub storage_failures: u64,
     pub repaired_span_boundaries: u64,
 }
 
@@ -136,7 +138,6 @@ pub fn initialize_browser_tracing() -> Result<(), String> {
         *state.borrow_mut() = Some(BrowserState {
             backend,
             records: Vec::new(),
-            retention_dropped_records: 0,
             active: false,
         });
         Ok(())
@@ -155,7 +156,6 @@ impl BrowserCapture {
                 return Err("browser tracing is already active".to_owned());
             }
             state.records.clear();
-            state.retention_dropped_records = 0;
             state
                 .backend
                 .with(|backend| {
@@ -205,13 +205,10 @@ impl BrowserCapture {
                 .with(|backend| backend.set_enabled(false))
                 .ok_or_else(|| "browser tracing backend lock is poisoned".to_owned())?;
             drain(state)?;
-            let (metadata, mut health) = state
+            let (metadata, health) = state
                 .backend
                 .with(|backend| (backend.take_metadata(), backend.health()))
                 .ok_or_else(|| "browser tracing backend lock is poisoned".to_owned())?;
-            health.dropped_records = health
-                .dropped_records
-                .saturating_add(state.retention_dropped_records);
             state.active = false;
             Ok(BrowserRealmData {
                 id: WINDOW_REALM_ID,
@@ -243,7 +240,6 @@ impl BrowserCapture {
                 })
                 .ok_or_else(|| "browser tracing backend lock is poisoned".to_owned())?;
             state.records.clear();
-            state.retention_dropped_records = 0;
             state.active = false;
             Ok::<(), String>(())
         })?;
@@ -293,46 +289,18 @@ fn drain(state: &mut BrowserState) -> Result<(), String> {
         let Some(batch) = batch else {
             break;
         };
-        append_bounded_browser_records(
-            &mut state.records,
-            &mut state.retention_dropped_records,
-            &batch,
-            MAX_RETAINED_RECORDS_PER_REALM,
-        )?;
+        state
+            .records
+            .try_reserve(batch.len())
+            .map_err(|_| "browser trace storage quota exhausted".to_owned())?;
+        state.records.extend_from_slice(&batch);
     }
-    Ok(())
-}
-
-pub fn append_bounded_browser_records(
-    destination: &mut Vec<u8>,
-    dropped_records: &mut u64,
-    batch: &[u8],
-    max_records: usize,
-) -> Result<(), String> {
-    if batch.len() % RECORD_SIZE != 0 {
-        return Err("browser trace backend returned partial record bytes".to_owned());
-    }
-    let remaining = max_records.saturating_sub(destination.len() / RECORD_SIZE);
-    let candidate_records = remaining.min(batch.len() / RECORD_SIZE);
-    let mut retained_records = 0;
-    for (index, bytes) in batch
-        .chunks_exact(RECORD_SIZE)
-        .take(candidate_records)
-        .enumerate()
-    {
-        let record = Record::decode(bytes).map_err(|error| error.to_string())?;
-        if record.flags & FLAG_GROUP_END != 0 {
-            retained_records = index + 1;
-        }
-    }
-    destination.extend_from_slice(&batch[..retained_records * RECORD_SIZE]);
-    *dropped_records =
-        dropped_records.saturating_add((batch.len() / RECORD_SIZE - retained_records) as u64);
     Ok(())
 }
 
 fn collect(realms: Vec<BrowserRealmData>) -> Result<Vec<u8>, String> {
     let mut config = CollectorConfig::default();
+    config.max_records = usize::MAX;
     config.max_clock_uncertainty_ns = 1_000_000_000;
     let mut collector = Collector::new(config);
     for realm in realms {
@@ -385,8 +353,14 @@ fn health_from_perfetto(health: ProducerHealth) -> BrowserHealth {
     BrowserHealth {
         emitted_records: health.emitted_records,
         dropped_records: health.dropped_records,
+        raw_dropped_records: health.raw_dropped_records,
+        pool_starvation_records: health.pool_starvation_records,
         completed_batches: health.completed_batches,
         high_water_records: health.high_water_records,
+        max_in_flight_chunks: health.max_in_flight_chunks,
+        returned_buffers: health.returned_buffers,
+        rejected_chunks: health.rejected_chunks,
+        storage_failures: health.storage_failures,
         repaired_span_boundaries: health.repaired_span_boundaries,
     }
 }
@@ -395,8 +369,14 @@ fn health_to_perfetto(health: BrowserHealth) -> ProducerHealth {
     ProducerHealth {
         emitted_records: health.emitted_records,
         dropped_records: health.dropped_records,
+        raw_dropped_records: health.raw_dropped_records,
+        pool_starvation_records: health.pool_starvation_records,
         completed_batches: health.completed_batches,
         high_water_records: health.high_water_records,
+        max_in_flight_chunks: health.max_in_flight_chunks,
+        returned_buffers: health.returned_buffers,
+        rejected_chunks: health.rejected_chunks,
+        storage_failures: health.storage_failures,
         repaired_span_boundaries: health.repaired_span_boundaries,
     }
 }

--- a/src/rust/shoop_tracing/src/lib.rs
+++ b/src/rust/shoop_tracing/src/lib.rs
@@ -38,6 +38,12 @@ pub use tracing::{
     trace_span, warn, warn_span, Level,
 };
 
+#[cfg(target_arch = "wasm32")]
+pub fn raw_chunk_ends_group(record: &[u8]) -> bool {
+    perfetto_everywhere_core::Record::decode(record)
+        .is_ok_and(|record| record.flags & perfetto_everywhere_core::FLAG_GROUP_END != 0)
+}
+
 static TRACING_ENABLED: AtomicBool = AtomicBool::new(false);
 static TRACING_OUTPUT_ENABLED: AtomicBool = AtomicBool::new(true);
 static ENGINE_DETAIL_ENABLED: AtomicBool = AtomicBool::new(false);

--- a/src/rust/shoop_tracing/src/lib.rs
+++ b/src/rust/shoop_tracing/src/lib.rs
@@ -20,10 +20,9 @@ mod browser;
 pub mod capture;
 #[cfg(all(target_arch = "wasm32", feature = "ordinary-web"))]
 pub use browser::{
-    append_bounded_browser_records, initialize_browser_tracing, wasm_test_trace_begin,
-    wasm_test_trace_finish, wasm_test_trace_finish_failure, wasm_test_trace_finish_result,
-    wasm_test_trace_opt_out, BrowserCalibration, BrowserCapture, BrowserHealth, BrowserMetadata,
-    BrowserRealmData,
+    initialize_browser_tracing, wasm_test_trace_begin, wasm_test_trace_finish,
+    wasm_test_trace_finish_failure, wasm_test_trace_finish_result, wasm_test_trace_opt_out,
+    BrowserCalibration, BrowserCapture, BrowserHealth, BrowserMetadata, BrowserRealmData,
 };
 #[cfg(target_arch = "wasm32")]
 mod raw;

--- a/src/rust/shoopdaloop/README.md
+++ b/src/rust/shoopdaloop/README.md
@@ -82,8 +82,8 @@ cd src/rust/shoopdaloop
 trunk serve --open
 ```
 
-Multirealm Perfetto tracing additionally requires cross-origin isolation. Build
-and serve the hosted output with the repository header-aware server:
+Multirealm Perfetto tracing uses transferable buffers and requires no
+cross-origin isolation. Build and serve the hosted output normally:
 
 ```sh
 trunk build

--- a/src/rust/shoopdaloop/audio_worker.js
+++ b/src/rust/shoopdaloop/audio_worker.js
@@ -1,4 +1,4 @@
-import { ShoopRawWasmHost } from './raw_wasm_host.js';
+import { ShoopRawWasmHost, ShoopTraceChunkTransport } from './raw_wasm_host.js';
 
 let applicationPort = null;
 let fixturePort = null;
@@ -39,25 +39,12 @@ function startTracing(options) {
     options.capacityRecords,
     options.engineDetail,
   );
-  const header = new Int32Array(options.sab, 0, 16);
-  if (Atomics.load(header, 0) !== 0x50454631) {
-    host.traceStop();
-    throw new Error('Worker trace ring magic/version mismatch');
-  }
-  const capacity = Atomics.load(header, 1) >>> 0;
   const frame = scheduler.processedQuanta * scheduler.quantum;
-  const referenceMs = Math.max(0, Math.round(options.referenceMs));
-  Atomics.store(header, 9, frame | 0);
-  Atomics.store(header, 10, Math.floor(frame / 0x1_0000_0000) | 0);
-  Atomics.store(header, 13, referenceMs | 0);
-  Atomics.store(header, 14, Math.floor(referenceMs / 0x1_0000_0000) | 0);
-  Atomics.store(header, 15, 1);
-  Atomics.store(header, 11, frame | 0);
-  Atomics.store(header, 12, Math.floor(frame / 0x1_0000_0000) | 0);
   host.traceSetFrame(frame);
-  trace = {header, data: new Uint8Array(options.sab, 64), capacity};
+  trace = new ShoopTraceChunkTransport(host, applicationPort, options);
   applicationPort.postMessage({
     kind: 'shoop-trace-metadata',
+    captureId: options.captureId,
     metadata,
     sourceTicks: frame,
     referenceMs: performance.timeOrigin + performance.now(),
@@ -65,54 +52,31 @@ function startTracing(options) {
 }
 
 function drainTracing() {
-  if (!trace) return;
-  let write = Atomics.load(trace.header, 2) >>> 0;
-  const read = Atomics.load(trace.header, 3) >>> 0;
-  let free = trace.capacity - ((write - read) >>> 0);
-  while (free > 0) {
-    const written = host.traceDrainRing(trace.data, write, free);
-    if (!written) break;
-    write = (write + written) >>> 0;
-    free -= written;
-  }
-  const occupancy = (write - read) >>> 0;
-  if (occupancy > (Atomics.load(trace.header, 8) >>> 0)) Atomics.store(trace.header, 8, occupancy);
-  Atomics.store(trace.header, 2, write | 0);
-  Atomics.store(trace.header, 4, host.traceDropped() | 0);
+  trace?.drain();
 }
 
-function stopTracing() {
+function recycleTracing(message) {
   if (!trace) return;
-  drainTracing();
-  Atomics.store(trace.header, 6, 1);
-  const status = {
-    kind: 'shoop-trace-stopped',
-    dropped: host.traceDropped(),
-    highWater: Atomics.load(trace.header, 8) >>> 0,
+  trace.recycle(message);
+  if (trace.finished) trace = null;
+}
+
+function stopTracing(options) {
+  if (!trace || options.captureId !== trace.captureId) return;
+  trace.stop({
     sourceTicks: scheduler.processedQuanta * scheduler.quantum,
     referenceMs: performance.timeOrigin + performance.now(),
-  };
-  host.traceStop();
-  trace = null;
-  applicationPort.postMessage(status);
+  });
+  if (trace.finished) trace = null;
 }
 
 function abortTracing() {
   if (!trace) return;
-  const active = trace;
-  try { drainTracing(); } catch (_) { /* preserve records already in the shared ring */ }
-  Atomics.store(active.header, 6, 1);
-  const status = {
-    kind: 'shoop-trace-stopped',
-    dropped: host?.traceDropped?.() || 0,
-    highWater: Atomics.load(active.header, 8) >>> 0,
+  trace.abort({
     sourceTicks: (scheduler?.processedQuanta || 0) * (scheduler?.quantum || 0),
     referenceMs: performance.timeOrigin + performance.now(),
-    aborted: true,
-  };
-  try { host?.traceStop(); } catch (_) { /* host is already failing */ }
+  });
   trace = null;
-  try { applicationPort?.postMessage(status); } catch (_) { /* realm is terminating */ }
 }
 
 function handleApplicationCommand(message) {
@@ -123,7 +87,15 @@ function handleApplicationCommand(message) {
       return;
     }
     if (message?.kind === 'shoop-trace-stop') {
-      stopTracing();
+      stopTracing(message);
+      return;
+    }
+    if (message?.kind === 'shoop-trace-abort') {
+      abortTracing();
+      return;
+    }
+    if (message?.kind === 'shoop-trace-recycle') {
+      recycleTracing(message);
       return;
     }
     let response = host.command(message);
@@ -147,9 +119,8 @@ function handleApplicationCommand(message) {
       const frame = (scheduler?.processedQuanta || 0) * (scheduler?.quantum || 0);
       try {
         applicationPort?.postMessage({
-          kind: 'shoop-trace-stopped',
-          dropped: 0,
-          highWater: 0,
+          kind: 'shoop-trace-aborted',
+          captureId: message.captureId,
           sourceTicks: frame,
           referenceMs: performance.timeOrigin + performance.now(),
           aborted: true,
@@ -193,12 +164,7 @@ class WorkerScheduler {
     this.host.traceSetFrame(frame);
     this.host.process(inputs, outputs, this.quantum);
     this.processedQuanta += 1;
-    if (trace) {
-      Atomics.store(trace.header, 11, frame | 0);
-      Atomics.store(trace.header, 12, Math.floor(frame / 0x1_0000_0000) | 0);
-      Atomics.add(trace.header, 5, 1);
-      drainTracing();
-    }
+    if (trace) drainTracing();
     if (performance.now() - startedAt > this.quantum * 1000 / this.sampleRate) {
       this.overruns += 1;
     }

--- a/src/rust/shoopdaloop/audio_worklet.js
+++ b/src/rust/shoopdaloop/audio_worklet.js
@@ -1,4 +1,4 @@
-import { ShoopRawWasmHost } from './raw_wasm_host.js';
+import { ShoopRawWasmHost, ShoopTraceChunkTransport } from './raw_wasm_host.js';
 
 class ShoopAudioProcessor extends AudioWorkletProcessor {
   constructor(options) {
@@ -19,6 +19,8 @@ class ShoopAudioProcessor extends AudioWorkletProcessor {
         try {
           if (event.data?.kind === 'shoop-trace-start') this.startTracing(event.data);
           else if (event.data?.kind === 'shoop-trace-stop') this.stopTracing(event.data);
+          else if (event.data?.kind === 'shoop-trace-abort') this.abortTracing();
+          else if (event.data?.kind === 'shoop-trace-recycle') this.recycleTracing(event.data);
           else this.handleCommand(event.data);
         } catch (error) {
           if (event.data?.kind === 'shoop-trace-start' && !this.trace) {
@@ -40,36 +42,15 @@ class ShoopAudioProcessor extends AudioWorkletProcessor {
       options.capacityRecords,
       options.engineDetail,
     );
-    const header = new Int32Array(options.sab, 0, 16);
-    if (Atomics.load(header, 0) !== 0x50454631) {
-      this.host.traceStop();
-      throw new Error('AudioWorklet trace ring magic/version mismatch');
-    }
-    const capacity = Atomics.load(header, 1) >>> 0;
-    if (capacity !== options.capacityRecords) {
-      this.host.traceStop();
-      throw new Error('AudioWorklet trace ring capacity mismatch');
-    }
-    const referenceMs = Math.max(0, Math.round(options.referenceMs));
-    Atomics.store(header, 9, currentFrame | 0);
-    Atomics.store(header, 10, Math.floor(currentFrame / 0x1_0000_0000) | 0);
-    Atomics.store(header, 13, referenceMs | 0);
-    Atomics.store(header, 14, Math.floor(referenceMs / 0x1_0000_0000) | 0);
-    Atomics.store(header, 15, 1);
-    Atomics.store(header, 11, currentFrame | 0);
-    Atomics.store(header, 12, Math.floor(currentFrame / 0x1_0000_0000) | 0);
     this.host.traceSetFrame(currentFrame);
-    this.trace = {
-      header,
-      data: new Uint8Array(options.sab, 64),
-      capacity,
-    };
+    this.trace = new ShoopTraceChunkTransport(this.host, this.port, options);
     const timer = globalThis.performance;
     const hasReferenceClock = timer
       && Number.isFinite(timer.timeOrigin)
       && typeof timer.now === 'function';
     this.port.postMessage({
       kind: 'shoop-trace-metadata',
+      captureId: options.captureId,
       metadata,
       sourceTicks: currentFrame,
       referenceMs: hasReferenceClock ? timer.timeOrigin + timer.now() : options.referenceMs,
@@ -84,8 +65,8 @@ class ShoopAudioProcessor extends AudioWorkletProcessor {
       && Number.isFinite(timer.timeOrigin)
       && typeof timer.now === 'function';
     this.port.postMessage({
-      kind: 'shoop-trace-stopped',
-      dropped: 0,
+      kind: 'shoop-trace-aborted',
+      captureId: options.captureId,
       highWater: 0,
       sourceTicks: currentFrame,
       referenceMs: hasReferenceClock ? timer.timeOrigin + timer.now() : options.referenceMs,
@@ -96,67 +77,42 @@ class ShoopAudioProcessor extends AudioWorkletProcessor {
   }
 
   drainTracing() {
+    this.trace?.drain();
+  }
+
+  recycleTracing(message) {
     if (!this.trace) return;
-    const {header, data, capacity} = this.trace;
-    let write = Atomics.load(header, 2) >>> 0;
-    const read = Atomics.load(header, 3) >>> 0;
-    let free = capacity - ((write - read) >>> 0);
-    while (free > 0) {
-      const written = this.host.traceDrainRing(data, write, free);
-      if (!written) break;
-      write = (write + written) >>> 0;
-      free -= written;
-    }
-    const occupancy = (write - read) >>> 0;
-    if (occupancy > (Atomics.load(header, 8) >>> 0)) Atomics.store(header, 8, occupancy);
-    Atomics.store(header, 2, write | 0);
-    Atomics.store(header, 4, this.host.traceDropped() | 0);
+    this.trace.recycle(message);
+    if (this.trace.finished) this.trace = null;
   }
 
   stopTracing(options = {}) {
-    if (!this.trace) return;
-    this.drainTracing();
-    Atomics.store(this.trace.header, 6, 1);
+    if (!this.trace || options.captureId !== this.trace.captureId) return;
     const timer = globalThis.performance;
     const hasReferenceClock = timer
       && Number.isFinite(timer.timeOrigin)
       && typeof timer.now === 'function';
-    const status = {
-      kind: 'shoop-trace-stopped',
-      dropped: this.host.traceDropped(),
-      highWater: Atomics.load(this.trace.header, 8) >>> 0,
+    this.trace.stop({
       sourceTicks: currentFrame,
       referenceMs: hasReferenceClock ? timer.timeOrigin + timer.now() : options.referenceMs,
       requestReferenceMs: options.referenceMs,
       fallbackClock: !hasReferenceClock,
-    };
-    this.host.traceStop();
-    this.trace = null;
-    this.port.postMessage(status);
+    });
+    if (this.trace.finished) this.trace = null;
   }
 
   abortTracing() {
     if (!this.trace) return;
-    const active = this.trace;
-    try { this.drainTracing(); } catch (_) { /* preserve records already in the shared ring */ }
-    Atomics.store(active.header, 6, 1);
     const timer = globalThis.performance;
     const hasReferenceClock = timer
       && Number.isFinite(timer.timeOrigin)
       && typeof timer.now === 'function';
-    const status = {
-      kind: 'shoop-trace-stopped',
-      dropped: this.host?.traceDropped?.() || 0,
-      highWater: Atomics.load(active.header, 8) >>> 0,
+    this.trace.abort({
       sourceTicks: currentFrame,
       referenceMs: hasReferenceClock ? timer.timeOrigin + timer.now() : undefined,
-      requestReferenceMs: undefined,
       fallbackClock: !hasReferenceClock,
-      aborted: true,
-    };
-    try { this.host?.traceStop(); } catch (_) { /* host is already failing */ }
+    });
     this.trace = null;
-    try { this.port.postMessage(status); } catch (_) { /* processor is terminating */ }
   }
 
   handleCommand(message) {
@@ -207,11 +163,6 @@ class ShoopAudioProcessor extends AudioWorkletProcessor {
       this.renderDiscontinuities += 1;
     }
     this.expectedFrame = currentFrame + frames;
-    if (this.trace) {
-      Atomics.store(this.trace.header, 11, currentFrame | 0);
-      Atomics.store(this.trace.header, 12, Math.floor(currentFrame / 0x1_0000_0000) | 0);
-      Atomics.add(this.trace.header, 5, 1);
-    }
     const timer = globalThis.performance;
     const startedAt = timer ? timer.now() : 0;
     try {

--- a/src/rust/shoopdaloop/build_single_file_app.py
+++ b/src/rust/shoopdaloop/build_single_file_app.py
@@ -98,12 +98,16 @@ def build_single_file(dist: Path, output: Path) -> None:
         raise RuntimeError("wasm-bindgen export footer has an unexpected shape")
 
     raw_host_source = raw_host_script_path.read_text(encoding="utf-8")
-    worklet_source = worklet_script_path.read_text(encoding="utf-8").replace(
-        "import { ShoopRawWasmHost } from './raw_wasm_host.js';\n", ""
-    )
-    worker_source = worker_script_path.read_text(encoding="utf-8").replace(
-        "import { ShoopRawWasmHost } from './raw_wasm_host.js';\n", ""
-    )
+    realm_import = "import { ShoopRawWasmHost, ShoopTraceChunkTransport } from './raw_wasm_host.js';\n"
+
+    def strip_realm_import(path: Path) -> str:
+        source = path.read_text(encoding="utf-8")
+        if source.count(realm_import) != 1:
+            raise RuntimeError(f"could not identify realm host import in {path.name}")
+        return source.replace(realm_import, "")
+
+    worklet_source = strip_realm_import(worklet_script_path)
+    worker_source = strip_realm_import(worker_script_path)
     encoded_worklet_source = base64.b64encode(
         f"{raw_host_source}\n{worklet_source}".encode("utf-8")
     ).decode("ascii")

--- a/src/rust/shoopdaloop/raw_wasm_host.js
+++ b/src/rust/shoopdaloop/raw_wasm_host.js
@@ -169,6 +169,23 @@ export class ShoopRawWasmHost {
     return this.trace ? Number(this.exports.shoop_worklet_trace_dropped(this.host)) : 0;
   }
 
+  traceHealth() {
+    return this.trace ? {
+      emittedRecords: Number(this.exports.shoop_worklet_trace_emitted(this.host)),
+      droppedRecords: Number(this.exports.shoop_worklet_trace_dropped(this.host)),
+      completedDrains: Number(this.exports.shoop_worklet_trace_completed_drains(this.host)),
+      highWaterRecords: Number(this.exports.shoop_worklet_trace_high_water(this.host)),
+    } : {emittedRecords: 0, droppedRecords: 0, completedDrains: 0, highWaterRecords: 0};
+  }
+
+  traceAvailableRecords() {
+    return this.trace ? Number(this.exports.shoop_worklet_trace_available(this.host)) : 0;
+  }
+
+  traceDisable() {
+    if (this.trace) this.exports.shoop_worklet_trace_disable(this.host);
+  }
+
   traceStop() {
     if (!this.trace) return;
     this.exports.shoop_worklet_trace_stop(this.host);
@@ -243,5 +260,154 @@ export class ShoopRawWasmHost {
     this.input = null;
     this.output = null;
     this.memoryBuffer = null;
+  }
+}
+
+export class ShoopTraceChunkTransport {
+  constructor(host, port, options) {
+    if (options.protocolVersion !== 2) throw new Error('trace chunk protocol version mismatch');
+    if (!Number.isInteger(options.captureId) || options.captureId <= 0) {
+      throw new Error('trace capture ID must be positive');
+    }
+    if (!Number.isInteger(options.poolSize) || options.poolSize < 2) {
+      throw new Error('trace chunk pool must contain at least two buffers');
+    }
+    const minimumBytes = options.capacityRecords * 48;
+    if (!Number.isInteger(options.chunkBytes)
+        || options.chunkBytes < minimumBytes
+        || options.chunkBytes % 48 !== 0) {
+      throw new Error('trace chunk capacity cannot hold the largest raw record group');
+    }
+    this.host = host;
+    this.port = port;
+    this.captureId = options.captureId;
+    this.chunkBytes = options.chunkBytes;
+    this.available = [];
+    for (let token = 0; token < options.poolSize; token += 1) {
+      const buffer = new ArrayBuffer(this.chunkBytes);
+      this.available.push({token, buffer, view: new Uint8Array(buffer), used: 0});
+    }
+    this.active = this.available.pop();
+    this.sequence = 0;
+    this.inFlight = new Array(options.poolSize).fill(false);
+    this.inFlightCount = 0;
+    this.maxInFlight = 0;
+    this.returnedBuffers = 0;
+    this.poolStarvationRecords = 0;
+    this.starvationDropStart = null;
+    this.rejectedChunks = 0;
+    this.stopping = null;
+    this.finished = false;
+  }
+
+  drain() {
+    while (this.host.traceAvailableRecords() > 0) {
+      if (!this.active) this.active = this.available.pop() || null;
+      if (!this.active) {
+        if (this.starvationDropStart === null) {
+          this.starvationDropStart = this.host.traceDropped();
+        }
+        return false;
+      }
+      const remaining = this.chunkBytes - this.active.used;
+      const bytes = this.host.traceDrainInto(this.active.view, this.active.used, remaining);
+      if (bytes > 0) this.active.used += bytes;
+      if (this.active.used === this.chunkBytes) {
+        this.transferActive();
+      } else if (bytes === 0 && this.host.traceAvailableRecords() > 0) {
+        // The next complete group fits an empty chunk but not this remaining tail.
+        this.transferActive();
+      }
+    }
+    return true;
+  }
+
+  transferActive() {
+    if (!this.active || this.active.used === 0) return;
+    const chunk = this.active;
+    this.active = this.available.pop() || null;
+    this.inFlight[chunk.token] = true;
+    this.inFlightCount += 1;
+    this.maxInFlight = Math.max(this.maxInFlight, this.inFlightCount);
+    this.port.postMessage({
+      kind: 'shoop-trace-chunk',
+      captureId: this.captureId,
+      sequence: this.sequence,
+      poolToken: chunk.token,
+      usedBytes: chunk.used,
+      buffer: chunk.buffer,
+    }, [chunk.buffer]);
+    this.sequence += 1;
+  }
+
+  recycle(message) {
+    if (message.captureId !== this.captureId || this.finished) return false;
+    if (!Number.isInteger(message.poolToken) || !this.inFlight[message.poolToken]) {
+      this.rejectedChunks += 1;
+      throw new Error('trace recycle has an unknown or duplicate pool token');
+    }
+    this.inFlight[message.poolToken] = false;
+    this.inFlightCount -= 1;
+    this.returnedBuffers += 1;
+    if (this.starvationDropStart !== null) {
+      this.poolStarvationRecords += this.host.traceDropped() - this.starvationDropStart;
+      this.starvationDropStart = null;
+    }
+    if (!(message.buffer instanceof ArrayBuffer) || message.buffer.byteLength !== this.chunkBytes) {
+      throw new Error('trace recycle buffer capacity mismatch');
+    }
+    this.available.push({
+      token: message.poolToken,
+      buffer: message.buffer,
+      view: new Uint8Array(message.buffer),
+      used: 0,
+    });
+    if (!this.active) this.active = this.available.pop();
+    if (this.stopping) this.tryFinish();
+    return true;
+  }
+
+  stop(status) {
+    if (this.stopping || this.finished) return;
+    this.host.traceDisable();
+    this.stopping = status;
+    this.tryFinish();
+  }
+
+  tryFinish() {
+    if (!this.stopping || this.finished || !this.drain()) return false;
+    this.transferActive();
+    const health = this.host.traceHealth();
+    this.host.traceStop();
+    this.finished = true;
+    this.port.postMessage({
+      kind: 'shoop-trace-stopped',
+      captureId: this.captureId,
+      chunkCount: this.sequence,
+      emittedRecords: health.emittedRecords,
+      droppedRecords: health.droppedRecords,
+      rawDroppedRecords: health.droppedRecords - this.poolStarvationRecords,
+      poolStarvationRecords: this.poolStarvationRecords,
+      highWaterRecords: health.highWaterRecords,
+      maxInFlight: this.maxInFlight,
+      returnedBuffers: this.returnedBuffers,
+      rejectedChunks: this.rejectedChunks,
+      ...this.stopping,
+    });
+    return true;
+  }
+
+  abort(status = {}) {
+    if (this.finished) return;
+    this.host.traceDisable();
+    this.host.traceStop();
+    this.finished = true;
+    try {
+      this.port.postMessage({
+        kind: 'shoop-trace-aborted',
+        captureId: this.captureId,
+        ...status,
+      });
+    } catch (_) { /* producer realm is terminating */ }
   }
 }

--- a/src/rust/shoopdaloop/raw_wasm_host.js
+++ b/src/rust/shoopdaloop/raw_wasm_host.js
@@ -266,7 +266,7 @@ export class ShoopRawWasmHost {
 export class ShoopTraceChunkTransport {
   constructor(host, port, options) {
     if (options.protocolVersion !== 2) throw new Error('trace chunk protocol version mismatch');
-    if (!Number.isInteger(options.captureId) || options.captureId <= 0) {
+    if (!Number.isSafeInteger(options.captureId) || options.captureId <= 0) {
       throw new Error('trace capture ID must be positive');
     }
     if (!Number.isInteger(options.poolSize) || options.poolSize < 2) {
@@ -283,9 +283,26 @@ export class ShoopTraceChunkTransport {
     this.captureId = options.captureId;
     this.chunkBytes = options.chunkBytes;
     this.available = [];
+    this.chunks = [];
     for (let token = 0; token < options.poolSize; token += 1) {
       const buffer = new ArrayBuffer(this.chunkBytes);
-      this.available.push({token, buffer, view: new Uint8Array(buffer), used: 0});
+      const chunk = {
+        token,
+        buffer,
+        view: new Uint8Array(buffer),
+        used: 0,
+        message: {
+          kind: 'shoop-trace-chunk',
+          captureId: this.captureId,
+          sequence: 0,
+          poolToken: token,
+          usedBytes: 0,
+          buffer,
+        },
+        transfer: [buffer],
+      };
+      this.chunks.push(chunk);
+      this.available.push(chunk);
     }
     this.active = this.available.pop();
     this.sequence = 0;
@@ -324,19 +341,20 @@ export class ShoopTraceChunkTransport {
 
   transferActive() {
     if (!this.active || this.active.used === 0) return;
+    if (!Number.isSafeInteger(this.sequence) || this.sequence >= Number.MAX_SAFE_INTEGER) {
+      this.abort({reason: 'trace chunk sequence exceeds JavaScript safe integer range'});
+      return;
+    }
     const chunk = this.active;
     this.active = this.available.pop() || null;
     this.inFlight[chunk.token] = true;
     this.inFlightCount += 1;
     this.maxInFlight = Math.max(this.maxInFlight, this.inFlightCount);
-    this.port.postMessage({
-      kind: 'shoop-trace-chunk',
-      captureId: this.captureId,
-      sequence: this.sequence,
-      poolToken: chunk.token,
-      usedBytes: chunk.used,
-      buffer: chunk.buffer,
-    }, [chunk.buffer]);
+    chunk.message.sequence = this.sequence;
+    chunk.message.usedBytes = chunk.used;
+    chunk.message.buffer = chunk.buffer;
+    chunk.transfer[0] = chunk.buffer;
+    this.port.postMessage(chunk.message, chunk.transfer);
     this.sequence += 1;
   }
 
@@ -356,12 +374,13 @@ export class ShoopTraceChunkTransport {
     if (!(message.buffer instanceof ArrayBuffer) || message.buffer.byteLength !== this.chunkBytes) {
       throw new Error('trace recycle buffer capacity mismatch');
     }
-    this.available.push({
-      token: message.poolToken,
-      buffer: message.buffer,
-      view: new Uint8Array(message.buffer),
-      used: 0,
-    });
+    const chunk = this.chunks[message.poolToken];
+    chunk.buffer = message.buffer;
+    chunk.view = new Uint8Array(message.buffer);
+    chunk.used = 0;
+    chunk.message.buffer = message.buffer;
+    chunk.transfer[0] = message.buffer;
+    this.available.push(chunk);
     if (!this.active) this.active = this.available.pop();
     if (this.stopping) this.tryFinish();
     return true;

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -21,8 +21,6 @@ const WORKLET_SCRIPT_URL: &str = "./audio_worklet.js";
 const WORKLET_WASM_URL: &str = "./generated/shoop_audio_worklet.wasm";
 const EMBEDDED_WORKLET_ASSETS: &str = "shoopEmbeddedAudioWorklet";
 const MAX_QUANTUM: u32 = 2048;
-const MAX_RETAINED_TRACE_RECORDS: usize = 262_144;
-const TRACE_RECORD_BYTES: usize = 48;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AudioInputMode {
@@ -227,12 +225,6 @@ impl BrowserAudioController {
             .ok_or_else(|| anyhow!("browser audio context is unavailable"))?
             .sample_rate()
             .round() as u64;
-        let retained_records = inner
-            .completed_trace_segments
-            .iter()
-            .map(|segment| segment.records.len() / TRACE_RECORD_BYTES)
-            .sum::<usize>();
-        let max_retained_records = MAX_RETAINED_TRACE_RECORDS.saturating_sub(retained_records);
         let realm_id = inner.next_trace_realm_id;
         inner.next_trace_realm_id = inner.next_trace_realm_id.saturating_add(1);
         let label = if realm_id == 4 {
@@ -247,7 +239,6 @@ impl BrowserAudioController {
             sample_rate,
             128,
             8192,
-            max_retained_records,
         )?;
         let message = trace.start_message(engine_detail)?;
         inner
@@ -274,10 +265,14 @@ impl BrowserAudioController {
     }
 
     pub fn discard_tracing(&self) {
-        let _ = self.request_stop_tracing();
         let mut inner = self.driver.state.borrow_mut();
+        if let (Some(trace), Some(node)) = (inner.trace.as_ref(), inner.node.as_ref()) {
+            if let (Ok(port), Ok(message)) = (node.port(), trace.abort_message()) {
+                let _ = port.post_message(&message);
+            }
+        }
         if let Some(mut trace) = inner.trace.take() {
-            let _ = trace.abort();
+            trace.abort();
         }
         inner.completed_trace_segments.clear();
     }
@@ -287,13 +282,14 @@ impl BrowserAudioController {
         if inner.trace.is_none() {
             return Ok(());
         }
+        let message = inner.trace.as_ref().unwrap().stop_message()?;
         inner
             .node
             .as_ref()
             .ok_or_else(|| anyhow!("AudioWorklet node disappeared during tracing"))?
             .port()
             .map_err(|error| anyhow!("could not access AudioWorklet trace port: {error:?}"))?
-            .post_message(&crate::browser_trace::RealmTraceState::stop_message()?)
+            .post_message(&message)
             .map_err(|error| anyhow!("could not stop AudioWorklet tracing: {error:?}"))?;
         Ok(())
     }
@@ -651,6 +647,7 @@ async fn start_audio_graph(
 
     let port = node.port()?;
     let weak = Rc::downgrade(&inner);
+    let trace_port = port.clone();
     let message_handler = Closure::wrap(Box::new(move |event: MessageEvent| {
         if let Some(inner) = weak.upgrade() {
             let mut inner = inner.borrow_mut();
@@ -658,14 +655,14 @@ async fn start_audio_graph(
                 let _ = inner.transport.receive(generation, &json);
             } else {
                 let handled = if let Some(trace) = inner.trace.as_mut() {
-                    match trace.handle_message(&event.data()) {
+                    match trace.handle_message(&event.data(), &trace_port) {
                         Ok(handled) => handled,
                         Err(error) => {
                             tracing::error!(
                                 error = %error,
                                 "frontend.browser_trace.audio_message_failed"
                             );
-                            let _ = trace.abort();
+                            trace.abort();
                             inner
                                 .transport
                                 .fail(format!("AudioWorklet trace message failed: {error}"));
@@ -907,7 +904,8 @@ fn finalize_active_trace_segment(inner: &mut PhysicalAudioDriverState) {
     let Some(mut trace) = inner.trace.take() else {
         return;
     };
-    let result = trace.abort().and_then(|()| trace.finish());
+    trace.abort();
+    let result = trace.finish();
     match result {
         Ok(segment) => inner.completed_trace_segments.push(segment),
         Err(error) => tracing::error!(

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -252,7 +252,6 @@ impl BrowserAudioController {
             .post_message(&message)
             .map_err(|error| anyhow!("could not start AudioWorklet tracing: {error:?}"))?;
         inner.trace = Some(trace);
-        inner.trace_failure = None;
         Ok(true)
     }
 

--- a/src/rust/shoopdaloop/src/browser_audio.rs
+++ b/src/rust/shoopdaloop/src/browser_audio.rs
@@ -58,6 +58,7 @@ struct PhysicalAudioDriverState {
     repaint_context: Option<eframe::egui::Context>,
     trace: Option<crate::browser_trace::RealmTraceState>,
     completed_trace_segments: Vec<shoop_tracing::BrowserRealmData>,
+    trace_failure: Option<String>,
     next_trace_realm_id: u32,
 }
 
@@ -102,6 +103,7 @@ impl BrowserAudioController {
             repaint_context: None,
             trace: None,
             completed_trace_segments: Vec::new(),
+            trace_failure: None,
             next_trace_realm_id: 4,
         }));
         let weak = Rc::downgrade(&inner);
@@ -250,6 +252,7 @@ impl BrowserAudioController {
             .post_message(&message)
             .map_err(|error| anyhow!("could not start AudioWorklet tracing: {error:?}"))?;
         inner.trace = Some(trace);
+        inner.trace_failure = None;
         Ok(true)
     }
 
@@ -264,6 +267,15 @@ impl BrowserAudioController {
         self.driver.state.borrow().trace.is_some()
     }
 
+    pub fn trace_stopped(&self) -> bool {
+        self.driver
+            .state
+            .borrow()
+            .trace
+            .as_ref()
+            .is_some_and(crate::browser_trace::RealmTraceState::stopped)
+    }
+
     pub fn discard_tracing(&self) {
         let mut inner = self.driver.state.borrow_mut();
         if let (Some(trace), Some(node)) = (inner.trace.as_ref(), inner.node.as_ref()) {
@@ -275,6 +287,7 @@ impl BrowserAudioController {
             trace.abort();
         }
         inner.completed_trace_segments.clear();
+        inner.trace_failure = None;
     }
 
     pub fn request_stop_tracing(&self) -> Result<()> {
@@ -296,6 +309,9 @@ impl BrowserAudioController {
 
     pub fn take_traces(&self) -> Result<Option<Vec<shoop_tracing::BrowserRealmData>>> {
         let mut inner = self.driver.state.borrow_mut();
+        if let Some(error) = inner.trace_failure.take() {
+            return Err(anyhow!(error).into());
+        }
         if inner.trace.as_ref().is_some_and(|trace| !trace.stopped()) {
             return Ok(None);
         }
@@ -662,7 +678,12 @@ async fn start_audio_graph(
                                 error = %error,
                                 "frontend.browser_trace.audio_message_failed"
                             );
-                            trace.abort();
+                            if let Ok(message) = trace.abort_message() {
+                                let _ = trace_port.post_message(&message);
+                            }
+                            trace.abort_with_reason(format!(
+                                "AudioWorklet trace message failed: {error}"
+                            ));
                             inner
                                 .transport
                                 .fail(format!("AudioWorklet trace message failed: {error}"));
@@ -901,18 +922,20 @@ fn stop_stream(stream: &MediaStream) {
 }
 
 fn finalize_active_trace_segment(inner: &mut PhysicalAudioDriverState) {
-    let Some(mut trace) = inner.trace.take() else {
+    if let (Some(trace), Some(node)) = (inner.trace.as_ref(), inner.node.as_ref()) {
+        if let (Ok(port), Ok(message)) = (node.port(), trace.abort_message()) {
+            let _ = port.post_message(&message);
+        }
+    }
+    let Some(trace) = inner.trace.take() else {
         return;
     };
-    trace.abort();
-    let result = trace.finish();
-    match result {
-        Ok(segment) => inner.completed_trace_segments.push(segment),
-        Err(error) => tracing::error!(
-            error = %error,
-            "frontend.browser_trace.audio_segment_finalize_failed"
-        ),
-    }
+    let error = format!(
+        "AudioWorklet graph ended before trace completion ({})",
+        trace.label()
+    );
+    tracing::error!(error = %error, "frontend.browser_trace.audio_segment_finalize_failed");
+    inner.trace_failure = Some(error);
 }
 
 fn shutdown_graph(inner: &mut PhysicalAudioDriverState) {

--- a/src/rust/shoopdaloop/src/browser_trace.rs
+++ b/src/rust/shoopdaloop/src/browser_trace.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
-use js_sys::{Array, Atomics, Int32Array, Object, Reflect, SharedArrayBuffer, Uint8Array};
+use js_sys::{Array, ArrayBuffer, Object, Reflect, Uint8Array};
 use wasm_bindgen::{JsCast, JsValue};
+use web_sys::MessagePort;
 
-const HEADER_WORDS: u32 = 16;
-const HEADER_BYTES: u32 = HEADER_WORDS * 4;
-const RECORD_BYTES: u32 = 48;
-const MAGIC: i32 = 0x5045_4631;
+const RECORD_BYTES: usize = 48;
+const TRACE_PROTOCOL_VERSION: u32 = 2;
+const TRACE_POOL_SIZE: usize = 3;
 
 type Result<T> = std::result::Result<T, BrowserTraceError>;
 
@@ -40,19 +40,25 @@ fn reference_time_ms() -> Result<f64> {
     Ok(performance.time_origin() + performance.now())
 }
 
+fn number(data: &JsValue, name: &str) -> Result<f64> {
+    Reflect::get(data, &name.into())?
+        .as_f64()
+        .ok_or_else(|| anyhow!("trace message {name} is not numeric").into())
+}
+
 pub struct RealmTraceState {
     realm_id: u32,
+    capture_id: u64,
     clock_id: u32,
     label: String,
     ticks_per_second: u64,
-    capacity: u32,
-    max_retained_records: usize,
-    sab: SharedArrayBuffer,
-    header: Int32Array,
+    chunk_bytes: usize,
+    next_sequence: u64,
+    collector_owned_tokens: Vec<bool>,
     metadata: Vec<shoop_tracing::BrowserMetadata>,
     calibrations: Vec<shoop_tracing::BrowserCalibration>,
     records: Vec<u8>,
-    retention_dropped_records: u64,
+    health: shoop_tracing::BrowserHealth,
     stopped: bool,
 }
 
@@ -62,38 +68,25 @@ impl RealmTraceState {
         clock_id: u32,
         label: impl Into<String>,
         ticks_per_second: u64,
-        quantum_frames: u32,
+        _quantum_frames: u32,
         capacity: u32,
-        max_retained_records: usize,
     ) -> Result<Self> {
-        let constructor = Reflect::get(&js_sys::global(), &JsValue::from_str("SharedArrayBuffer"))?
-            .dyn_into::<js_sys::Function>()
-            .map_err(|_| anyhow!("SharedArrayBuffer is unavailable; serve with COOP/COEP"))?;
-        let arguments = Array::new();
-        arguments.push(&JsValue::from_f64(
-            (HEADER_BYTES + capacity * RECORD_BYTES) as f64,
-        ));
-        let sab = Reflect::construct(&constructor, &arguments)?
-            .dyn_into::<SharedArrayBuffer>()
-            .map_err(|_| anyhow!("SharedArrayBuffer construction returned the wrong type"))?;
-        let header = Int32Array::new_with_byte_offset_and_length(&sab, 0, HEADER_WORDS);
-        header.set_index(0, MAGIC);
-        header.set_index(1, capacity as i32);
-        header.set_index(9, ticks_per_second.min(i32::MAX as u64) as i32);
-        header.set_index(10, quantum_frames as i32);
+        if realm_id == 0 || clock_id == 0 || capacity == 0 {
+            return Err(anyhow!("trace realm, clock, and capacity must be nonzero").into());
+        }
         Ok(Self {
             realm_id,
+            capture_id: u64::from(realm_id),
             clock_id,
             label: label.into(),
             ticks_per_second,
-            capacity,
-            max_retained_records,
-            sab,
-            header,
+            chunk_bytes: capacity as usize * RECORD_BYTES,
+            next_sequence: 0,
+            collector_owned_tokens: vec![false; TRACE_POOL_SIZE],
             metadata: Vec::new(),
             calibrations: Vec::new(),
             records: Vec::new(),
-            retention_dropped_records: 0,
+            health: shoop_tracing::BrowserHealth::default(),
             stopped: false,
         })
     }
@@ -101,7 +94,16 @@ impl RealmTraceState {
     pub fn start_message(&self, engine_detail: bool) -> Result<JsValue> {
         let message = Object::new();
         Reflect::set(&message, &"kind".into(), &"shoop-trace-start".into())?;
-        Reflect::set(&message, &"sab".into(), self.sab.as_ref())?;
+        Reflect::set(
+            &message,
+            &"protocolVersion".into(),
+            &JsValue::from_f64(TRACE_PROTOCOL_VERSION as f64),
+        )?;
+        Reflect::set(
+            &message,
+            &"captureId".into(),
+            &JsValue::from_f64(self.capture_id as f64),
+        )?;
         Reflect::set(
             &message,
             &"realmId".into(),
@@ -115,7 +117,17 @@ impl RealmTraceState {
         Reflect::set(
             &message,
             &"capacityRecords".into(),
-            &JsValue::from_f64(self.capacity as f64),
+            &JsValue::from_f64((self.chunk_bytes / RECORD_BYTES) as f64),
+        )?;
+        Reflect::set(
+            &message,
+            &"chunkBytes".into(),
+            &JsValue::from_f64(self.chunk_bytes as f64),
+        )?;
+        Reflect::set(
+            &message,
+            &"poolSize".into(),
+            &JsValue::from_f64(TRACE_POOL_SIZE as f64),
         )?;
         Reflect::set(
             &message,
@@ -130,13 +142,29 @@ impl RealmTraceState {
         Ok(message.into())
     }
 
-    pub fn stop_message() -> Result<JsValue> {
+    pub fn stop_message(&self) -> Result<JsValue> {
         let message = Object::new();
         Reflect::set(&message, &"kind".into(), &"shoop-trace-stop".into())?;
         Reflect::set(
             &message,
+            &"captureId".into(),
+            &JsValue::from_f64(self.capture_id as f64),
+        )?;
+        Reflect::set(
+            &message,
             &"referenceMs".into(),
             &JsValue::from_f64(reference_time_ms()?),
+        )?;
+        Ok(message.into())
+    }
+
+    pub fn abort_message(&self) -> Result<JsValue> {
+        let message = Object::new();
+        Reflect::set(&message, &"kind".into(), &"shoop-trace-abort".into())?;
+        Reflect::set(
+            &message,
+            &"captureId".into(),
+            &JsValue::from_f64(self.capture_id as f64),
         )?;
         Ok(message.into())
     }
@@ -148,20 +176,23 @@ impl RealmTraceState {
             .is_some_and(|kind| kind.starts_with("shoop-trace-"))
     }
 
-    pub fn handle_message(&mut self, data: &JsValue) -> Result<bool> {
+    pub fn poll(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn handle_message(&mut self, data: &JsValue, port: &MessagePort) -> Result<bool> {
         let kind = Reflect::get(data, &"kind".into())
             .ok()
             .and_then(|value| value.as_string());
         match kind.as_deref() {
             Some("shoop-trace-metadata") => {
+                self.validate_capture(data)?;
                 let entries = Array::from(&Reflect::get(data, &"metadata".into())?);
                 self.metadata.clear();
                 for value in entries.iter() {
                     self.metadata.push(shoop_tracing::BrowserMetadata {
-                        id: Reflect::get(&value, &"id".into())?.as_f64().unwrap_or(0.0) as u32,
-                        namespace: Reflect::get(&value, &"namespace".into())?
-                            .as_f64()
-                            .unwrap_or(0.0) as u8,
+                        id: number(&value, "id")? as u32,
+                        namespace: number(&value, "namespace")? as u8,
                         label: Reflect::get(&value, &"label".into())?
                             .as_string()
                             .ok_or_else(|| anyhow!("trace metadata label is not a string"))?,
@@ -174,63 +205,121 @@ impl RealmTraceState {
                 );
                 Ok(true)
             }
+            Some("shoop-trace-chunk") => {
+                self.handle_chunk(data, port)?;
+                Ok(true)
+            }
             Some("shoop-trace-stopped") => {
-                self.poll()?;
-                self.stopped = true;
+                self.validate_capture(data)?;
+                let chunk_count = number(data, "chunkCount")? as u64;
+                if chunk_count != self.next_sequence {
+                    return Err(anyhow!(
+                        "trace stopped with {chunk_count} chunks after receiving {}",
+                        self.next_sequence
+                    )
+                    .into());
+                }
+                self.health.emitted_records = number(data, "emittedRecords")? as u64;
+                self.health.dropped_records = number(data, "droppedRecords")? as u64;
+                self.health.raw_dropped_records = number(data, "rawDroppedRecords")? as u64;
+                self.health.pool_starvation_records = number(data, "poolStarvationRecords")? as u64;
+                self.health.completed_batches = chunk_count;
+                self.health.high_water_records = number(data, "highWaterRecords")? as usize;
+                self.health.max_in_flight_chunks = number(data, "maxInFlight")? as usize;
+                self.health.returned_buffers = number(data, "returnedBuffers")? as u64;
+                self.health.rejected_chunks = number(data, "rejectedChunks")? as u64;
                 self.add_message_calibration(data)?;
+                self.stopped = true;
                 tracing::info!(realm = self.realm_id, "frontend.browser_trace.stopped");
                 Ok(true)
+            }
+            Some("shoop-trace-aborted") => {
+                self.validate_capture(data)?;
+                self.stopped = true;
+                Err(anyhow!("{} trace producer aborted", self.label).into())
             }
             _ => Ok(false),
         }
     }
 
-    pub fn poll(&mut self) -> Result<()> {
-        let write = Atomics::load(&self.header, 2)? as u32;
-        let read = Atomics::load(&self.header, 3)? as u32;
-        let available = write.wrapping_sub(read).min(self.capacity);
-        if available == 0 {
-            return Ok(());
+    fn handle_chunk(&mut self, data: &JsValue, port: &MessagePort) -> Result<()> {
+        self.validate_capture(data)?;
+        let sequence = number(data, "sequence")? as u64;
+        if sequence != self.next_sequence {
+            return Err(anyhow!(
+                "expected trace chunk {}, received {sequence}",
+                self.next_sequence
+            )
+            .into());
         }
-        let data = Uint8Array::new_with_byte_offset(&self.sab, HEADER_BYTES);
-        let mut drained = vec![0_u8; available as usize * RECORD_BYTES as usize];
-        for offset in 0..available {
-            let slot = read.wrapping_add(offset) % self.capacity;
-            let source = slot * RECORD_BYTES;
-            let destination = offset as usize * RECORD_BYTES as usize;
-            data.slice(source, source + RECORD_BYTES)
-                .copy_to(&mut drained[destination..destination + RECORD_BYTES as usize]);
+        let token = number(data, "poolToken")? as usize;
+        let owned = self
+            .collector_owned_tokens
+            .get_mut(token)
+            .ok_or_else(|| anyhow!("unknown trace pool token {token}"))?;
+        if *owned {
+            return Err(anyhow!("trace pool token {token} is already collector-owned").into());
         }
-        Atomics::store(&self.header, 3, write as i32)?;
-        shoop_tracing::append_bounded_browser_records(
-            &mut self.records,
-            &mut self.retention_dropped_records,
-            &drained,
-            self.max_retained_records,
-        )
-        .map_err(BrowserTraceError)?;
+        let used_bytes = number(data, "usedBytes")? as usize;
+        if used_bytes == 0 || used_bytes > self.chunk_bytes || used_bytes % RECORD_BYTES != 0 {
+            return Err(anyhow!("invalid trace chunk byte count {used_bytes}").into());
+        }
+        let buffer = Reflect::get(data, &"buffer".into())?
+            .dyn_into::<ArrayBuffer>()
+            .map_err(|_| anyhow!("trace chunk buffer is not an ArrayBuffer"))?;
+        if buffer.byte_length() as usize != self.chunk_bytes {
+            return Err(anyhow!("trace chunk capacity mismatch").into());
+        }
+        *owned = true;
+        let view = Uint8Array::new_with_byte_offset_and_length(&buffer, 0, used_bytes as u32);
+        let offset = self.records.len();
+        self.records
+            .try_reserve(used_bytes)
+            .map_err(|_| anyhow!("browser trace storage quota exhausted"))?;
+        self.records.resize(offset + used_bytes, 0);
+        view.copy_to(&mut self.records[offset..]);
+        self.next_sequence = self.next_sequence.saturating_add(1);
+
+        let recycle = Object::new();
+        Reflect::set(&recycle, &"kind".into(), &"shoop-trace-recycle".into())?;
+        Reflect::set(
+            &recycle,
+            &"captureId".into(),
+            &JsValue::from_f64(self.capture_id as f64),
+        )?;
+        Reflect::set(
+            &recycle,
+            &"poolToken".into(),
+            &JsValue::from_f64(token as f64),
+        )?;
+        Reflect::set(&recycle, &"buffer".into(), buffer.as_ref())?;
+        let transfer = Array::new();
+        transfer.push(buffer.as_ref());
+        port.post_message_with_transferable(recycle.as_ref(), &transfer)?;
+        *owned = false;
         Ok(())
     }
 
-    pub fn abort(&mut self) -> Result<()> {
-        self.poll()?;
-        if self.calibrations.is_empty() {
-            self.add_startup_calibration()?;
+    fn validate_capture(&self, data: &JsValue) -> Result<()> {
+        let capture_id = number(data, "captureId")? as u64;
+        if capture_id != self.capture_id {
+            return Err(anyhow!("stale trace capture {capture_id}").into());
         }
-        self.stopped = true;
         Ok(())
+    }
+
+    pub fn abort(&mut self) {
+        self.stopped = true;
     }
 
     pub fn stopped(&self) -> bool {
         self.stopped
     }
 
-    pub fn finish(mut self) -> Result<shoop_tracing::BrowserRealmData> {
+    pub fn finish(self) -> Result<shoop_tracing::BrowserRealmData> {
         if !self.stopped {
             return Err(anyhow!("{} trace producer has not stopped", self.label).into());
         }
-        self.poll()?;
-        let emitted_records = self.records.len() / RECORD_BYTES as usize;
         Ok(shoop_tracing::BrowserRealmData {
             id: self.realm_id,
             label: self.label,
@@ -238,14 +327,7 @@ impl RealmTraceState {
             records: self.records,
             metadata: self.metadata,
             calibrations: self.calibrations,
-            health: shoop_tracing::BrowserHealth {
-                emitted_records: emitted_records as u64,
-                dropped_records: u64::from(Atomics::load(&self.header, 4)? as u32)
-                    .saturating_add(self.retention_dropped_records),
-                completed_batches: u64::from(Atomics::load(&self.header, 5)? as u32),
-                high_water_records: Atomics::load(&self.header, 8)? as u32 as usize,
-                repaired_span_boundaries: 0,
-            },
+            health: self.health,
         })
     }
 
@@ -299,26 +381,6 @@ impl RealmTraceState {
             });
             return Ok(());
         }
-        self.add_startup_calibration()
-    }
-
-    fn add_startup_calibration(&mut self) -> Result<()> {
-        if !self.calibrations.is_empty() || Atomics::load(&self.header, 15)? == 0 {
-            return Ok(());
-        }
-        let source_low = Atomics::load(&self.header, 9)? as u32;
-        let source_high = Atomics::load(&self.header, 10)? as u32;
-        let reference_low = Atomics::load(&self.header, 13)? as u32;
-        let reference_high = Atomics::load(&self.header, 14)? as u32;
-        let source_ticks = u64::from(source_low) | (u64::from(source_high) << 32);
-        let reference_ms = u64::from(reference_low) | (u64::from(reference_high) << 32);
-        self.calibrations.push(shoop_tracing::BrowserCalibration {
-            realm_id: self.realm_id,
-            clock_id: self.clock_id,
-            source_ticks,
-            reference_time_ns: reference_ms.saturating_mul(1_000_000),
-            uncertainty_ns: 1_000_000_000,
-        });
-        Ok(())
+        Err(anyhow!("trace calibration message is incomplete").into())
     }
 }

--- a/src/rust/shoopdaloop/src/browser_trace.rs
+++ b/src/rust/shoopdaloop/src/browser_trace.rs
@@ -1,11 +1,18 @@
 use anyhow::anyhow;
 use js_sys::{Array, ArrayBuffer, Object, Reflect, Uint8Array};
+use std::cell::Cell;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::MessagePort;
 
 const RECORD_BYTES: usize = 48;
 const TRACE_PROTOCOL_VERSION: u32 = 2;
 const TRACE_POOL_SIZE: usize = 3;
+const MAX_SAFE_INTEGER: u64 = (1_u64 << 53) - 1;
+const MAX_REALM_TRACE_BYTES: usize = 512 * 1024 * 1024;
+
+thread_local! {
+    static NEXT_CAPTURE_ID: Cell<u64> = const { Cell::new(1) };
+}
 
 type Result<T> = std::result::Result<T, BrowserTraceError>;
 
@@ -46,6 +53,29 @@ fn number(data: &JsValue, name: &str) -> Result<f64> {
         .ok_or_else(|| anyhow!("trace message {name} is not numeric").into())
 }
 
+fn integer(data: &JsValue, name: &str, maximum: u64) -> Result<u64> {
+    let value = number(data, name)?;
+    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 || value > maximum as f64 {
+        return Err(anyhow!("trace message {name} is not a valid integer").into());
+    }
+    Ok(value as u64)
+}
+
+fn next_capture_id() -> u64 {
+    NEXT_CAPTURE_ID.with(|next| {
+        let id = next.get();
+        next.set(if id == MAX_SAFE_INTEGER { 1 } else { id + 1 });
+        id
+    })
+}
+
+#[derive(Debug)]
+enum TerminalState {
+    Active,
+    Complete,
+    Aborted(String),
+}
+
 pub struct RealmTraceState {
     realm_id: u32,
     capture_id: u64,
@@ -59,7 +89,7 @@ pub struct RealmTraceState {
     calibrations: Vec<shoop_tracing::BrowserCalibration>,
     records: Vec<u8>,
     health: shoop_tracing::BrowserHealth,
-    stopped: bool,
+    terminal: TerminalState,
 }
 
 impl RealmTraceState {
@@ -76,7 +106,7 @@ impl RealmTraceState {
         }
         Ok(Self {
             realm_id,
-            capture_id: u64::from(realm_id),
+            capture_id: next_capture_id(),
             clock_id,
             label: label.into(),
             ticks_per_second,
@@ -87,7 +117,7 @@ impl RealmTraceState {
             calibrations: Vec::new(),
             records: Vec::new(),
             health: shoop_tracing::BrowserHealth::default(),
-            stopped: false,
+            terminal: TerminalState::Active,
         })
     }
 
@@ -184,15 +214,25 @@ impl RealmTraceState {
         let kind = Reflect::get(data, &"kind".into())
             .ok()
             .and_then(|value| value.as_string());
+        if kind
+            .as_deref()
+            .is_some_and(|kind| kind.starts_with("shoop-trace-"))
+            && !self.matches_capture(data)?
+        {
+            tracing::debug!(
+                realm = self.realm_id,
+                "frontend.browser_trace.stale_message_ignored"
+            );
+            return Ok(true);
+        }
         match kind.as_deref() {
             Some("shoop-trace-metadata") => {
-                self.validate_capture(data)?;
                 let entries = Array::from(&Reflect::get(data, &"metadata".into())?);
                 self.metadata.clear();
                 for value in entries.iter() {
                     self.metadata.push(shoop_tracing::BrowserMetadata {
-                        id: number(&value, "id")? as u32,
-                        namespace: number(&value, "namespace")? as u8,
+                        id: integer(&value, "id", u32::MAX.into())? as u32,
+                        namespace: integer(&value, "namespace", u8::MAX.into())? as u8,
                         label: Reflect::get(&value, &"label".into())?
                             .as_string()
                             .ok_or_else(|| anyhow!("trace metadata label is not a string"))?,
@@ -210,8 +250,7 @@ impl RealmTraceState {
                 Ok(true)
             }
             Some("shoop-trace-stopped") => {
-                self.validate_capture(data)?;
-                let chunk_count = number(data, "chunkCount")? as u64;
+                let chunk_count = integer(data, "chunkCount", MAX_SAFE_INTEGER)?;
                 if chunk_count != self.next_sequence {
                     return Err(anyhow!(
                         "trace stopped with {chunk_count} chunks after receiving {}",
@@ -219,32 +258,34 @@ impl RealmTraceState {
                     )
                     .into());
                 }
-                self.health.emitted_records = number(data, "emittedRecords")? as u64;
-                self.health.dropped_records = number(data, "droppedRecords")? as u64;
-                self.health.raw_dropped_records = number(data, "rawDroppedRecords")? as u64;
-                self.health.pool_starvation_records = number(data, "poolStarvationRecords")? as u64;
+                self.health.emitted_records = integer(data, "emittedRecords", MAX_SAFE_INTEGER)?;
+                self.health.dropped_records = integer(data, "droppedRecords", MAX_SAFE_INTEGER)?;
+                self.health.raw_dropped_records =
+                    integer(data, "rawDroppedRecords", MAX_SAFE_INTEGER)?;
+                self.health.pool_starvation_records =
+                    integer(data, "poolStarvationRecords", MAX_SAFE_INTEGER)?;
                 self.health.completed_batches = chunk_count;
-                self.health.high_water_records = number(data, "highWaterRecords")? as usize;
-                self.health.max_in_flight_chunks = number(data, "maxInFlight")? as usize;
-                self.health.returned_buffers = number(data, "returnedBuffers")? as u64;
-                self.health.rejected_chunks = number(data, "rejectedChunks")? as u64;
+                self.health.high_water_records =
+                    integer(data, "highWaterRecords", usize::MAX as u64)? as usize;
+                self.health.max_in_flight_chunks =
+                    integer(data, "maxInFlight", TRACE_POOL_SIZE as u64)? as usize;
+                self.health.returned_buffers = integer(data, "returnedBuffers", MAX_SAFE_INTEGER)?;
+                self.health.rejected_chunks = integer(data, "rejectedChunks", MAX_SAFE_INTEGER)?;
                 self.add_message_calibration(data)?;
-                self.stopped = true;
+                self.terminal = TerminalState::Complete;
                 tracing::info!(realm = self.realm_id, "frontend.browser_trace.stopped");
                 Ok(true)
             }
             Some("shoop-trace-aborted") => {
-                self.validate_capture(data)?;
-                self.stopped = true;
-                Err(anyhow!("{} trace producer aborted", self.label).into())
+                self.abort_with_reason(format!("{} trace producer aborted", self.label));
+                Ok(true)
             }
             _ => Ok(false),
         }
     }
 
     fn handle_chunk(&mut self, data: &JsValue, port: &MessagePort) -> Result<()> {
-        self.validate_capture(data)?;
-        let sequence = number(data, "sequence")? as u64;
+        let sequence = integer(data, "sequence", MAX_SAFE_INTEGER)?;
         if sequence != self.next_sequence {
             return Err(anyhow!(
                 "expected trace chunk {}, received {sequence}",
@@ -252,7 +293,7 @@ impl RealmTraceState {
             )
             .into());
         }
-        let token = number(data, "poolToken")? as usize;
+        let token = integer(data, "poolToken", (TRACE_POOL_SIZE - 1) as u64)? as usize;
         let owned = self
             .collector_owned_tokens
             .get_mut(token)
@@ -260,7 +301,7 @@ impl RealmTraceState {
         if *owned {
             return Err(anyhow!("trace pool token {token} is already collector-owned").into());
         }
-        let used_bytes = number(data, "usedBytes")? as usize;
+        let used_bytes = integer(data, "usedBytes", self.chunk_bytes as u64)? as usize;
         if used_bytes == 0 || used_bytes > self.chunk_bytes || used_bytes % RECORD_BYTES != 0 {
             return Err(anyhow!("invalid trace chunk byte count {used_bytes}").into());
         }
@@ -272,13 +313,29 @@ impl RealmTraceState {
         }
         *owned = true;
         let view = Uint8Array::new_with_byte_offset_and_length(&buffer, 0, used_bytes as u32);
+        let final_record = view
+            .slice((used_bytes - RECORD_BYTES) as u32, used_bytes as u32)
+            .to_vec();
+        if !shoop_tracing::raw_chunk_ends_group(&final_record) {
+            return Err(anyhow!("trace chunk ends inside a record group").into());
+        }
         let offset = self.records.len();
+        if offset > MAX_REALM_TRACE_BYTES.saturating_sub(used_bytes) {
+            self.health.storage_failures = self.health.storage_failures.saturating_add(1);
+            return Err(anyhow!("browser trace storage quota exhausted").into());
+        }
         self.records
             .try_reserve(used_bytes)
             .map_err(|_| anyhow!("browser trace storage quota exhausted"))?;
         self.records.resize(offset + used_bytes, 0);
         view.copy_to(&mut self.records[offset..]);
-        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .filter(|value| *value <= MAX_SAFE_INTEGER)
+            .ok_or_else(|| {
+                anyhow!("trace chunk sequence exceeds JavaScript's safe integer range")
+            })?;
 
         let recycle = Object::new();
         Reflect::set(&recycle, &"kind".into(), &"shoop-trace-recycle".into())?;
@@ -300,25 +357,33 @@ impl RealmTraceState {
         Ok(())
     }
 
-    fn validate_capture(&self, data: &JsValue) -> Result<()> {
-        let capture_id = number(data, "captureId")? as u64;
-        if capture_id != self.capture_id {
-            return Err(anyhow!("stale trace capture {capture_id}").into());
-        }
-        Ok(())
+    fn matches_capture(&self, data: &JsValue) -> Result<bool> {
+        Ok(integer(data, "captureId", MAX_SAFE_INTEGER)? == self.capture_id)
     }
 
     pub fn abort(&mut self) {
-        self.stopped = true;
+        self.abort_with_reason(format!("{} trace collection was aborted", self.label));
+    }
+
+    pub fn abort_with_reason(&mut self, reason: impl Into<String>) {
+        self.terminal = TerminalState::Aborted(reason.into());
     }
 
     pub fn stopped(&self) -> bool {
-        self.stopped
+        !matches!(self.terminal, TerminalState::Active)
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
     }
 
     pub fn finish(self) -> Result<shoop_tracing::BrowserRealmData> {
-        if !self.stopped {
-            return Err(anyhow!("{} trace producer has not stopped", self.label).into());
+        match &self.terminal {
+            TerminalState::Active => {
+                return Err(anyhow!("{} trace producer has not stopped", self.label).into())
+            }
+            TerminalState::Aborted(reason) => return Err(anyhow!(reason.clone()).into()),
+            TerminalState::Complete => {}
         }
         Ok(shoop_tracing::BrowserRealmData {
             id: self.realm_id,

--- a/src/rust/shoopdaloop/src/browser_worker.rs
+++ b/src/rust/shoopdaloop/src/browser_worker.rs
@@ -17,7 +17,6 @@ const WORKER_SCRIPT_URL: &str = "./audio_worker.js";
 const WORKLET_WASM_URL: &str = "./generated/shoop_audio_worklet.wasm";
 const EMBEDDED_WORKLET_ASSETS: &str = "shoopEmbeddedAudioWorklet";
 const MAX_QUANTUM: u32 = 2048;
-const MAX_RETAINED_TRACE_RECORDS: usize = 262_144;
 const GENERATION: u64 = 1;
 
 struct BrowserWorkerEndpoint(MessagePort);
@@ -47,12 +46,7 @@ pub struct BrowserWorkerDriver {
 
 fn abort_pending_trace(trace: &Rc<RefCell<Option<crate::browser_trace::RealmTraceState>>>) {
     if let Some(trace) = trace.borrow_mut().as_mut() {
-        if let Err(error) = trace.abort() {
-            tracing::error!(
-                error = %error,
-                "frontend.browser_trace.worker_abort_failed"
-            );
-        }
+        trace.abort();
     }
 }
 
@@ -83,6 +77,7 @@ impl BrowserWorkerDriver {
         let receive_repaint_context = Rc::clone(&repaint_context);
         let trace = Rc::new(RefCell::new(None::<crate::browser_trace::RealmTraceState>));
         let receive_trace = Rc::clone(&trace);
+        let trace_port = application_port.clone();
         let message_handler = Closure::wrap(Box::new(move |event: MessageEvent| {
             if let Some(json) = event.data().as_string() {
                 let _ = receive_control.receive(GENERATION, &json);
@@ -90,14 +85,14 @@ impl BrowserWorkerDriver {
                 let handled = {
                     let mut slot = receive_trace.borrow_mut();
                     if let Some(trace) = slot.as_mut() {
-                        match trace.handle_message(&event.data()) {
+                        match trace.handle_message(&event.data(), &trace_port) {
                             Ok(handled) => handled,
                             Err(error) => {
                                 tracing::error!(
                                     error = %error,
                                     "frontend.browser_trace.worker_message_failed"
                                 );
-                                let _ = trace.abort();
+                                trace.abort();
                                 receive_control
                                     .fail(format!("Worker trace message failed: {error}"));
                                 true
@@ -226,15 +221,8 @@ impl BrowserWorkerDriver {
         if self.trace.borrow().is_some() {
             return Ok(true);
         }
-        let trace = crate::browser_trace::RealmTraceState::new(
-            2,
-            102,
-            "Engine Worker",
-            48_000,
-            128,
-            8192,
-            MAX_RETAINED_TRACE_RECORDS,
-        )?;
+        let trace =
+            crate::browser_trace::RealmTraceState::new(2, 102, "Engine Worker", 48_000, 128, 8192)?;
         self.application_port
             .post_message(&trace.start_message(engine_detail)?)
             .map_err(|error| anyhow!("could not start Worker tracing: {error:?}"))?;
@@ -254,16 +242,21 @@ impl BrowserWorkerDriver {
     }
 
     pub fn discard_tracing(&self) {
-        let _ = self.request_stop_tracing();
+        if let Some(trace) = self.trace.borrow().as_ref() {
+            if let Ok(message) = trace.abort_message() {
+                let _ = self.application_port.post_message(&message);
+            }
+        }
         if let Some(mut trace) = self.trace.borrow_mut().take() {
-            let _ = trace.abort();
+            trace.abort();
         }
     }
 
     pub fn request_stop_tracing(&self) -> Result<()> {
         if self.trace.borrow().is_some() {
+            let message = self.trace.borrow().as_ref().unwrap().stop_message()?;
             self.application_port
-                .post_message(&crate::browser_trace::RealmTraceState::stop_message()?)
+                .post_message(&message)
                 .map_err(|error| anyhow!("could not stop Worker tracing: {error:?}"))?;
         }
         Ok(())

--- a/src/rust/shoopdaloop/src/browser_worker.rs
+++ b/src/rust/shoopdaloop/src/browser_worker.rs
@@ -92,7 +92,12 @@ impl BrowserWorkerDriver {
                                     error = %error,
                                     "frontend.browser_trace.worker_message_failed"
                                 );
-                                trace.abort();
+                                if let Ok(message) = trace.abort_message() {
+                                    let _ = trace_port.post_message(&message);
+                                }
+                                trace.abort_with_reason(format!(
+                                    "Worker trace message failed: {error}"
+                                ));
                                 receive_control
                                     .fail(format!("Worker trace message failed: {error}"));
                                 true
@@ -239,6 +244,13 @@ impl BrowserWorkerDriver {
 
     pub fn has_active_trace(&self) -> bool {
         self.trace.borrow().is_some()
+    }
+
+    pub fn trace_stopped(&self) -> bool {
+        self.trace
+            .borrow()
+            .as_ref()
+            .is_some_and(crate::browser_trace::RealmTraceState::stopped)
     }
 
     pub fn discard_tracing(&self) {

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -752,6 +752,13 @@ impl UnifiedApp {
             self.tracing_stop_started = None;
         }
         if let Err(error) = self.tracing.poll() {
+            self.runtime.cancel_tracing_request();
+            if let Err(discard_error) = self.tracing.discard_active() {
+                tracing::error!(
+                    error = %discard_error,
+                    "frontend.browser_trace.window_storage_failure_cleanup_failed"
+                );
+            }
             self.settings.report_action_error(error.to_string());
         }
         if let Err(error) = self.runtime.poll_tracing() {

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -185,7 +185,7 @@ impl NativeTracing {
 #[cfg(not(target_arch = "wasm32"))]
 type SharedNativeTracing = Arc<Mutex<NativeTracing>>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum PendingTracingAction {
     Start { engine_detail: bool },
     Stop { save: bool },
@@ -202,19 +202,10 @@ struct BrowserTracing {
 #[cfg(target_arch = "wasm32")]
 impl BrowserTracing {
     fn new() -> Self {
-        let global = js_sys::global();
-        let isolated = js_sys::Reflect::get(&global, &"crossOriginIsolated".into())
-            .ok()
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
-        let has_shared_buffer = js_sys::Reflect::get(&global, &"SharedArrayBuffer".into())
-            .is_ok_and(|value| value.is_function());
-        let unavailable_reason = (!isolated || !has_shared_buffer)
-            .then_some("Multirealm tracing requires COOP/COEP cross-origin isolation");
         Self {
             capture: None,
             window_calibrations: Vec::new(),
-            unavailable_reason,
+            unavailable_reason: None,
         }
     }
 
@@ -411,6 +402,8 @@ struct UnifiedApp {
     tracing: BrowserTracing,
     #[cfg(target_arch = "wasm32")]
     tracing_smoke_started: Option<Instant>,
+    #[cfg(target_arch = "wasm32")]
+    tracing_stop_started: Option<Instant>,
     pending_tracing_action: Option<PendingTracingAction>,
     last_update: Instant,
     startup_session: Option<(String, bool)>,
@@ -513,6 +506,8 @@ impl UnifiedApp {
             tracing: BrowserTracing::new(),
             #[cfg(target_arch = "wasm32")]
             tracing_smoke_started: None,
+            #[cfg(target_arch = "wasm32")]
+            tracing_stop_started: None,
             pending_tracing_action: if cfg!(target_arch = "wasm32") && args.tracing {
                 Some(PendingTracingAction::Start {
                     engine_detail: args.tracing_engine_detail,
@@ -692,6 +687,21 @@ impl UnifiedApp {
 
     #[cfg(target_arch = "wasm32")]
     fn process_tracing(&mut self) {
+        if self
+            .pending_tracing_action
+            .is_some_and(|action| matches!(action, PendingTracingAction::FinishStop { .. }))
+            && self
+                .tracing_stop_started
+                .is_some_and(|started| started.elapsed() >= Duration::from_secs(5))
+        {
+            self.runtime.cancel_tracing_request();
+            let _ = self.tracing.discard_active();
+            self.pending_tracing_action = None;
+            self.tracing_stop_started = None;
+            tracing::error!("frontend.browser_trace.stop_timeout");
+            self.settings
+                .report_action_error("Browser trace stop timed out; capture is incomplete");
+        }
         if let Some(action) = self.pending_tracing_action.take() {
             let result: anyhow::Result<Option<TracingStopped>> = (|| match action {
                 PendingTracingAction::Start { engine_detail } => {
@@ -710,6 +720,7 @@ impl UnifiedApp {
                 }
                 PendingTracingAction::Stop { save } => {
                     self.runtime.request_stop_tracing()?;
+                    self.tracing_stop_started = Some(Instant::now());
                     self.pending_tracing_action = Some(PendingTracingAction::FinishStop { save });
                     Ok(None)
                 }
@@ -732,6 +743,12 @@ impl UnifiedApp {
                     self.settings.report_action_error(error.to_string());
                 }
             }
+        }
+        if !self
+            .pending_tracing_action
+            .is_some_and(|action| matches!(action, PendingTracingAction::FinishStop { .. }))
+        {
+            self.tracing_stop_started = None;
         }
         if let Err(error) = self.tracing.poll() {
             self.settings.report_action_error(error.to_string());

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -693,6 +693,7 @@ impl UnifiedApp {
             && self
                 .tracing_stop_started
                 .is_some_and(|started| started.elapsed() >= Duration::from_secs(5))
+            && !self.runtime.trace_stopped()
         {
             self.runtime.cancel_tracing_request();
             let _ = self.tracing.discard_active();
@@ -2479,6 +2480,13 @@ impl Runtime {
         match &self.mode {
             BrowserRuntimeMode::WebAudio(controller) => controller.request_stop_tracing(),
             BrowserRuntimeMode::Worker(driver) => driver.request_stop_tracing(),
+        }
+    }
+
+    fn trace_stopped(&self) -> bool {
+        match &self.mode {
+            BrowserRuntimeMode::WebAudio(controller) => controller.trace_stopped(),
+            BrowserRuntimeMode::Worker(driver) => driver.trace_stopped(),
         }
     }
 


### PR DESCRIPTION
## Summary

Implements ShoopDaLoop's half of the joint transferable browser trace transport migration completed in SanderVocke/perfetto-everywhere#2.

- removes browser trace `SharedArrayBuffer`, Atomics polling, fixed retained-record limits, and the cross-origin-isolation tracing gate
- adds recyclable preallocated `ArrayBuffer` chunk producers for AudioWorklet and Engine Worker realms
- validates capture IDs, sequences, pool tokens, used byte counts, declared final chunk counts, calibration, and transport health in the Rust/Wasm collector
- makes save await complete realm acknowledgements and adds bounded stop timeout, explicit abort/discard, storage failure reporting, and late-message safety
- supports arbitrary capture lengths through repeated transfer/recycle rotations rather than a bounded capture buffer
- updates permanent tracing and migration documentation; the completed temporary execution plan has been removed

## Upstream dependency

ShoopDaLoop pins the immutable upstream merge commit `caaa26c067cc91a2b3f6dc9ca2a87da22071e5a4`. All seven perfetto-everywhere CI jobs passed. Its 60-second non-isolated AudioWorklet acceptance capture produced 89,801 records in 11 chunks and a validated 6.7 MB trace with zero drops.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` — 1,523 passed, 4 skipped
- `python3 scripts/validate_perfetto_traces.py`
- `node --test scripts/tests/trace_chunk_transport.test.mjs` — includes 262,145 records, pool recycling, starved stop, and empty stop
- Node and non-isolated Chromium `shoop_audio_worklet` Wasm suites — 14 passed in each runtime
- `trunk build` with warnings denied
- packaged non-isolated worker and AudioWorklet browser tracing smokes, followed by Trace Processor realm/health validation (zero producer drops, starvation, rejected chunks, and storage failures)
- `sphinx-build -W --keep-going docs/source /tmp/shoopdaloop-docs-build`
- tracing coverage and `#[shoop_test]` policy checks
