### PR TITLE
Implement authoritative composite start and seek snapshots

### DIFF
--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -77,15 +77,15 @@ Immediate transitions and seeks use authoritative reconciliation. Delayed transi
 
 ### Stage 3: Verify Nested Propagation and Conflict Resolution
 
-- [ ] Add a boundary-timeline test where starting a root composite starts a nested composite and stops a deep primitive that is referenced but not desired at iteration zero.
-- [ ] Add or extend a conflict test where an authoritative composite stop conflicts with a higher-priority direct start, proving the direct intent still wins and the losing conflict is traced.
-- [ ] Add a regression test proving natural advancement does not emit redundant stops for referenced targets that remain locally inactive.
-- [ ] Confirm same-sample propagation remains topology-ordered and transactional for all affected nested operations.
+- [x] Add a boundary-timeline test where starting a root composite starts a nested composite and stops a deep primitive that is referenced but not desired at iteration zero.
+- [x] Add or extend a conflict test where an authoritative composite stop conflicts with a higher-priority direct start, proving the direct intent still wins and the losing conflict is traced.
+- [x] Add a regression test proving natural advancement does not emit redundant stops for referenced targets that remain locally inactive.
+- [x] Confirm same-sample propagation remains topology-ordered and transactional for all affected nested operations.
 
 **Verification**
 
-- [ ] Run targeted composite timeline, state-machine, timing, control, and app-backend tests.
-- [ ] Inspect boundary traces in the new cases for the expected origin, action, winner, and losing-conflict count.
+- [x] Run targeted composite timeline, state-machine, timing, control, and app-backend tests.
+- [x] Inspect boundary traces in the new cases for the expected origin, action, winner, and losing-conflict count.
 
 ### Stage 4: Document and Audit the Contract
 

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -1,0 +1,114 @@
+# Authoritative Composite Start and Seek Plan
+
+## Goals
+
+- Make every explicit composite start and seek establish an authoritative snapshot over all targets referenced by the active composite plan.
+- Preserve incremental, delta-based behavior during natural schedule advancement and wraparound.
+- Preserve the existing boundary intent precedence model, including its deterministic runtime-identity tie-breaks.
+- Apply the same semantics to primitive and nested-composite targets, immediate and delayed transitions, native and browser backends, without adding realtime allocation.
+
+## Scope
+
+This work changes composite runtime reconciliation and its tests. It may update developer- or user-facing composite semantic documentation where the contract is described. It does not introduce persisted composite priority, change session IDs or formats, change the current direct/script/regular/natural precedence ordering, or implement hierarchy-based precedence.
+
+## Immutable Acceptance Criteria
+
+1. An explicit non-stopped start at iteration `N` emits `SetMode` for every referenced target desired at `N` and `Stop` for every referenced target not desired at `N`, regardless of the composite runtime's remembered active targets.
+2. An explicit seek to iteration `N` establishes the same complete target snapshot as an explicit start at `N`.
+3. A delayed transition establishes the same authoritative snapshot when it executes as the equivalent immediate transition.
+4. Explicit stop continues to stop every referenced target.
+5. Authoritative operations on nested composites propagate to primitive descendants at the same sample through normal boundary intent resolution.
+6. All generated operations continue to participate in the existing precedence and conflict-tracing model; direct, script, regular, and natural priority is unchanged.
+7. Natural iteration advancement, regular wraparound, script completion, and plan replacement remain delta-based unless they execute an explicit start or seek; they do not repeatedly stop referenced targets that are already inactive in that composite runtime.
+8. Empty plans retain their existing stopped behavior, invalid seeks and modes retain their existing errors, and stale targets retain their existing counter/error behavior.
+9. Composite processing remains bounded and allocation-free on the realtime path.
+10. Native and WebAssembly composite test coverage passes.
+
+## Design Rules and Constraints
+
+- Model reconciliation policy explicitly, preferably with a private enum such as `Delta` and `Authoritative`; do not add another unexplained positional boolean.
+- Authoritative means emitting a complete set of intents for the selected iteration. It does not bypass conflict resolution or grant exclusive ownership after that boundary.
+- In authoritative reconciliation, an undesired current target receives `Stop` even when the runtime's local active entry is false. A desired target follows existing mode, offset, retrigger, empty-child, and recording rules.
+- Delta reconciliation retains the current stop condition: emit a stop only for a locally active target that is no longer desired.
+- Reuse the immediate-transition path for delayed transition execution so both forms cannot diverge semantically.
+- Keep target ordering, fixed-capacity batches, stale-identity checks, counters, transactional boundary commit, and no-allocation guarantees intact.
+- Treat engine source identity as a deterministic runtime tie-break, not a persisted session priority. Application loop IDs are persisted, but this work must not make engine slot/generation identity part of the session contract.
+- Avoid unrelated refactors, formatting changes, or changes to composite plan compilation.
+
+## Execution Contract
+
+- Keep this plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.
+
+## Staged Implementation
+
+### Stage 1: Lock Down Runtime Semantics
+
+- [ ] Add focused state-machine tests showing that an explicit start stops a referenced primitive that is not desired at the selected iteration even when the composite does not remember it as active.
+- [ ] Add a two-target test showing that one authoritative operation emits `SetMode` for the desired target and `Stop` for the undesired target.
+- [ ] Add explicit-seek coverage for the same complete destination snapshot, including a target whose external state cannot be inferred from local `active` bookkeeping.
+- [ ] Add delayed-start coverage proving execution matches an immediate start.
+- [ ] Verify the new tests fail for the missing authoritative stops while existing start, seek, invalid-input, empty-child, and recording cases remain meaningful.
+
+**Verification**
+
+- [ ] Run the targeted `shoop_engine` composite state-machine tests.
+- [ ] Confirm failures are limited to the new authoritative expectations before changing runtime code.
+
+### Stage 2: Implement Explicit Reconciliation Policy
+
+- [ ] Add a private reconciliation policy type and thread it through composite runtime reconciliation.
+- [ ] Change the stop pass so authoritative reconciliation emits `Stop` for every undesired installed target, while delta reconciliation preserves the existing active-to-inactive behavior.
+- [ ] Use authoritative reconciliation for explicit non-stopped immediate transitions and explicit seeks.
+- [ ] Confirm delayed transitions execute through the authoritative immediate-transition path.
+- [ ] Keep natural advancement, regular wraparound, recording pass completion, script completion, and plan activation/replacement on the appropriate delta paths.
+- [ ] Preserve desired-target mode selection, offsets, retrigger behavior, local active state, stale-target handling, batch capacity, counters, and empty-plan behavior.
+
+**Verification**
+
+- [ ] Run the targeted composite state-machine tests and confirm all Stage 1 cases pass.
+- [ ] Run the realtime no-allocation composite test to ensure the policy adds no allocation.
+- [ ] Review every reconciliation call site and record its authoritative or delta rationale in the implementation commit or plan progress notes.
+
+### Stage 3: Verify Nested Propagation and Conflict Resolution
+
+- [ ] Add a boundary-timeline test where starting a root composite starts a nested composite and stops a deep primitive that is referenced but not desired at iteration zero.
+- [ ] Add or extend a conflict test where an authoritative composite stop conflicts with a higher-priority direct start, proving the direct intent still wins and the losing conflict is traced.
+- [ ] Add a regression test proving natural advancement does not emit redundant stops for referenced targets that remain locally inactive.
+- [ ] Confirm same-sample propagation remains topology-ordered and transactional for all affected nested operations.
+
+**Verification**
+
+- [ ] Run targeted composite timeline, state-machine, timing, control, and app-backend tests.
+- [ ] Inspect boundary traces in the new cases for the expected origin, action, winner, and losing-conflict count.
+
+### Stage 4: Document and Audit the Contract
+
+- [ ] Document that explicit start and seek establish a complete target snapshot, while natural schedule advancement is incremental.
+- [ ] Document that authoritative operations still participate in normal conflict resolution.
+- [ ] Where tie-break semantics are documented, state that engine source identity is a deterministic runtime tie-break and not a persisted user-defined priority.
+- [ ] Audit native and AudioWorklet command paths to confirm they both reach the same engine runtime semantics without backend-specific duplication.
+
+**Verification**
+
+- [ ] Review terminology consistently for `authoritative`, `snapshot`, `explicit`, and `delta` behavior.
+- [ ] Confirm no session schema, wire protocol, or public API change is required.
+
+### Stage 5: End-to-End Validation
+
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Run the repository's Rust test-usage check if Rust tests were changed.
+- [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown` and run the documented browser smoke checks when browsers are available.
+- [ ] Review the final diff for unrelated changes and verify every immutable acceptance criterion has direct test or inspection evidence.
+
+**Verification**
+
+- [ ] Record every command and outcome, including any environment-only limitation.
+- [ ] Confirm native and WebAssembly behavior uses the same authoritative runtime implementation.
+- [ ] Commit the completed validation milestone with this plan updated to reflect actual progress.

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -47,16 +47,16 @@ This work changes composite runtime reconciliation and its tests. It may update 
 
 ### Stage 1: Lock Down Runtime Semantics
 
-- [ ] Add focused state-machine tests showing that an explicit start stops a referenced primitive that is not desired at the selected iteration even when the composite does not remember it as active.
-- [ ] Add a two-target test showing that one authoritative operation emits `SetMode` for the desired target and `Stop` for the undesired target.
-- [ ] Add explicit-seek coverage for the same complete destination snapshot, including a target whose external state cannot be inferred from local `active` bookkeeping.
-- [ ] Add delayed-start coverage proving execution matches an immediate start.
-- [ ] Verify the new tests fail for the missing authoritative stops while existing start, seek, invalid-input, empty-child, and recording cases remain meaningful.
+- [x] Add focused state-machine tests showing that an explicit start stops a referenced primitive that is not desired at the selected iteration even when the composite does not remember it as active.
+- [x] Add a two-target test showing that one authoritative operation emits `SetMode` for the desired target and `Stop` for the undesired target.
+- [x] Add explicit-seek coverage for the same complete destination snapshot, including a target whose external state cannot be inferred from local `active` bookkeeping.
+- [x] Add delayed-start coverage proving execution matches an immediate start.
+- [x] Verify the new tests fail for the missing authoritative stops while existing start, seek, invalid-input, empty-child, and recording cases remain meaningful.
 
 **Verification**
 
-- [ ] Run the targeted `shoop_engine` composite state-machine tests.
-- [ ] Confirm failures are limited to the new authoritative expectations before changing runtime code.
+- [x] Run the targeted `shoop_engine` composite state-machine tests.
+- [x] Confirm failures are limited to the new authoritative expectations before changing runtime code.
 
 ### Stage 2: Implement Explicit Reconciliation Policy
 
@@ -105,6 +105,7 @@ This work changes composite runtime reconciliation and its tests. It may update 
 - [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
 - [ ] Run the repository's Rust test-usage check if Rust tests were changed.
 - [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown` and run the documented browser smoke checks when browsers are available.
+- [ ] Run `python3 scripts/run_wasm_tests.py --profile ci --runtime node --package shoop_engine` and also use the Chrome runtime when available.
 - [ ] Review the final diff for unrelated changes and verify every immutable acceptance criterion has direct test or inspection evidence.
 
 **Verification**

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -89,15 +89,15 @@ Immediate transitions and seeks use authoritative reconciliation. Delayed transi
 
 ### Stage 4: Document and Audit the Contract
 
-- [ ] Document that explicit start and seek establish a complete target snapshot, while natural schedule advancement is incremental.
-- [ ] Document that authoritative operations still participate in normal conflict resolution.
-- [ ] Where tie-break semantics are documented, state that engine source identity is a deterministic runtime tie-break and not a persisted user-defined priority.
-- [ ] Audit native and AudioWorklet command paths to confirm they both reach the same engine runtime semantics without backend-specific duplication.
+- [x] Document that explicit start and seek establish a complete target snapshot, while natural schedule advancement is incremental.
+- [x] Document that authoritative operations still participate in normal conflict resolution.
+- [x] Where tie-break semantics are documented, state that engine source identity is a deterministic runtime tie-break and not a persisted user-defined priority.
+- [x] Audit native and AudioWorklet command paths to confirm they both reach the same engine runtime semantics without backend-specific duplication.
 
 **Verification**
 
-- [ ] Review terminology consistently for `authoritative`, `snapshot`, `explicit`, and `delta` behavior.
-- [ ] Confirm no session schema, wire protocol, or public API change is required.
+- [x] Review terminology consistently for `authoritative`, `snapshot`, `explicit`, and `delta` behavior.
+- [x] Confirm no session schema, wire protocol, or public API change is required.
 
 ### Stage 5: End-to-End Validation
 

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -60,18 +60,20 @@ This work changes composite runtime reconciliation and its tests. It may update 
 
 ### Stage 2: Implement Explicit Reconciliation Policy
 
-- [ ] Add a private reconciliation policy type and thread it through composite runtime reconciliation.
-- [ ] Change the stop pass so authoritative reconciliation emits `Stop` for every undesired installed target, while delta reconciliation preserves the existing active-to-inactive behavior.
-- [ ] Use authoritative reconciliation for explicit non-stopped immediate transitions and explicit seeks.
-- [ ] Confirm delayed transitions execute through the authoritative immediate-transition path.
-- [ ] Keep natural advancement, regular wraparound, recording pass completion, script completion, and plan activation/replacement on the appropriate delta paths.
-- [ ] Preserve desired-target mode selection, offsets, retrigger behavior, local active state, stale-target handling, batch capacity, counters, and empty-plan behavior.
+- [x] Add a private reconciliation policy type and thread it through composite runtime reconciliation.
+- [x] Change the stop pass so authoritative reconciliation emits `Stop` for every undesired installed target, while delta reconciliation preserves the existing active-to-inactive behavior.
+- [x] Use authoritative reconciliation for explicit non-stopped immediate transitions and explicit seeks.
+- [x] Confirm delayed transitions execute through the authoritative immediate-transition path.
+- [x] Keep natural advancement, regular wraparound, recording pass completion, script completion, and plan activation/replacement on the appropriate delta paths.
+- [x] Preserve desired-target mode selection, offsets, retrigger behavior, local active state, stale-target handling, batch capacity, counters, and empty-plan behavior.
 
 **Verification**
 
-- [ ] Run the targeted composite state-machine tests and confirm all Stage 1 cases pass.
-- [ ] Run the realtime no-allocation composite test to ensure the policy adds no allocation.
-- [ ] Review every reconciliation call site and record its authoritative or delta rationale in the implementation commit or plan progress notes.
+- [x] Run the targeted composite state-machine tests and confirm all Stage 1 cases pass.
+- [x] Run the realtime no-allocation composite test to ensure the policy adds no allocation.
+- [x] Review every reconciliation call site and record its authoritative or delta rationale in the implementation commit or plan progress notes.
+
+Immediate transitions and seeks use authoritative reconciliation. Delayed transitions reuse the immediate path when due. Natural advancement, pass completion, wraparound, and plan activation use delta reconciliation because they continue or retire existing runtime ownership rather than establish an externally requested snapshot.
 
 ### Stage 3: Verify Nested Propagation and Conflict Resolution
 

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -75,6 +75,8 @@ This work changes composite runtime reconciliation and its tests. It may update 
 
 Immediate transitions and seeks use authoritative reconciliation. Delayed transitions reuse the immediate path when due. Natural advancement, pass completion, wraparound, and plan activation use delta reconciliation because they continue or retire existing runtime ownership rather than establish an externally requested snapshot.
 
+The reconciliation scope is carried with composite-generated start intents. This keeps nested transitions authoritative when they descend from an explicit start or seek, while a nested composite first started by natural parent advancement remains incremental.
+
 ### Stage 3: Verify Nested Propagation and Conflict Resolution
 
 - [x] Add a boundary-timeline test where starting a root composite starts a nested composite and stops a deep primitive that is referenced but not desired at iteration zero.
@@ -116,4 +118,4 @@ Immediate transitions and seeks use authoritative reconciliation. Delayed transi
 - [x] Confirm native and WebAssembly behavior uses the same authoritative runtime implementation.
 - [x] Commit the completed validation milestone with this plan updated to reflect actual progress.
 
-Native validation passed 1,529 tests with four environment skips. The Node WebAssembly harness passed all 794 `shoop_engine` tests. The application Wasm check and release AudioWorklet build passed. Chrome and packaged-browser smoke tests were not run because no Chrome or Chromium executable is available in this environment; the Node harness covers the shared composite runtime implementation.
+Native validation passed all feature-relevant tests; one unrelated graph-control timing test failed in the 1,530-test concurrent run and passed immediately when rerun alone. Four host-facility tests were skipped. The Node WebAssembly harness passed all 795 `shoop_engine` tests. The application Wasm check and release AudioWorklet build passed. Chrome and packaged-browser smoke tests were not run because no Chrome or Chromium executable is available in this environment; the Node harness covers the shared composite runtime implementation.

--- a/COMPOSITES.md
+++ b/COMPOSITES.md
@@ -101,17 +101,19 @@ Immediate transitions and seeks use authoritative reconciliation. Delayed transi
 
 ### Stage 5: End-to-End Validation
 
-- [ ] Run `cargo fmt --all -- --check`.
-- [ ] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
-- [ ] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
-- [ ] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
-- [ ] Run the repository's Rust test-usage check if Rust tests were changed.
-- [ ] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown` and run the documented browser smoke checks when browsers are available.
-- [ ] Run `python3 scripts/run_wasm_tests.py --profile ci --runtime node --package shoop_engine` and also use the Chrome runtime when available.
-- [ ] Review the final diff for unrelated changes and verify every immutable acceptance criterion has direct test or inspection evidence.
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `RUSTFLAGS="-D warnings" cargo build --workspace`.
+- [x] Run `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [x] Run `python3 scripts/check_tracing_coverage.py --require-closed`.
+- [x] Run the repository's Rust test-usage check if Rust tests were changed.
+- [x] Build `shoopdaloop` and `shoop_audio_worklet` for `wasm32-unknown-unknown` and run the documented browser smoke checks when browsers are available.
+- [x] Run `python3 scripts/run_wasm_tests.py --profile ci --runtime node --package shoop_engine` and also use the Chrome runtime when available.
+- [x] Review the final diff for unrelated changes and verify every immutable acceptance criterion has direct test or inspection evidence.
 
 **Verification**
 
-- [ ] Record every command and outcome, including any environment-only limitation.
-- [ ] Confirm native and WebAssembly behavior uses the same authoritative runtime implementation.
-- [ ] Commit the completed validation milestone with this plan updated to reflect actual progress.
+- [x] Record every command and outcome, including any environment-only limitation.
+- [x] Confirm native and WebAssembly behavior uses the same authoritative runtime implementation.
+- [x] Commit the completed validation milestone with this plan updated to reflect actual progress.
+
+Native validation passed 1,529 tests with four environment skips. The Node WebAssembly harness passed all 794 `shoop_engine` tests. The application Wasm check and release AudioWorklet build passed. Chrome and packaged-browser smoke tests were not run because no Chrome or Chromium executable is available in this environment; the Node harness covers the shared composite runtime implementation.

--- a/docs/composite_loop_semantics.md
+++ b/docs/composite_loop_semantics.md
@@ -1,0 +1,26 @@
+# Composite Loop Control Semantics
+
+Composite schedules may reference primitive loops or other composites. References must form an acyclic graph, but different composites may share a target.
+
+## Explicit control
+
+Starting a composite or seeking it to an iteration establishes an authoritative snapshot at that boundary. Every referenced target desired at the selected iteration receives its scheduled mode and offset. Every other referenced target receives a stop, even if the composite did not previously start it.
+
+A delayed transition applies the same snapshot when its countdown expires. Stopping a composite stops every referenced target. Operations directed at nested composites propagate to their descendants at the same sample.
+
+Authoritative describes the intents emitted at that boundary; it does not give the composite continuing exclusive ownership of shared targets. Every emitted operation participates in normal conflict resolution.
+
+## Schedule advancement
+
+Natural iteration advancement, regular wraparound, script completion, and plan replacement reconcile incrementally. They change targets previously active in that composite or newly desired by the schedule, without repeatedly stopping every referenced inactive target.
+
+## Conflicts
+
+Coincident incompatible operations use this precedence, from highest to lowest:
+
+1. direct control;
+2. script composite;
+3. regular composite;
+4. natural event.
+
+Later accepted direct controls win within their class. Composite and natural ties use stable runtime source identity and action order for deterministic processing. Runtime identity is not persisted user-defined priority and must not be used to encode session behavior.

--- a/src/rust/shoop_engine/src/composite_runtime.rs
+++ b/src/rust/shoop_engine/src/composite_runtime.rs
@@ -128,6 +128,12 @@ struct ActiveTarget {
     cycle_offset: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileScope {
+    Delta,
+    Authoritative,
+}
+
 const INACTIVE_TARGET: ActiveTarget = ActiveTarget {
     active: false,
     mode: LoopMode::Stopped,
@@ -302,6 +308,7 @@ impl CompositeRuntime {
             plan,
             Some(self.iteration),
             mode,
+            ReconcileScope::Authoritative,
             true,
             false,
             &mut target_is_current,
@@ -330,6 +337,7 @@ impl CompositeRuntime {
             plan,
             Some(self.iteration),
             self.mode,
+            ReconcileScope::Authoritative,
             true,
             false,
             &mut target_is_current,
@@ -401,6 +409,7 @@ impl CompositeRuntime {
             current_plan,
             None,
             LoopMode::Stopped,
+            ReconcileScope::Delta,
             false,
             false,
             &mut target_is_current,
@@ -518,6 +527,7 @@ impl CompositeRuntime {
                 candidate,
                 Some(0),
                 next_mode,
+                ReconcileScope::Delta,
                 false,
                 recorded_children,
                 &mut target_is_current,
@@ -623,7 +633,15 @@ impl CompositeRuntime {
         let next = self.iteration + 1;
         if next < plan.n_iterations() {
             self.iteration = next;
-            return self.reconcile(plan, Some(next), self.mode, false, false, target_is_current);
+            return self.reconcile(
+                plan,
+                Some(next),
+                self.mode,
+                ReconcileScope::Delta,
+                false,
+                false,
+                target_is_current,
+            );
         }
 
         match plan.kind() {
@@ -632,6 +650,7 @@ impl CompositeRuntime {
                     plan,
                     None,
                     LoopMode::Stopped,
+                    ReconcileScope::Delta,
                     false,
                     false,
                     target_is_current,
@@ -645,12 +664,21 @@ impl CompositeRuntime {
                 self.iteration = 0;
                 if self.play_after_record {
                     self.mode = playback_mode_after_record(self.mode);
-                    self.reconcile(plan, Some(0), self.mode, false, true, target_is_current)
+                    self.reconcile(
+                        plan,
+                        Some(0),
+                        self.mode,
+                        ReconcileScope::Delta,
+                        false,
+                        true,
+                        target_is_current,
+                    )
                 } else {
                     let batch = self.reconcile(
                         plan,
                         None,
                         LoopMode::Stopped,
+                        ReconcileScope::Delta,
                         false,
                         false,
                         target_is_current,
@@ -666,7 +694,15 @@ impl CompositeRuntime {
                 } else {
                     self.cycle_count += 1;
                 }
-                self.reconcile(plan, Some(0), self.mode, false, false, target_is_current)
+                self.reconcile(
+                    plan,
+                    Some(0),
+                    self.mode,
+                    ReconcileScope::Delta,
+                    false,
+                    false,
+                    target_is_current,
+                )
             }
         }
     }
@@ -700,6 +736,7 @@ impl CompositeRuntime {
         plan: &CompiledCompositePlan,
         desired_iteration: Option<u32>,
         composite_mode: LoopMode,
+        scope: ReconcileScope,
         force_seek: bool,
         assume_recorded_children_nonempty: bool,
         target_is_current: &mut F,
@@ -720,7 +757,9 @@ impl CompositeRuntime {
                     state
                 })
                 .and_then(|state| effective_target(state, composite_mode, self.iteration));
-            if self.active[index].active && desired.is_none() {
+            if desired.is_none()
+                && (scope == ReconcileScope::Authoritative || self.active[index].active)
+            {
                 self.emit(
                     &mut batch,
                     index,

--- a/src/rust/shoop_engine/src/composite_runtime.rs
+++ b/src/rust/shoop_engine/src/composite_runtime.rs
@@ -26,11 +26,13 @@ pub enum CompositeTargetAction {
 pub struct CompositeTargetTransition {
     pub target: LoopIdentity,
     pub action: CompositeTargetAction,
+    pub authoritative: bool,
 }
 
 const EMPTY_TRANSITION: CompositeTargetTransition = CompositeTargetTransition {
     target: EMPTY_IDENTITY,
     action: CompositeTargetAction::Stop,
+    authoritative: false,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -280,13 +282,52 @@ impl CompositeRuntime {
     where
         F: FnMut(LoopIdentity) -> bool,
     {
+        self.transition_immediate_inner(
+            plan,
+            mode,
+            seek_iteration,
+            ReconcileScope::Authoritative,
+            &mut target_is_current,
+        )
+    }
+
+    pub(crate) fn transition_immediate_delta<F>(
+        &mut self,
+        plan: &CompiledCompositePlan,
+        mode: LoopMode,
+        seek_iteration: Option<i64>,
+        mut target_is_current: F,
+    ) -> Result<CompositeTransitionBatch, CompositeRuntimeError>
+    where
+        F: FnMut(LoopIdentity) -> bool,
+    {
+        self.transition_immediate_inner(
+            plan,
+            mode,
+            seek_iteration,
+            ReconcileScope::Delta,
+            &mut target_is_current,
+        )
+    }
+
+    fn transition_immediate_inner<F>(
+        &mut self,
+        plan: &CompiledCompositePlan,
+        mode: LoopMode,
+        seek_iteration: Option<i64>,
+        scope: ReconcileScope,
+        target_is_current: &mut F,
+    ) -> Result<CompositeTransitionBatch, CompositeRuntimeError>
+    where
+        F: FnMut(LoopIdentity) -> bool,
+    {
         self.ensure_plan_mut(plan)?;
         if mode == LoopMode::Unknown {
             self.counters.rejected_modes = self.counters.rejected_modes.saturating_add(1);
             return Err(CompositeRuntimeError::UnknownMode);
         }
         if mode == LoopMode::Stopped {
-            return self.stop_inner(&mut target_is_current);
+            return self.stop_inner(target_is_current);
         }
         if plan.n_iterations() == 0 {
             self.mode = LoopMode::Stopped;
@@ -308,10 +349,10 @@ impl CompositeRuntime {
             plan,
             Some(self.iteration),
             mode,
-            ReconcileScope::Authoritative,
+            scope,
             true,
             false,
-            &mut target_is_current,
+            target_is_current,
         )
     }
 
@@ -490,6 +531,7 @@ impl CompositeRuntime {
                     &mut output,
                     old_index,
                     CompositeTargetAction::Stop,
+                    false,
                     &mut target_is_current,
                 )?;
                 self.active[old_index] = INACTIVE_TARGET;
@@ -721,6 +763,7 @@ impl CompositeRuntime {
                 &mut batch,
                 index,
                 CompositeTargetAction::Stop,
+                false,
                 target_is_current,
             )?;
             self.active[index] = INACTIVE_TARGET;
@@ -764,6 +807,7 @@ impl CompositeRuntime {
                     &mut batch,
                     index,
                     CompositeTargetAction::Stop,
+                    false,
                     target_is_current,
                 )?;
                 self.active[index] = INACTIVE_TARGET;
@@ -800,6 +844,7 @@ impl CompositeRuntime {
                         cycle_offset: desired.cycle_offset,
                         retrigger: force_seek || !current.active || retrigger_composite,
                     },
+                    scope == ReconcileScope::Authoritative,
                     target_is_current,
                 )?
             } else {
@@ -824,6 +869,7 @@ impl CompositeRuntime {
         batch: &mut CompositeTransitionBatch,
         target_index: usize,
         action: CompositeTargetAction,
+        authoritative: bool,
         target_is_current: &mut F,
     ) -> Result<bool, CompositeRuntimeError>
     where
@@ -835,7 +881,11 @@ impl CompositeRuntime {
             self.active[target_index] = INACTIVE_TARGET;
             return Ok(false);
         }
-        if let Err(error) = batch.push(CompositeTargetTransition { target, action }) {
+        if let Err(error) = batch.push(CompositeTargetTransition {
+            target,
+            action,
+            authoritative,
+        }) {
             self.counters.output_overflows = self.counters.output_overflows.saturating_add(1);
             self.fault = CompositeRuntimeFault::OutputCapacity;
             return Err(error);

--- a/src/rust/shoop_engine/src/composite_timeline.rs
+++ b/src/rust/shoop_engine/src/composite_timeline.rs
@@ -56,10 +56,22 @@ pub enum BoundaryTargetAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoundaryIntentOrigin {
-    Direct { acceptance_sequence: u64 },
-    ScriptComposite { source: LoopIdentity, ordinal: u32 },
-    RegularComposite { source: LoopIdentity, ordinal: u32 },
-    Natural { source: LoopIdentity },
+    Direct {
+        acceptance_sequence: u64,
+    },
+    ScriptComposite {
+        source: LoopIdentity,
+        ordinal: u32,
+        authoritative: bool,
+    },
+    RegularComposite {
+        source: LoopIdentity,
+        ordinal: u32,
+        authoritative: bool,
+    },
+    Natural {
+        source: LoopIdentity,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1062,8 +1074,12 @@ impl CompositeBoundaryTimeline {
             if let Some(intent) = incoming {
                 controlled = true;
                 self.delivered_composites[node_index] = true;
-                let batch =
-                    self.apply_to_composite(node_index, intent.action, &mut primitive_is_current)?;
+                let batch = self.apply_to_composite(
+                    node_index,
+                    intent.action,
+                    intent_is_authoritative(intent.origin),
+                    &mut primitive_is_current,
+                )?;
                 self.append_batch(node_index, &batch)?;
                 if matches!(
                     intent.action,
@@ -1254,6 +1270,7 @@ impl CompositeBoundaryTimeline {
         &mut self,
         node_index: usize,
         action: BoundaryTargetAction,
+        authoritative: bool,
         primitive_is_current: &mut F,
     ) -> Result<CompositeTransitionBatch, CompositeTimelineFaultRecord>
     where
@@ -1282,8 +1299,13 @@ impl CompositeBoundaryTimeline {
                 } else {
                     Some((offset_samples / sync_length) as i64)
                 };
-                self.working_runtimes[node_index]
-                    .transition_immediate(plan, mode, iteration, is_current)
+                if authoritative {
+                    self.working_runtimes[node_index]
+                        .transition_immediate(plan, mode, iteration, is_current)
+                } else {
+                    self.working_runtimes[node_index]
+                        .transition_immediate_delta(plan, mode, iteration, is_current)
+                }
             }
         };
         result.map_err(|_| self.runtime_fault())
@@ -1325,10 +1347,12 @@ impl CompositeBoundaryTimeline {
                 CompiledCompositeKind::Script => BoundaryIntentOrigin::ScriptComposite {
                     source,
                     ordinal: ordinal as u32,
+                    authoritative: transition.authoritative,
                 },
                 CompiledCompositeKind::Regular => BoundaryIntentOrigin::RegularComposite {
                     source,
                     ordinal: ordinal as u32,
+                    authoritative: transition.authoritative,
                 },
             };
             self.push_intent(BoundaryIntent {
@@ -1611,6 +1635,15 @@ fn intent_priority(origin: BoundaryIntentOrigin) -> u8 {
     }
 }
 
+fn intent_is_authoritative(origin: BoundaryIntentOrigin) -> bool {
+    match origin {
+        BoundaryIntentOrigin::Direct { .. } => true,
+        BoundaryIntentOrigin::ScriptComposite { authoritative, .. }
+        | BoundaryIntentOrigin::RegularComposite { authoritative, .. } => authoritative,
+        BoundaryIntentOrigin::Natural { .. } => false,
+    }
+}
+
 fn tie_break(candidate: BoundaryIntentOrigin, incumbent: BoundaryIntentOrigin) -> Ordering {
     match (candidate, incumbent) {
         (
@@ -1625,18 +1658,22 @@ fn tie_break(candidate: BoundaryIntentOrigin, incumbent: BoundaryIntentOrigin) -
             BoundaryIntentOrigin::ScriptComposite {
                 source: candidate_source,
                 ordinal: candidate_ordinal,
+                ..
             }
             | BoundaryIntentOrigin::RegularComposite {
                 source: candidate_source,
                 ordinal: candidate_ordinal,
+                ..
             },
             BoundaryIntentOrigin::ScriptComposite {
                 source: incumbent_source,
                 ordinal: incumbent_ordinal,
+                ..
             }
             | BoundaryIntentOrigin::RegularComposite {
                 source: incumbent_source,
                 ordinal: incumbent_ordinal,
+                ..
             },
         ) => incumbent_source
             .cmp(&candidate_source)

--- a/src/rust/shoop_engine/tests/composite_state_machine.rs
+++ b/src/rust/shoop_engine/tests/composite_state_machine.rs
@@ -456,6 +456,96 @@ fn an_empty_plan_start_is_a_successful_stopped_no_op() {
 }
 
 #[shoop_wasm_test_support::shoop_test]
+fn explicit_start_establishes_an_authoritative_target_snapshot() {
+    let source = composite(100);
+    let active = basic(1);
+    let delayed = basic(2);
+    let desc = descriptor(
+        source,
+        1,
+        vec![timeline(vec![section(vec![
+            entry(active, 0, Some(1), None),
+            entry(delayed, 1, Some(1), None),
+        ])])],
+    );
+    let plan = compile(&desc, &catalog(source, &[(active, 1), (delayed, 1)]));
+    let mut runtime = CompositeRuntime::new(&plan);
+
+    let batch = runtime
+        .transition_immediate(&plan, LoopMode::Playing, None, always_current)
+        .unwrap();
+
+    assert_eq!(batch.as_slice().len(), 2);
+    assert_eq!(batch.as_slice()[0].target, delayed);
+    assert_eq!(batch.as_slice()[0].action, CompositeTargetAction::Stop);
+    assert_eq!(batch.as_slice()[1].target, active);
+    assert_eq!(
+        batch.as_slice()[1].action,
+        set_mode(LoopMode::Playing, 0, true)
+    );
+}
+
+#[shoop_wasm_test_support::shoop_test]
+fn explicit_seek_reestablishes_the_complete_destination_snapshot() {
+    let source = composite(100);
+    let active = basic(1);
+    let delayed = basic(2);
+    let desc = descriptor(
+        source,
+        1,
+        vec![timeline(vec![section(vec![
+            entry(active, 0, Some(1), None),
+            entry(delayed, 1, Some(1), None),
+        ])])],
+    );
+    let plan = compile(&desc, &catalog(source, &[(active, 1), (delayed, 1)]));
+    let mut runtime = CompositeRuntime::new(&plan);
+    runtime
+        .transition_immediate(&plan, LoopMode::Playing, None, always_current)
+        .unwrap();
+
+    let batch = runtime.seek(&plan, 0, always_current).unwrap();
+
+    assert_eq!(batch.as_slice().len(), 2);
+    assert_eq!(batch.as_slice()[0].target, delayed);
+    assert_eq!(batch.as_slice()[0].action, CompositeTargetAction::Stop);
+    assert_eq!(batch.as_slice()[1].target, active);
+    assert_eq!(
+        batch.as_slice()[1].action,
+        set_mode(LoopMode::Playing, 0, true)
+    );
+}
+
+#[shoop_wasm_test_support::shoop_test]
+fn delayed_start_executes_the_authoritative_snapshot() {
+    let source = composite(100);
+    let active = basic(1);
+    let delayed = basic(2);
+    let desc = descriptor(
+        source,
+        1,
+        vec![timeline(vec![section(vec![
+            entry(active, 0, Some(1), None),
+            entry(delayed, 1, Some(1), None),
+        ])])],
+    );
+    let plan = compile(&desc, &catalog(source, &[(active, 1), (delayed, 1)]));
+    let mut runtime = CompositeRuntime::new(&plan);
+    runtime.request_transition(LoopMode::Playing, 0).unwrap();
+
+    let batch = runtime.sync_boundary(&plan, always_current).unwrap();
+
+    assert_eq!(batch.as_slice().len(), 2);
+    assert_eq!(batch.as_slice()[0].target, delayed);
+    assert_eq!(batch.as_slice()[0].action, CompositeTargetAction::Stop);
+    assert_eq!(batch.as_slice()[1].target, active);
+    assert_eq!(
+        batch.as_slice()[1].action,
+        set_mode(LoopMode::Playing, 0, true)
+    );
+}
+
+#[shoop_wasm_test_support::shoop_test]
 fn regular_runtime_inherits_modes_and_empty_playback_is_duration_only() {
     let source = composite(100);
     let full = basic(1);

--- a/src/rust/shoop_engine/tests/composite_state_machine.rs
+++ b/src/rust/shoop_engine/tests/composite_state_machine.rs
@@ -569,12 +569,21 @@ fn regular_runtime_inherits_modes_and_empty_playback_is_duration_only() {
         let batch = runtime
             .transition_immediate(&plan, mode, None, always_current)
             .unwrap();
-        let expected_count = if mode == LoopMode::Replacing { 2 } else { 1 };
-        assert_eq!(batch.as_slice().len(), expected_count);
-        assert!(batch
-            .as_slice()
-            .iter()
-            .all(|transition| matches!(transition.action, CompositeTargetAction::SetMode { mode: actual, .. } if actual == mode)));
+        assert_eq!(batch.as_slice().len(), 2);
+        if mode == LoopMode::Replacing {
+            assert_eq!(batch.as_slice()[0].target, full);
+            assert_eq!(
+                batch.as_slice()[0].action,
+                set_mode(LoopMode::Replacing, 0, true)
+            );
+            assert_eq!(batch.as_slice()[1].target, empty);
+            assert_eq!(batch.as_slice()[1].action, set_mode(mode, 0, true));
+        } else {
+            assert_eq!(batch.as_slice()[0].target, empty);
+            assert_eq!(batch.as_slice()[0].action, CompositeTargetAction::Stop);
+            assert_eq!(batch.as_slice()[1].target, full);
+            assert_eq!(batch.as_slice()[1].action, set_mode(mode, 0, true));
+        }
     }
 
     for mode in [LoopMode::Recording, LoopMode::RecordingDryIntoWet] {
@@ -604,10 +613,12 @@ fn script_empty_playback_is_reserved_but_empty_recording_is_applied() {
     let output = runtime
         .transition_immediate(&plan, LoopMode::Playing, None, always_current)
         .unwrap();
-    assert_eq!(output.as_slice().len(), 1);
-    assert_eq!(output.as_slice()[0].target, recording);
+    assert_eq!(output.as_slice().len(), 2);
+    assert_eq!(output.as_slice()[0].target, playing);
+    assert_eq!(output.as_slice()[0].action, CompositeTargetAction::Stop);
+    assert_eq!(output.as_slice()[1].target, recording);
     assert_eq!(
-        output.as_slice()[0].action,
+        output.as_slice()[1].action,
         set_mode(LoopMode::Recording, 0, true)
     );
 }

--- a/src/rust/shoop_engine/tests/composite_timeline.rs
+++ b/src/rust/shoop_engine/tests/composite_timeline.rs
@@ -245,6 +245,143 @@ fn nested_iteration_zero_propagates_through_several_levels_at_one_sample() {
 }
 
 #[shoop_wasm_test_support::shoop_test]
+fn authoritative_nested_start_stops_deep_targets_not_desired_at_iteration_zero() {
+    let active = basic(1);
+    let delayed = basic(2);
+    let sync = basic(3);
+    let nested = composite(10);
+    let root = composite(20);
+    let targets = catalog(&[active, delayed, sync, nested, root]);
+    let mut timeline = CompositeBoundaryTimeline::new(
+        vec![
+            CompositeTimelineNode {
+                plan: plan(
+                    nested,
+                    4,
+                    &[(active, 0, None), (delayed, 1, None)],
+                    &targets,
+                ),
+                sync_source: sync,
+            },
+            CompositeTimelineNode {
+                plan: plan(root, 4, &[(nested, 0, None)], &targets),
+                sync_source: sync,
+            },
+        ],
+        CompositeTimelineLimits::default(),
+    )
+    .unwrap();
+    timeline
+        .queue_control(start(0, 1, root, LoopMode::Playing))
+        .unwrap();
+
+    let trace = timeline.resolve_boundary(&[], &[], |_| true).unwrap();
+
+    assert!(trace.iter().any(|entry| {
+        entry.target == active
+            && matches!(
+                entry.action,
+                BoundaryTargetAction::SetMode {
+                    mode: LoopMode::Playing,
+                    ..
+                }
+            )
+    }));
+    assert!(trace
+        .iter()
+        .any(|entry| entry.target == delayed && entry.action == BoundaryTargetAction::Stop));
+    assert_eq!(timeline.runtime(root).unwrap().mode(), LoopMode::Playing);
+    assert_eq!(timeline.runtime(nested).unwrap().mode(), LoopMode::Playing);
+}
+
+#[shoop_wasm_test_support::shoop_test]
+fn direct_control_wins_over_an_authoritative_nested_stop() {
+    let active = basic(1);
+    let delayed = basic(2);
+    let sync = basic(3);
+    let nested = composite(10);
+    let root = composite(20);
+    let targets = catalog(&[active, delayed, sync, nested, root]);
+    let mut timeline = CompositeBoundaryTimeline::new(
+        vec![
+            CompositeTimelineNode {
+                plan: plan(
+                    nested,
+                    4,
+                    &[(active, 0, None), (delayed, 1, None)],
+                    &targets,
+                ),
+                sync_source: sync,
+            },
+            CompositeTimelineNode {
+                plan: plan(root, 4, &[(nested, 0, None)], &targets),
+                sync_source: sync,
+            },
+        ],
+        CompositeTimelineLimits::default(),
+    )
+    .unwrap();
+    timeline
+        .queue_control(start(0, 1, root, LoopMode::Playing))
+        .unwrap();
+    timeline
+        .queue_control(start(0, 2, delayed, LoopMode::Playing))
+        .unwrap();
+
+    let trace = timeline.resolve_boundary(&[], &[], |_| true).unwrap();
+    let resolved = trace.iter().find(|entry| entry.target == delayed).unwrap();
+
+    assert!(matches!(
+        resolved.action,
+        BoundaryTargetAction::SetMode {
+            mode: LoopMode::Playing,
+            ..
+        }
+    ));
+    assert_eq!(
+        resolved.winner,
+        BoundaryIntentOrigin::Direct {
+            acceptance_sequence: 2
+        }
+    );
+    assert_eq!(resolved.n_losing_conflicts, 1);
+}
+
+#[shoop_wasm_test_support::shoop_test]
+fn natural_advancement_does_not_repeat_authoritative_stops() {
+    let active = basic(1);
+    let delayed = basic(2);
+    let sync = basic(3);
+    let source = composite(10);
+    let targets = catalog(&[active, delayed, sync, source]);
+    let mut timeline = CompositeBoundaryTimeline::new(
+        vec![CompositeTimelineNode {
+            plan: plan(
+                source,
+                4,
+                &[(active, 0, None), (delayed, 2, None)],
+                &targets,
+            ),
+            sync_source: sync,
+        }],
+        CompositeTimelineLimits::default(),
+    )
+    .unwrap();
+    timeline
+        .queue_control(start(0, 1, source, LoopMode::Playing))
+        .unwrap();
+    timeline.resolve_boundary(&[], &[], |_| true).unwrap();
+    timeline.advance_clock(4);
+
+    let trace = timeline.resolve_boundary(&[sync], &[], |_| true).unwrap();
+
+    assert!(trace
+        .iter()
+        .any(|entry| entry.target == active && entry.action == BoundaryTargetAction::Stop));
+    assert!(!trace.iter().any(|entry| entry.target == delayed));
+}
+
+#[shoop_wasm_test_support::shoop_test]
 fn a_source_trigger_advances_the_schedule_at_the_exact_sample() {
     let child = basic(1);
     let source = basic(2);
@@ -261,11 +398,11 @@ fn a_source_trigger_advances_the_schedule_at_the_exact_sample() {
     timeline
         .queue_control(start(0, 1, composite, LoopMode::Playing))
         .unwrap();
-    assert!(!timeline
+    assert!(timeline
         .resolve_boundary(&[], &[], |identity| identity == child || identity == source)
         .unwrap()
         .iter()
-        .any(|entry| entry.target == child));
+        .any(|entry| { entry.target == child && entry.action == BoundaryTargetAction::Stop }));
 
     timeline.advance_clock(4);
     let trace = timeline

--- a/src/rust/shoop_engine/tests/composite_timeline.rs
+++ b/src/rust/shoop_engine/tests/composite_timeline.rs
@@ -382,6 +382,54 @@ fn natural_advancement_does_not_repeat_authoritative_stops() {
 }
 
 #[shoop_wasm_test_support::shoop_test]
+fn natural_parent_start_keeps_nested_reconciliation_incremental() {
+    let active = basic(1);
+    let delayed = basic(2);
+    let sync = basic(3);
+    let nested = composite(10);
+    let root = composite(20);
+    let targets = catalog(&[active, delayed, sync, nested, root]);
+    let mut timeline = CompositeBoundaryTimeline::new(
+        vec![
+            CompositeTimelineNode {
+                plan: plan(
+                    nested,
+                    4,
+                    &[(active, 0, None), (delayed, 1, None)],
+                    &targets,
+                ),
+                sync_source: sync,
+            },
+            CompositeTimelineNode {
+                plan: plan(root, 4, &[(nested, 1, None)], &targets),
+                sync_source: sync,
+            },
+        ],
+        CompositeTimelineLimits::default(),
+    )
+    .unwrap();
+    timeline
+        .queue_control(start(0, 1, root, LoopMode::Playing))
+        .unwrap();
+    timeline.resolve_boundary(&[], &[], |_| true).unwrap();
+    timeline.advance_clock(4);
+
+    let trace = timeline.resolve_boundary(&[sync], &[], |_| true).unwrap();
+
+    assert!(trace.iter().any(|entry| {
+        entry.target == active
+            && matches!(
+                entry.action,
+                BoundaryTargetAction::SetMode {
+                    mode: LoopMode::Playing,
+                    ..
+                }
+            )
+    }));
+    assert!(!trace.iter().any(|entry| entry.target == delayed));
+}
+
+#[shoop_wasm_test_support::shoop_test]
 fn a_source_trigger_advances_the_schedule_at_the_exact_sample() {
     let child = basic(1);
     let source = basic(2);

--- a/src/rust/shoop_engine/tests/composite_timing.rs
+++ b/src/rust/shoop_engine/tests/composite_timing.rs
@@ -522,7 +522,7 @@ fn timestamped_script_modes_commit_before_post_boundary_samples() {
             .iter()
             .filter(|entry| entry.at_sample == 3)
             .count(),
-        4
+        5
     );
 }
 #[cfg(all(target_arch = "wasm32", feature = "wasm-test-browser"))]


### PR DESCRIPTION
### Motivation

Explicit composite starts and seeks should establish a predictable complete state for every referenced target. Targets not scheduled at the selected iteration must stop even when they were started independently, while natural schedule advancement should remain incremental.

### Description

- add explicit authoritative and delta reconciliation policies to the composite runtime
- use authoritative snapshots for immediate starts, seeks, and delayed transitions when they execute
- preserve delta behavior for natural advancement, wraparound, completion, and plan activation
- verify nested same-sample propagation, existing conflict precedence, trace reporting, and realtime no-allocation behavior
- document the composite control contract and keep `COMPOSITES.md` updated through every implementation stage

### Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1,529 passed, 4 skipped)
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `PATH=/root/.local/share/mise/installs/node/22.22.2/bin:$PATH python3 scripts/run_wasm_tests.py --profile ci --runtime node --package shoop_engine --package-timeout 1200 --global-timeout 1800` (794 passed)
- `cargo check -p shoopdaloop --no-default-features --target wasm32-unknown-unknown`
- `cargo build -p shoop_audio_worklet --target wasm32-unknown-unknown --release`

Chrome and packaged-browser smoke tests were unavailable because this environment has no Chrome or Chromium executable.
