### PR TITLE
Add transparent build identity and About dialog

### DIFF
--- a/.github/scripts/publish_dev_web_release.sh
+++ b/.github/scripts/publish_dev_web_release.sh
@@ -18,18 +18,22 @@ if [[ ! $SOURCE_RUN_ID =~ ^[0-9]+$ || ! $ASSET_NAME =~ ^[A-Za-z0-9._-]+$ ]]; the
     echo "Invalid run ID or asset name" >&2
     exit 1
 fi
+if [[ -n ${LEGACY_ASSET_NAME:-} && ! $LEGACY_ASSET_NAME =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid legacy asset name" >&2
+    exit 1
+fi
 
 if [[ -d $input_path ]]; then
-    mapfile -d '' candidates < <(find "$input_path" -type f -name "$ASSET_NAME" -print0)
+    mapfile -d '' candidates < <(find "$input_path" -type f -name '*.html' -print0)
     if (( ${#candidates[@]} != 1 )); then
-        echo "Expected exactly one $ASSET_NAME in $input_path, found ${#candidates[@]}" >&2
+        echo "Expected exactly one HTML file in $input_path, found ${#candidates[@]}" >&2
         exit 1
     fi
     source_file=${candidates[0]}
-elif [[ -f $input_path && $(basename "$input_path") == "$ASSET_NAME" ]]; then
+elif [[ -f $input_path && $input_path == *.html ]]; then
     source_file=$input_path
 else
-    echo "Artifact input does not contain $ASSET_NAME: $input_path" >&2
+    echo "Artifact input is not an HTML file: $input_path" >&2
     exit 1
 fi
 
@@ -189,7 +193,7 @@ new_promoted=true
 published_at=$(date --utc +'%Y-%m-%dT%H:%M:%SZ')
 short_sha=${CANDIDATE_SHA:0:12}
 cat >"$notes_file" <<EOF
-Rolling standalone web build from the latest \`master\` commit that produced the release HTML artifact. This is not an official release. The \`$RELEASE_TAG\` tag is a stable release locator; the commit below identifies the attached build.
+Rolling standalone web development preview from the latest \`master\` commit that produced the optimized HTML artifact. This is not an official release. The \`$RELEASE_TAG\` tag is a stable preview locator; the commit below identifies the attached build.
 
 - Commit: [$short_sha](https://github.com/$GITHUB_REPOSITORY/commit/$CANDIDATE_SHA)
 - Workflow run: [$SOURCE_RUN_ID]($SOURCE_RUN_URL)
@@ -211,6 +215,12 @@ trap - ERR INT TERM
 backup_id=$(asset_id "$backup_name")
 if [[ -n $backup_id ]] && ! delete_asset "$backup_id"; then
     echo "Warning: could not remove backup asset $backup_name" >&2
+fi
+if [[ -n ${LEGACY_ASSET_NAME:-} ]]; then
+    legacy_id=$(asset_id "$LEGACY_ASSET_NAME")
+    if [[ -n $legacy_id ]] && ! delete_asset "$legacy_id"; then
+        echo "Warning: could not remove legacy asset $LEGACY_ASSET_NAME" >&2
+    fi
 fi
 rm -rf "$staging_dir"
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -173,6 +173,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set release build identity
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: echo "SHOOP_RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Install Rust stable
         if: env.ACT != 'true'
         uses: dtolnay/rust-toolchain@stable
@@ -519,15 +524,27 @@ jobs:
 
       - name: Record identified artifact paths
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          artifact=$(find artifacts -maxdepth 1 -type f ! -name '*.html' -print -quit)
-          test -n "$artifact"
-          echo "SHOOP_ARTIFACT=$PWD/$artifact" >> "$GITHUB_ENV"
-          if [ "${{ matrix.target }}" = "web" ]; then
-            html=$(find artifacts -maxdepth 1 -type f -name '*.html' -print -quit)
-            test -n "$html"
-            echo "SHOOP_HTML_ARTIFACT=$PWD/$html" >> "$GITHUB_ENV"
-          fi
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          artifacts = [path for path in Path("artifacts").iterdir() if path.is_file()]
+          archives = [path for path in artifacts if path.suffix != ".html"]
+          html = [path for path in artifacts if path.suffix == ".html"]
+          if len(archives) != 1:
+              raise RuntimeError(f"expected one packaged archive, found: {archives}")
+          if os.environ["TARGET"] == "web" and len(html) != 1:
+              raise RuntimeError(f"expected one packaged HTML file, found: {html}")
+          if os.environ["TARGET"] != "web" and html:
+              raise RuntimeError(f"unexpected packaged HTML files: {html}")
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as environment:
+              environment.write(f"SHOOP_ARTIFACT={archives[0].resolve()}\n")
+              if html:
+                  environment.write(f"SHOOP_HTML_ARTIFACT={html[0].resolve()}\n")
+          PY
 
       - name: Upload native application
         if: matrix.target != 'web' && env.ACT != 'true'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -517,33 +517,45 @@ jobs:
           --dist src/rust/shoopdaloop/dist
           --output-dir artifacts
 
+      - name: Record identified artifact paths
+        shell: bash
+        run: |
+          artifact=$(find artifacts -maxdepth 1 -type f ! -name '*.html' -print -quit)
+          test -n "$artifact"
+          echo "SHOOP_ARTIFACT=$PWD/$artifact" >> "$GITHUB_ENV"
+          if [ "${{ matrix.target }}" = "web" ]; then
+            html=$(find artifacts -maxdepth 1 -type f -name '*.html' -print -quit)
+            test -n "$html"
+            echo "SHOOP_HTML_ARTIFACT=$PWD/$html" >> "$GITHUB_ENV"
+          fi
+
       - name: Upload native application
         if: matrix.target != 'web' && env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          path: artifacts/${{ matrix.artifact }}
+          path: ${{ env.SHOOP_ARTIFACT }}
           archive: false
 
       - name: Upload hosted web bundle
         if: matrix.target == 'web' && env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          path: artifacts/${{ matrix.artifact }}
+          path: ${{ env.SHOOP_ARTIFACT }}
           archive: false
 
       - name: Upload core-only single-file web application
         if: matrix.target == 'web' && env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
-          path: artifacts/${{ matrix.html_artifact }}
+          path: ${{ env.SHOOP_HTML_ARTIFACT }}
           archive: false
 
       - name: Stage application artifacts for local act
         if: env.ACT == 'true'
         run: |
-          test -s "artifacts/${{ matrix.artifact }}"
+          test -s "$SHOOP_ARTIFACT"
           if [ "${{ matrix.target }}" = "web" ]; then
-            test -s "artifacts/${{ matrix.html_artifact }}"
+            test -s "$SHOOP_HTML_ARTIFACT"
           fi
           ls -lh artifacts
 
@@ -553,7 +565,7 @@ jobs:
         run: >-
           python3 src/rust/shoopdaloop/package_artifacts.py verify
           --platform ${{ matrix.target }}
-          --artifact artifacts/${{ matrix.artifact }}
+          --artifact "$SHOOP_ARTIFACT"
 
       - name: Probe extracted Linux application archive
         if: matrix.target == 'linux'
@@ -561,7 +573,7 @@ jobs:
         run: |
           destination="$RUNNER_TEMP/Shoop Δ ${{ matrix.profile }}"
           mkdir -p "$destination"
-          tar -xzf "artifacts/${{ matrix.artifact }}" -C "$destination"
+          tar -xzf "$SHOOP_ARTIFACT" -C "$destination"
           app="$destination/shoopdaloop/shoopdaloop"
           env -u SHOOP_CARLA_NATIVE_LIBRARY -u SHOOP_CARLA_RESOURCE_DIR \
             "$app" --probe-carla-native \
@@ -578,7 +590,7 @@ jobs:
         run: |
           destination="$RUNNER_TEMP/Shoop Δ ${{ matrix.profile }}"
           mkdir -p "$destination"
-          tar -xzf "artifacts/${{ matrix.artifact }}" -C "$destination"
+          tar -xzf "$SHOOP_ARTIFACT" -C "$destination"
           app="$destination/shoopdaloop/ShoopDaLoop.app/Contents/MacOS/shoopdaloop"
           env -u SHOOP_CARLA_NATIVE_LIBRARY -u SHOOP_CARLA_RESOURCE_DIR \
             "$app" --probe-carla-native \
@@ -593,7 +605,7 @@ jobs:
         shell: pwsh
         run: |
           $destination = Join-Path $env:RUNNER_TEMP "Shoop Δ ${{ matrix.profile }}"
-          Expand-Archive "artifacts/${{ matrix.artifact }}" -DestinationPath $destination
+          Expand-Archive $env:SHOOP_ARTIFACT -DestinationPath $destination
           $shortRoot = Join-Path $env:RUNNER_TEMP "shoop-carla-ui-${{ matrix.profile }}"
           cmd /c "mklink /J `"$shortRoot`" `"$destination`""
           if ($LASTEXITCODE -ne 0) { throw "Could not create ASCII Carla UI test junction" }
@@ -769,8 +781,8 @@ jobs:
         run: >-
           python3 src/rust/shoopdaloop/package_artifacts.py verify
           --platform web
-          --artifact artifacts/${{ matrix.artifact }}
-          --html artifacts/${{ matrix.html_artifact }}
+          --artifact "$SHOOP_ARTIFACT"
+          --html "$SHOOP_HTML_ARTIFACT"
 
       - name: Check WebAssembly packages
         if: matrix.target == 'web'
@@ -913,7 +925,7 @@ jobs:
         if: matrix.target == 'web' && matrix.profile == 'debug' && env.ACT != 'true'
         working-directory: src/rust/shoopdaloop
         env:
-          SELF_CONTAINED_PATH: ../../../artifacts/${{ matrix.html_artifact }}
+          SELF_CONTAINED_PATH: ${{ env.SHOOP_HTML_ARTIFACT }}
         run: SELF_CONTAINED=1 OUTPUT_ONLY=1 BROWSER_SIZE=900,600 node --experimental-websocket browser_smoke.mjs
 
       - name: Start virtual Firefox audio output

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -547,6 +547,7 @@ jobs:
         if: matrix.target == 'web' && env.ACT != 'true'
         uses: actions/upload-artifact@v7
         with:
+          name: ${{ matrix.html_artifact }}
           path: ${{ env.SHOOP_HTML_ARTIFACT }}
           archive: false
 

--- a/.github/workflows/publish_dev_web_release.yml
+++ b/.github/workflows/publish_dev_web_release.yml
@@ -27,23 +27,24 @@ jobs:
           ref: master
           persist-credentials: false
 
-      - name: Download release web application
+      - name: Download optimized web application
         uses: actions/download-artifact@v8
         with:
           name: shoopdaloop-web-wasm32-release.html
-          path: ${{ runner.temp }}/self-contained-web-release
+          path: ${{ runner.temp }}/self-contained-web-preview
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-decompress: true
 
       - name: Publish rolling development release
         env:
-          ASSET_NAME: shoopdaloop-web-wasm32-release.html
+          ASSET_NAME: shoopdaloop-web-wasm32-development-preview.html
           CANDIDATE_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEGACY_ASSET_NAME: shoopdaloop-web-wasm32-release.html
           RELEASE_TAG: dev-web
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
           SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: >-
           bash .github/scripts/publish_dev_web_release.sh
-          "${{ runner.temp }}/self-contained-web-release"
+          "${{ runner.temp }}/self-contained-web-preview"

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -599,6 +599,7 @@ enum BottomPane {
 pub struct AppWidgetResponse {
     pub app_actions: Vec<AppAction>,
     pub settings_actions: Vec<SettingsAction>,
+    pub about_requested: bool,
 }
 
 #[derive(Clone)]
@@ -808,6 +809,7 @@ impl AppWidget {
         .map(AppAction::KeyEvent)
         .collect::<Vec<_>>();
         let mut settings_actions = Vec::new();
+        let mut about_requested = false;
         let touch_mode = settings_state.active.get(TOUCH_MODE).unwrap_or(false);
         crate::loop_widget::set_touch_mode(ui.ctx(), touch_mode);
 
@@ -847,6 +849,7 @@ impl AppWidget {
                             if self.global_controls.take_settings_requested() {
                                 self.settings.open(settings_state);
                             }
+                            about_requested |= self.global_controls.take_about_requested();
                             ui.separator();
                             self.script_dialogs
                                 .show_control(ui, &state.scripting.dialogs);
@@ -1050,6 +1053,7 @@ impl AppWidget {
         AppWidgetResponse {
             app_actions: actions,
             settings_actions,
+            about_requested,
         }
     }
 

--- a/src/rust/shoop_egui/src/global_controls.rs
+++ b/src/rust/shoop_egui/src/global_controls.rs
@@ -18,6 +18,7 @@ pub struct GlobalControls {
     load_session_requested: bool,
     load_session_url_requested: bool,
     settings_requested: bool,
+    about_requested: bool,
     apply_n_cycles: OptimisticValue<u32>,
     apply_n_cycles_dragging: bool,
     #[cfg(test)]
@@ -33,6 +34,7 @@ enum TestGlobalControl {
     LoadSession,
     LoadSessionUrl,
     Settings,
+    About,
     StopAll,
     MidiPanic,
     DeselectAll,
@@ -56,6 +58,7 @@ struct TestGlobalControlRects {
     load_session: Option<egui::Rect>,
     load_session_url: Option<egui::Rect>,
     settings: Option<egui::Rect>,
+    about: Option<egui::Rect>,
     stop_all: Option<egui::Rect>,
     midi_panic: Option<egui::Rect>,
     deselect_all: Option<egui::Rect>,
@@ -81,6 +84,7 @@ impl GlobalControls {
         self.load_session_requested = false;
         self.load_session_url_requested = false;
         self.settings_requested = false;
+        self.about_requested = false;
         let mut actions = Vec::new();
         ui.horizontal(|ui| {
             let response = ui
@@ -120,6 +124,13 @@ impl GlobalControls {
                     self.record_rect(TestGlobalControl::Settings, &settings);
                     if settings.clicked() {
                         self.settings_requested = true;
+                        ui.close();
+                    }
+                    ui.separator();
+                    let about = ui.button("About ShoopDaLoop");
+                    self.record_rect(TestGlobalControl::About, &about);
+                    if about.clicked() {
+                        self.about_requested = true;
                         ui.close();
                     }
                 })
@@ -378,6 +389,10 @@ impl GlobalControls {
         std::mem::take(&mut self.settings_requested)
     }
 
+    pub fn take_about_requested(&mut self) -> bool {
+        std::mem::take(&mut self.about_requested)
+    }
+
     #[cfg(test)]
     fn record_rect(&mut self, control: TestGlobalControl, response: &egui::Response) {
         let target = match control {
@@ -388,6 +403,7 @@ impl GlobalControls {
             TestGlobalControl::LoadSession => &mut self.test_rects.load_session,
             TestGlobalControl::LoadSessionUrl => &mut self.test_rects.load_session_url,
             TestGlobalControl::Settings => &mut self.test_rects.settings,
+            TestGlobalControl::About => &mut self.test_rects.about,
             TestGlobalControl::StopAll => &mut self.test_rects.stop_all,
             TestGlobalControl::MidiPanic => &mut self.test_rects.midi_panic,
             TestGlobalControl::DeselectAll => &mut self.test_rects.deselect_all,
@@ -420,6 +436,7 @@ impl GlobalControls {
             TestGlobalControl::LoadSession => self.test_rects.load_session,
             TestGlobalControl::LoadSessionUrl => self.test_rects.load_session_url,
             TestGlobalControl::Settings => self.test_rects.settings,
+            TestGlobalControl::About => self.test_rects.about,
             TestGlobalControl::StopAll => self.test_rects.stop_all,
             TestGlobalControl::MidiPanic => self.test_rects.midi_panic,
             TestGlobalControl::DeselectAll => self.test_rects.deselect_all,
@@ -667,6 +684,9 @@ mod tests {
         assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
         assert!(click(&context, &mut controls, &state, TestGlobalControl::Settings).is_empty());
         assert!(controls.take_settings_requested());
+        assert!(click(&context, &mut controls, &state, TestGlobalControl::MainMenu).is_empty());
+        assert!(click(&context, &mut controls, &state, TestGlobalControl::About).is_empty());
+        assert!(controls.take_about_requested());
         assert_eq!(
             click(&context, &mut controls, &state, TestGlobalControl::StopAll),
             vec![GlobalControlAction::StopAll]

--- a/src/rust/shoopdaloop/README.md
+++ b/src/rust/shoopdaloop/README.md
@@ -211,7 +211,8 @@ Domain, Worker, settings, Web MIDI, lifecycle, and stress behavior belongs in th
 cd src/rust/shoopdaloop
 OUTPUT_ONLY=1 node --experimental-websocket browser_smoke.mjs
 SELF_CONTAINED=1 OUTPUT_ONLY=1 \
-  SELF_CONTAINED_PATH=../../../artifacts/shoopdaloop-web-wasm32-debug.html \
+  SELF_CONTAINED_PATH=$(find ../../../artifacts -maxdepth 1 -type f \
+    -name 'shoopdaloop-web-wasm32-debug-*.html' -print -quit) \
   node --experimental-websocket browser_smoke.mjs
 xvfb-run -a python3 browser_firefox_smoke.py
 ```

--- a/src/rust/shoopdaloop/browser_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_smoke.mjs
@@ -70,12 +70,15 @@ async function waitForHttp(url, timeoutMilliseconds) {
   throw new Error(`timed out waiting for ${url}`);
 }
 
-async function waitForJson(url, timeoutMilliseconds) {
+async function waitForJson(url, timeoutMilliseconds, accept = () => true) {
   const deadline = Date.now() + timeoutMilliseconds;
   while (Date.now() < deadline) {
     try {
       const response = await fetch(url);
-      if (response.ok) return response.json();
+      if (response.ok) {
+        const value = await response.json();
+        if (accept(value)) return value;
+      }
     } catch (_) {
       // The process is still starting.
     }
@@ -137,7 +140,11 @@ try {
   if (settingsUnavailable) chromeArgs.splice(-1, 0, '--disable-local-storage');
   start(chrome, chromeArgs);
 
-  const targets = await waitForJson(`http://${host}:${debugPort}/json`, 60_000);
+  const targets = await waitForJson(
+    `http://${host}:${debugPort}/json`,
+    60_000,
+    candidates => candidates.some(candidate => candidate.type === 'page'),
+  );
   const target = targets.find(candidate => candidate.type === 'page');
   if (!target) throw new Error('Chrome exposed no page target');
 

--- a/src/rust/shoopdaloop/browser_tracing_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_tracing_smoke.mjs
@@ -30,11 +30,14 @@ async function waitForHttp(url, attempts = 300) {
   throw new Error(`timed out waiting for ${url}`);
 }
 
-async function waitForJson(url, attempts = 300) {
+async function waitForJson(url, attempts = 300, accept = () => true) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
       const response = await fetch(url);
-      if (response.ok) return response.json();
+      if (response.ok) {
+        const value = await response.json();
+        if (accept(value)) return value;
+      }
     } catch {}
     await new Promise(resolve => setTimeout(resolve, 100));
   }
@@ -60,7 +63,11 @@ try {
     `--user-data-dir=${path.join(downloads, 'profile')}`,
     `http://127.0.0.1:${webPort}/?${realm === 'worker' ? 'worker=1&' : ''}tracing=1&tracing-smoke-test=1`,
   ], {env: {...process.env, HOME: process.env.HOME}});
-  const targets = await waitForJson(`http://127.0.0.1:${debugPort}/json/list`);
+  const targets = await waitForJson(
+    `http://127.0.0.1:${debugPort}/json/list`,
+    300,
+    candidates => candidates.some(candidate => candidate.type === 'page'),
+  );
   const page = targets.find(target => target.type === 'page');
   if (!page) throw new Error('Chrome exposed no page target');
   socket = new WebSocket(page.webSocketDebuggerUrl);

--- a/src/rust/shoopdaloop/build.rs
+++ b/src/rust/shoopdaloop/build.rs
@@ -1,7 +1,65 @@
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const SOURCE_TREE_MARKER: &str = "SHOOP_SRC_TREE";
+
+fn command_output(program: &str, arguments: &[&str], directory: &Path) -> Option<String> {
+    let output = Command::new(program)
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn emit_build_identity() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let release_version = std::env::var("SHOOP_RELEASE_VERSION")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let revision = command_output("git", &["rev-parse", "--short=8", "HEAD"], &root)
+        .unwrap_or_else(|| "unknown".to_owned());
+    let branch = std::env::var("GITHUB_HEAD_REF")
+        .or_else(|_| std::env::var("GITHUB_REF_NAME"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| command_output("git", &["branch", "--show-current"], &root))
+        .unwrap_or_else(|| "unknown".to_owned());
+    let build_date = std::env::var("SHOOP_BUILD_DATE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| command_output("date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"], &root))
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| format!("Unix timestamp {}", duration.as_secs()))
+                .unwrap_or_else(|_| "unknown".to_owned())
+        });
+    let kind = if release_version.is_some() {
+        "release"
+    } else {
+        "development"
+    };
+    let version = release_version.unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+
+    println!("cargo:rustc-env=SHOOP_BUILD_KIND={kind}");
+    println!("cargo:rustc-env=SHOOP_BUILD_VERSION={version}");
+    println!("cargo:rustc-env=SHOOP_BUILD_REVISION={revision}");
+    println!("cargo:rustc-env=SHOOP_BUILD_BRANCH={branch}");
+    println!("cargo:rustc-env=SHOOP_BUILD_DATE={build_date}");
+    println!("cargo:rerun-if-env-changed=SHOOP_RELEASE_VERSION");
+    println!("cargo:rerun-if-env-changed=SHOOP_BUILD_DATE");
+    println!(
+        "cargo:rerun-if-changed={}",
+        root.join(".git/HEAD").display()
+    );
+}
 
 fn profile_output_directory(out_directory: &Path) -> Option<&Path> {
     let build_directory = out_directory.parent()?.parent()?;
@@ -75,6 +133,7 @@ fn write_source_tree_marker() -> Result<(), String> {
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    emit_build_identity();
     if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
         return;
     }

--- a/src/rust/shoopdaloop/build.rs
+++ b/src/rust/shoopdaloop/build.rs
@@ -18,6 +18,29 @@ fn command_output(program: &str, arguments: &[&str], directory: &Path) -> Option
         .filter(|value| !value.is_empty())
 }
 
+fn git_path(root: &Path, path: &str) -> Option<PathBuf> {
+    command_output(
+        "git",
+        &["rev-parse", "--path-format=absolute", "--git-path", path],
+        root,
+    )
+    .map(PathBuf::from)
+}
+
+fn emit_git_rerun_paths(root: &Path) {
+    if let Some(head) = git_path(root, "HEAD") {
+        println!("cargo:rerun-if-changed={}", head.display());
+    }
+    if let Some(reference) = command_output("git", &["symbolic-ref", "HEAD"], root)
+        .and_then(|reference| git_path(root, &reference))
+    {
+        println!("cargo:rerun-if-changed={}", reference.display());
+    }
+    if let Some(packed_refs) = git_path(root, "packed-refs") {
+        println!("cargo:rerun-if-changed={}", packed_refs.display());
+    }
+}
+
 fn emit_build_identity() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
     let release_version = std::env::var("SHOOP_RELEASE_VERSION")
@@ -55,10 +78,7 @@ fn emit_build_identity() {
     println!("cargo:rustc-env=SHOOP_BUILD_DATE={build_date}");
     println!("cargo:rerun-if-env-changed=SHOOP_RELEASE_VERSION");
     println!("cargo:rerun-if-env-changed=SHOOP_BUILD_DATE");
-    println!(
-        "cargo:rerun-if-changed={}",
-        root.join(".git/HEAD").display()
-    );
+    emit_git_rerun_paths(&root);
 }
 
 fn profile_output_directory(out_directory: &Path) -> Option<&Path> {

--- a/src/rust/shoopdaloop/package_artifacts.py
+++ b/src/rust/shoopdaloop/package_artifacts.py
@@ -533,6 +533,8 @@ def verify_web(bundle: Path, html: Path) -> None:
 
 
 def verify(args: argparse.Namespace) -> list[Path]:
+    if args.artifact == Path(".") and os.environ.get("SHOOP_ARTIFACT"):
+        args.artifact = Path(os.environ["SHOOP_ARTIFACT"])
     if args.platform == "web":
         if args.html is None:
             raise RuntimeError("--html is required when verifying a web artifact")

--- a/src/rust/shoopdaloop/package_artifacts.py
+++ b/src/rust/shoopdaloop/package_artifacts.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import os
 import plistlib
 import json
 import re
@@ -50,8 +51,25 @@ WEB_REQUIRED_FILES = (
 )
 
 
+def build_identity() -> str:
+    release = os.environ.get("SHOOP_RELEASE_VERSION", "").strip()
+    if release:
+        return release
+    try:
+        revision = subprocess.run(
+            ["git", "rev-parse", "--short=8", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        revision = "unknown"
+    return f"dev-{revision or 'unknown'}"
+
+
 def artifact_stem(platform: str, arch: str, profile: str) -> str:
-    return f"shoopdaloop-{platform}-{arch}-{profile}"
+    return f"shoopdaloop-{platform}-{arch}-{profile}-{build_identity()}"
 
 
 def copy_metadata(destination: Path) -> None:

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -361,6 +361,7 @@ enum StartupSessionAction {
 struct UnifiedApp {
     runtime: Runtime,
     widget: AppWidget,
+    about_open: bool,
     settings: SettingsManager,
     #[cfg(not(target_arch = "wasm32"))]
     pending_audio_settings: Option<PendingAudioSettings>,
@@ -462,6 +463,7 @@ impl UnifiedApp {
         Ok(Self {
             runtime,
             widget,
+            about_open: false,
             settings,
             #[cfg(not(target_arch = "wasm32"))]
             pending_audio_settings: None,
@@ -1140,12 +1142,14 @@ impl UnifiedApp {
         let response = self
             .widget
             .show(ui, &snapshot, &settings_state, script_paths);
+        self.about_open |= response.about_requested;
         for intent in response.app_actions {
             self.handle_ui_intent(intent);
         }
         for action in response.settings_actions {
             self.handle_settings_action(action);
         }
+        self.show_about_dialog(ui.ctx());
         self.show_file_drop_overlay(ui.ctx());
         self.show_session_url_dialogs(ui.ctx());
         #[cfg(not(target_arch = "wasm32"))]
@@ -1164,6 +1168,27 @@ impl UnifiedApp {
             }
         }
         ui.ctx().request_repaint_after(UPDATE_INTERVAL);
+    }
+
+    fn show_about_dialog(&mut self, context: &egui::Context) {
+        if !self.about_open {
+            return;
+        }
+        egui::Window::new("About ShoopDaLoop")
+            .open(&mut self.about_open)
+            .resizable(false)
+            .show(context, |ui| {
+                ui.heading("ShoopDaLoop by Sander Vocke");
+                ui.separator();
+                ui.label(format!("Build: {}", env!("SHOOP_BUILD_KIND")));
+                if env!("SHOOP_BUILD_KIND") == "release" {
+                    ui.label(format!("Version: {}", env!("SHOOP_BUILD_VERSION")));
+                } else {
+                    ui.label(format!("Branch: {}", env!("SHOOP_BUILD_BRANCH")));
+                    ui.label(format!("Commit: {}", env!("SHOOP_BUILD_REVISION")));
+                }
+                ui.label(format!("Built: {}", env!("SHOOP_BUILD_DATE")));
+            });
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -358,6 +358,46 @@ enum StartupSessionAction {
     FetchUrl(String),
 }
 
+#[derive(Clone, Copy)]
+struct BuildIdentity {
+    kind: &'static str,
+    version: &'static str,
+    branch: &'static str,
+    revision: &'static str,
+    date: &'static str,
+}
+
+impl BuildIdentity {
+    const CURRENT: Self = Self {
+        kind: env!("SHOOP_BUILD_KIND"),
+        version: env!("SHOOP_BUILD_VERSION"),
+        branch: env!("SHOOP_BUILD_BRANCH"),
+        revision: env!("SHOOP_BUILD_REVISION"),
+        date: env!("SHOOP_BUILD_DATE"),
+    };
+}
+
+fn show_about_dialog(context: &egui::Context, open: &mut bool, identity: BuildIdentity) {
+    if !*open {
+        return;
+    }
+    egui::Window::new("About ShoopDaLoop")
+        .open(open)
+        .resizable(false)
+        .show(context, |ui| {
+            ui.heading("ShoopDaLoop by Sander Vocke");
+            ui.separator();
+            ui.label(format!("Build: {}", identity.kind));
+            if identity.kind == "release" {
+                ui.label(format!("Version: {}", identity.version));
+            } else {
+                ui.label(format!("Branch: {}", identity.branch));
+                ui.label(format!("Commit: {}", identity.revision));
+            }
+            ui.label(format!("Built: {}", identity.date));
+        });
+}
+
 struct UnifiedApp {
     runtime: Runtime,
     widget: AppWidget,
@@ -1149,7 +1189,7 @@ impl UnifiedApp {
         for action in response.settings_actions {
             self.handle_settings_action(action);
         }
-        self.show_about_dialog(ui.ctx());
+        show_about_dialog(ui.ctx(), &mut self.about_open, BuildIdentity::CURRENT);
         self.show_file_drop_overlay(ui.ctx());
         self.show_session_url_dialogs(ui.ctx());
         #[cfg(not(target_arch = "wasm32"))]
@@ -1168,27 +1208,6 @@ impl UnifiedApp {
             }
         }
         ui.ctx().request_repaint_after(UPDATE_INTERVAL);
-    }
-
-    fn show_about_dialog(&mut self, context: &egui::Context) {
-        if !self.about_open {
-            return;
-        }
-        egui::Window::new("About ShoopDaLoop")
-            .open(&mut self.about_open)
-            .resizable(false)
-            .show(context, |ui| {
-                ui.heading("ShoopDaLoop by Sander Vocke");
-                ui.separator();
-                ui.label(format!("Build: {}", env!("SHOOP_BUILD_KIND")));
-                if env!("SHOOP_BUILD_KIND") == "release" {
-                    ui.label(format!("Version: {}", env!("SHOOP_BUILD_VERSION")));
-                } else {
-                    ui.label(format!("Branch: {}", env!("SHOOP_BUILD_BRANCH")));
-                    ui.label(format!("Commit: {}", env!("SHOOP_BUILD_REVISION")));
-                }
-                ui.label(format!("Built: {}", env!("SHOOP_BUILD_DATE")));
-            });
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -5376,6 +5395,41 @@ mod tests {
     };
 
     use super::*;
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn about_dialog_renders_release_and_development_identities() {
+        let context = egui::Context::default();
+        for identity in [
+            BuildIdentity {
+                kind: "release",
+                version: "1.2.3",
+                branch: "unused",
+                revision: "unused",
+                date: "2026-08-31T12:00:00Z",
+            },
+            BuildIdentity {
+                kind: "development",
+                version: "unused",
+                branch: "topic/build-identity",
+                revision: "12345678",
+                date: "2026-08-31T12:00:00Z",
+            },
+        ] {
+            let mut open = true;
+            let mut output = context.run_ui(Default::default(), |ui| {
+                show_about_dialog(ui.ctx(), &mut open, identity);
+            });
+            output.textures_delta.clear();
+            assert!(open);
+        }
+
+        let mut open = false;
+        let mut output = context.run_ui(Default::default(), |ui| {
+            show_about_dialog(ui.ctx(), &mut open, BuildIdentity::CURRENT);
+        });
+        output.textures_delta.clear();
+        assert!(!open);
+    }
 
     #[cfg(all(target_arch = "wasm32", feature = "wasm-test-browser"))]
     #[shoop_wasm_test_support::shoop_test(


### PR DESCRIPTION
### Motivation

- Make each build self-identifying so users and CI can tell release vs development builds without extra state.
- Expose the same identity in packaged artifact filenames and in the running app UI so builds are easy to trace at a glance.
- Ensure builds remain robust when Git metadata is unavailable by providing safe fallbacks (e.g. `unknown`).

### Description

- Emit build identity at build-time from `build.rs` by exporting `SHOOP_BUILD_KIND`, `SHOOP_BUILD_VERSION`, `SHOOP_BUILD_REVISION`, `SHOOP_BUILD_BRANCH`, and `SHOOP_BUILD_DATE` environment variables with fallbacks when Git/date info is missing (file: `src/rust/shoopdaloop/build.rs`).
- Suffix packaged artifact filenames with either the explicit `SHOOP_RELEASE_VERSION` (release) or `dev-<short-revision>` (development) by changing `artifact_stem` (file: `src/rust/shoopdaloop/package_artifacts.py`).
- Add an "About ShoopDaLoop" main-menu entry and thread it through the UI path, and implement an About window that shows author, build kind/version or branch/revision, and build date (files: `src/rust/shoop_egui/src/global_controls.rs` and `src/rust/shoopdaloop/src/main.rs`).
- Teach CI to discover and record the actual artifact paths produced by packaging and use those environment-backed paths for upload/verification and downstream steps (file: `.github/workflows/build_and_test.yml`).

### Testing

- Ran `cargo fmt --all -- --check` which succeeded.
- Ran the focused unit test `cargo test -p shoop_egui buttons_generate_typed_global_actions_and_main_menu_has_no_business_intent` which passed.
- Verified Python packaging helpers with `python3 -m py_compile src/rust/shoopdaloop/package_artifacts.py` and ran small assertions using `PYTHONPATH=src/rust/shoopdaloop` to confirm release and development artifact naming, which succeeded.
- Attempted a workspace build with `RUSTFLAGS='-D warnings' cargo build --workspace`, but the build was blocked by a missing system ALSA development package (`pkg-config`/`alsa.pc`) during compilation of `alsa-sys`; this is an environment dependency rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a956212cb34832894c6b7281869b965)