### PR TITLE
Repeat immediate primitive playback independently

### DIFF
--- a/UNSYNC.md
+++ b/UNSYNC.md
@@ -106,16 +106,18 @@ Completed evidence: `cargo nextest run -p shoop_engine -p shoop_app` passed all 
 
 Depends on Stages 1 and 2.
 
-- [ ] Clarify the Lua compatibility documentation: `Loop_DontWaitForSync` on a primitive playing transition also selects independent repeating until superseded by a later playing transition or explicit repeat-sync setting.
-- [ ] Review the implementation for all playing modes, same-mode playing transitions, aligned immediate transitions, inactive sync sources, and zero-length handling.
-- [ ] Confirm no backend trait, worklet protocol, or session-format changes were introduced.
-- [ ] Run formatting and the targeted tests again.
-- [ ] Commit documentation and any review-driven cleanup as a meaningful milestone.
+- [x] Clarify the Lua compatibility documentation: `Loop_DontWaitForSync` on a primitive playing transition also selects independent repeating until superseded by a later playing transition or explicit repeat-sync setting.
+- [x] Review the implementation for all playing modes, same-mode playing transitions, aligned immediate transitions, inactive sync sources, and zero-length handling.
+- [x] Confirm no backend trait, worklet protocol, or session-format changes were introduced.
+- [x] Run formatting and the targeted tests again.
+- [x] Commit documentation and any review-driven cleanup as a meaningful milestone.
 
 ### Stage 3 verification
 
 - Documentation matches tested precedence and lifetime semantics.
 - The diff remains limited to primitive engine mechanics, application bookkeeping/tests, and relevant documentation.
+
+Completed evidence: focused tests cover every playing mode plus same-mode and aligned immediate transitions; existing zero-length and inactive/no-source behavior remains passing. The refined application test applies both explicit repeat-policy overrides while playback is active. No backend trait, protocol, or session-format file changed. Formatting, focused tests, the test-usage checker, and the warning-denying workspace build passed before the milestone commit.
 
 ## Final end-to-end validation
 

--- a/UNSYNC.md
+++ b/UNSYNC.md
@@ -132,7 +132,16 @@ Run all commands in the environment selected by `.agents/info/build.md`; on Nix/
 - [x] Confirm `git status` contains only intended source, test, documentation, and plan updates.
 - [x] Commit the final validated state if validation required any follow-up changes.
 
-Completed evidence: formatting and the warning-denying workspace build passed; the test-usage and closed tracing-inventory checks passed; the complete CI-profile workspace suite passed 1,623 tests with four permitted host-facility skips. The acceptance-criteria audit found direct focused or integration coverage for every behavioral requirement, and the final diff contains only the plan, primitive engine/session/application implementation and tests, and Lua contract documentation.
+Completed evidence: formatting and the warning-denying workspace build passed; the test-usage and closed tracing-inventory checks passed; the complete CI-profile workspace suite passed 1,623 tests with four permitted host-facility skips. The acceptance-criteria audit found direct focused or integration coverage for every behavioral requirement, and the final diff contains only the plan, primitive engine/session/backend/application/worklet implementation and tests, and Lua contract documentation.
+
+## Review follow-up
+
+- [x] Route unaligned immediate backend and worklet commands through the same latch-aware planned-transition path.
+- [x] Preserve immediate latency latching when that path applies synchronously.
+- [x] Add a worklet command-path regression proving a four-frame primitive wraps before its ten-frame sync source.
+- [x] Re-run native, WebAssembly, formatting, warning, and policy validation before pushing the review update.
+
+Review evidence: the complete CI-profile workspace suite passed 1,624 tests with four permitted host-facility skips, and the focused Node WebAssembly worklet regression passed.
 
 ## Execution contract
 

--- a/UNSYNC.md
+++ b/UNSYNC.md
@@ -76,22 +76,22 @@ Completed evidence: `cargo test -p shoop_engine basic_loop::tests` passed 20 foc
 
 Depends on Stage 1.
 
-- [ ] Update `Session::set_loop_sync_source()` so an explicit source configuration applies the corresponding repeat policy exactly once at configuration time.
-- [ ] Ensure per-processing-cycle sync-source snapshot refreshes only refresh source state and cannot reset an immediate transition's independent-repeat latch.
-- [ ] In primitive handling for `ControlOperation::Transition`, update `LoopModel.repeat_sync` after an accepted playing transition according to whether `cycles_delay` is present.
-- [ ] Leave `LoopModel.repeat_sync` unchanged for stop, plain recording, and composite transitions.
-- [ ] Preserve `ControlOperation::SetRepeatSync` as the explicit override path and verify that application metadata and engine behavior agree after both `true` and `false` operations.
-- [ ] Add an application integration test using the real in-process engine backend:
+- [x] Update `Session::set_loop_sync_source()` so an explicit source configuration applies the corresponding repeat policy exactly once at configuration time.
+- [x] Ensure per-processing-cycle sync-source snapshot refreshes only refresh source state and cannot reset an immediate transition's independent-repeat latch.
+- [x] In primitive handling for `ControlOperation::Transition`, update `LoopModel.repeat_sync` after an accepted playing transition according to whether `cycles_delay` is present.
+- [x] Leave `LoopModel.repeat_sync` unchanged for stop, plain recording, and composite transitions.
+- [x] Preserve `ControlOperation::SetRepeatSync` as the explicit override path and verify that application metadata and engine behavior agree after both `true` and `false` operations.
+- [x] Add an application integration test using the real in-process engine backend:
   - configure a playing sync loop longer than the primitive;
   - keep the primitive configured with that sync source;
   - apply a primitive scripting transition with `cycles_delay: None`;
   - advance exactly one primitive length;
   - assert the primitive is still playing at position zero before the sync loop wraps.
-- [ ] Extend the integration coverage to verify a subsequent synchronized start and explicit repeat-sync overrides.
-- [ ] Add a negative assertion or focused test showing a composite transition does not receive primitive repeat-policy bookkeeping.
-- [ ] Run targeted `shoop_engine` and `shoop_app` tests.
-- [ ] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
-- [ ] Commit session/application integration and regression coverage as one meaningful milestone.
+- [x] Extend the integration coverage to verify a subsequent synchronized start and explicit repeat-sync overrides.
+- [x] Add a negative assertion or focused test showing a composite transition does not receive primitive repeat-policy bookkeeping.
+- [x] Run targeted `shoop_engine` and `shoop_app` tests.
+- [x] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
+- [x] Commit session/application integration and regression coverage as one meaningful milestone.
 
 ### Stage 2 verification
 
@@ -99,6 +99,8 @@ Depends on Stage 1.
 - Repeat-policy metadata agrees with observed primitive behavior.
 - Explicit setters override the transition-derived policy when applied later.
 - Composite tests retain their previous behavior.
+
+Completed evidence: `cargo nextest run -p shoop_engine -p shoop_app` passed all 1,015 package tests, including the real-backend timing and composite-negative regressions. Formatting, the test-usage checker, and a workspace warning-denying build passed before the milestone commit.
 
 ## Stage 3: Contract documentation and focused review
 

--- a/UNSYNC.md
+++ b/UNSYNC.md
@@ -1,0 +1,137 @@
+# Unsynchronized Primitive Loop Repeat Plan
+
+## Goal
+
+Make a primitive loop that enters a playback mode through a `Loop_DontWaitForSync` transition repeat at its own loop boundary instead of waiting for its configured sync source after the first iteration.
+
+## Scope
+
+### In scope
+
+- Primitive loop playback in all modes for which `LoopMode::is_playing_mode()` is true:
+  - `Playing`
+  - `Replacing`
+  - `PlayingDryThroughWet`
+  - `RecordingDryIntoWet`
+- Native and browser/worklet behavior shared through the Rust engine.
+- Explicit `loop_set_repeat_sync()` overrides.
+- Application-side repeat-policy bookkeeping for primitive scripting transitions.
+- Focused engine and application regression coverage.
+
+### Out of scope
+
+- Composite-loop repeat semantics.
+- Changes to backend traits, browser/worklet protocols, session formats, or public Lua function signatures.
+- Changing the timing semantics of stopped or plain `Recording` transitions.
+
+## Immutable acceptance criteria
+
+1. With an active sync source whose cycle is longer than a primitive loop, starting that primitive in a playing mode with `cycles_delay == None` makes it wrap at its own boundary before the sync source wraps.
+2. The primitive remains in its requested playing mode across that independent wrap.
+3. A playing transition with a normal cycle delay retains synchronized-repeat behavior: at its own end, the primitive waits for the active sync source.
+4. A later synchronized playing transition can restore synchronized repeating after an immediate playing transition.
+5. `loop_set_repeat_sync(true)` restores synchronized repeating, and `loop_set_repeat_sync(false)` restores independent repeating; the latest applied playing-transition policy or explicit setter wins.
+6. Stop, `Recording`, and other non-playing transitions do not silently alter the latched repeat policy.
+7. Composite-loop behavior remains unchanged.
+8. Existing Rust tests, warning-denying builds, formatting checks, and project test-usage checks pass.
+
+## Design rules and constraints
+
+- Represent the behavior as primitive-loop state in `BasicLoop`; do not implement it by automatically detaching the primitive from its sync source in the application layer.
+- Keep the sync-source relationship available for normal trigger propagation and later explicit synchronization changes.
+- Use a default-false latch such as `repeat_unsynced`, preserving current synchronized behavior whenever a sync source exists and no immediate playing transition has selected independent repeating.
+- Change the latch only when a playing transition is applied or an explicit repeat-sync policy is configured. Non-playing transitions must leave it unchanged.
+- An applied playing transition with `n_cycles_delay == None` selects independent repeating. An applied playing transition with a cycle delay selects synchronized repeating.
+- Update the policy when a queued transition executes, not prematurely when it is merely queued.
+- Sync-source snapshot refreshes during processing must not overwrite the latch. Only explicit sync/repeat configuration may do so.
+- Preserve the existing behavior that a loop with no active playing sync source wraps independently regardless of the latch.
+- Keep `LoopModel.repeat_sync` consistent with accepted primitive scripting transitions without applying the new policy to backend composites.
+- Avoid protocol or persistence changes unless implementation evidence proves one is unavoidable; if that occurs, stop and revise the plan before broadening scope.
+
+## Stage 1: Engine repeat-policy latch
+
+- [x] Add focused failing tests in `src/rust/shoop_engine/src/basic_loop.rs` that establish:
+  - an immediate playing transition wraps at the primitive's own end while its sync source is still playing and has not triggered;
+  - a synchronized playing transition still waits at the primitive's end;
+  - a later synchronized playing transition restores waiting after an immediate playing transition;
+  - non-playing transitions do not change the selected repeat policy.
+- [x] Add the default-false independent-repeat latch to `BasicLoop`.
+- [x] Centralize application of planned transitions so entering any `is_playing_mode()` updates the latch from that transition's wait policy before changing mode.
+- [x] Set independent repeating for immediately applied transitions whose cycle delay is `None`.
+- [x] Set synchronized repeating when a queued playing transition actually executes.
+- [x] Update loop-end handling to self-trigger when independent repeating is latched, while retaining the existing no-source/inactive-source behavior.
+- [x] Add a narrow engine setter for explicit repeat-sync policy changes; do not expose the latch in snapshots unless tests demonstrate a consumer requirement.
+- [x] Run the targeted engine tests in the development environment selected by `.agents/info/build.md`.
+- [x] Commit the completed engine behavior and unit tests as one meaningful milestone.
+
+### Stage 1 verification
+
+- The immediate-start regression test fails before the implementation and passes afterward.
+- The synchronized control case proves the change does not make every primitive repeat independently.
+- Existing `BasicLoop` tests pass.
+
+Completed evidence: `cargo test -p shoop_engine basic_loop::tests` passed 20 focused tests; `cargo fmt --all -- --check`, the project test-usage checker, and a workspace warning-denying build also passed before the milestone commit.
+
+## Stage 2: Explicit policy and application integration
+
+Depends on Stage 1.
+
+- [ ] Update `Session::set_loop_sync_source()` so an explicit source configuration applies the corresponding repeat policy exactly once at configuration time.
+- [ ] Ensure per-processing-cycle sync-source snapshot refreshes only refresh source state and cannot reset an immediate transition's independent-repeat latch.
+- [ ] In primitive handling for `ControlOperation::Transition`, update `LoopModel.repeat_sync` after an accepted playing transition according to whether `cycles_delay` is present.
+- [ ] Leave `LoopModel.repeat_sync` unchanged for stop, plain recording, and composite transitions.
+- [ ] Preserve `ControlOperation::SetRepeatSync` as the explicit override path and verify that application metadata and engine behavior agree after both `true` and `false` operations.
+- [ ] Add an application integration test using the real in-process engine backend:
+  - configure a playing sync loop longer than the primitive;
+  - keep the primitive configured with that sync source;
+  - apply a primitive scripting transition with `cycles_delay: None`;
+  - advance exactly one primitive length;
+  - assert the primitive is still playing at position zero before the sync loop wraps.
+- [ ] Extend the integration coverage to verify a subsequent synchronized start and explicit repeat-sync overrides.
+- [ ] Add a negative assertion or focused test showing a composite transition does not receive primitive repeat-policy bookkeeping.
+- [ ] Run targeted `shoop_engine` and `shoop_app` tests.
+- [ ] Run `python3 scripts/check_shoop_test_usage.py` because Rust tests changed.
+- [ ] Commit session/application integration and regression coverage as one meaningful milestone.
+
+### Stage 2 verification
+
+- The end-to-end application test reproduces the reported timing relationship rather than only inspecting internal flags.
+- Repeat-policy metadata agrees with observed primitive behavior.
+- Explicit setters override the transition-derived policy when applied later.
+- Composite tests retain their previous behavior.
+
+## Stage 3: Contract documentation and focused review
+
+Depends on Stages 1 and 2.
+
+- [ ] Clarify the Lua compatibility documentation: `Loop_DontWaitForSync` on a primitive playing transition also selects independent repeating until superseded by a later playing transition or explicit repeat-sync setting.
+- [ ] Review the implementation for all playing modes, same-mode playing transitions, aligned immediate transitions, inactive sync sources, and zero-length handling.
+- [ ] Confirm no backend trait, worklet protocol, or session-format changes were introduced.
+- [ ] Run formatting and the targeted tests again.
+- [ ] Commit documentation and any review-driven cleanup as a meaningful milestone.
+
+### Stage 3 verification
+
+- Documentation matches tested precedence and lifetime semantics.
+- The diff remains limited to primitive engine mechanics, application bookkeeping/tests, and relevant documentation.
+
+## Final end-to-end validation
+
+Run all commands in the environment selected by `.agents/info/build.md`; on Nix/NixOS, enter the repository development shell first.
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `RUSTFLAGS="-D warnings" cargo build --workspace`
+- [ ] `python3 scripts/check_shoop_test_usage.py`
+- [ ] `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`
+- [ ] `python3 scripts/check_tracing_coverage.py --require-closed`
+- [ ] Review the final diff and test output against every immutable acceptance criterion.
+- [ ] Confirm `git status` contains only intended source, test, documentation, and plan updates.
+- [ ] Commit the final validated state if validation required any follow-up changes.
+
+## Execution contract
+
+- Keep this plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.

--- a/UNSYNC.md
+++ b/UNSYNC.md
@@ -123,14 +123,16 @@ Completed evidence: focused tests cover every playing mode plus same-mode and al
 
 Run all commands in the environment selected by `.agents/info/build.md`; on Nix/NixOS, enter the repository development shell first.
 
-- [ ] `cargo fmt --all -- --check`
-- [ ] `RUSTFLAGS="-D warnings" cargo build --workspace`
-- [ ] `python3 scripts/check_shoop_test_usage.py`
-- [ ] `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`
-- [ ] `python3 scripts/check_tracing_coverage.py --require-closed`
-- [ ] Review the final diff and test output against every immutable acceptance criterion.
-- [ ] Confirm `git status` contains only intended source, test, documentation, and plan updates.
-- [ ] Commit the final validated state if validation required any follow-up changes.
+- [x] `cargo fmt --all -- --check`
+- [x] `RUSTFLAGS="-D warnings" cargo build --workspace`
+- [x] `python3 scripts/check_shoop_test_usage.py`
+- [x] `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`
+- [x] `python3 scripts/check_tracing_coverage.py --require-closed`
+- [x] Review the final diff and test output against every immutable acceptance criterion.
+- [x] Confirm `git status` contains only intended source, test, documentation, and plan updates.
+- [x] Commit the final validated state if validation required any follow-up changes.
+
+Completed evidence: formatting and the warning-denying workspace build passed; the test-usage and closed tracing-inventory checks passed; the complete CI-profile workspace suite passed 1,623 tests with four permitted host-facility skips. The acceptance-criteria audit found direct focused or integration coverage for every behavioral requirement, and the final diff contains only the plan, primitive engine/session/application implementation and tests, and Lua contract documentation.
 
 ## Execution contract
 

--- a/docs/lua_compatibility_contract.md
+++ b/docs/lua_compatibility_contract.md
@@ -28,7 +28,7 @@ The auto-mute-other-track-inputs policy defaults off, and changing the policy do
 | Loop query | `loop_get_next_mode_delay(selector)` | Sequence of queued cycle delays or `nil` entries. |
 | Loop query | `loop_get_length(selector)` | Sequence of lengths in frames. |
 | Loop query | `loop_get_by_track(track)` | Coordinates in the selected track. |
-| Loop transition | `loop_transition(selector, mode, cycles_delay, align_to_sync_at)` | Explicit transition. `Loop_DontWaitForSync` and `Loop_DontAlignToSyncImmediately` disable the corresponding behavior. |
+| Loop transition | `loop_transition(selector, mode, cycles_delay, align_to_sync_at)` | Explicit transition. `Loop_DontWaitForSync` makes a primitive playing transition immediate and its playback repeat independently; a later primitive playing transition or `loop_set_repeat_sync` call supersedes that repeat policy. `Loop_DontAlignToSyncImmediately` disables immediate alignment. |
 | Loop transition | `loop_trigger(selector, mode)` | Applies the same sync, solo, fixed-cycle, target, and play-after-record policy as the GUI trigger. |
 | Loop transition | `loop_trigger_grab(selector)` | Applies the same ringbuffer-grab policy as the GUI grab action. |
 | Loop query | `loop_get_gain(selector)` | Sequence of linear output gains. |

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -13117,8 +13117,8 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         assert_eq!(snapshot.loops[&sync_backend].position, 0);
         assert_eq!(snapshot.loops[&loop_backend].mode, BackendLoopMode::Playing);
         assert_eq!(snapshot.loops[&loop_backend].position, 0);
-        backend.advance(Duration::from_millis(4));
-        assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 4);
+        backend.advance(Duration::from_millis(2));
+        assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 2);
 
         model
             .apply_script_operation(
@@ -13129,29 +13129,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 },
             )
             .unwrap();
-        model
-            .apply_script_operation(
-                &mut backend,
-                ControlOperation::Transition {
-                    loops: vec![loop_id],
-                    mode: LoopMode::Stopped,
-                    cycles_delay: None,
-                    align_to_sync_at: None,
-                },
-            )
-            .unwrap();
-        model
-            .apply_script_operation(
-                &mut backend,
-                ControlOperation::Transition {
-                    loops: vec![loop_id],
-                    mode: LoopMode::Playing,
-                    cycles_delay: None,
-                    align_to_sync_at: None,
-                },
-            )
-            .unwrap();
-        backend.advance(Duration::from_millis(4));
+        backend.advance(Duration::from_millis(2));
         assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 0);
         assert!(!model.loops[&loop_id].repeat_sync);
 

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -2244,6 +2244,14 @@ impl ApplicationModel {
                 cycles_delay,
                 align_to_sync_at,
             } => {
+                let repeat_sync = matches!(
+                    mode,
+                    LoopMode::Playing
+                        | LoopMode::Replacing
+                        | LoopMode::PlayingDryThroughWet
+                        | LoopMode::RecordingDryIntoWet
+                )
+                .then_some(cycles_delay.is_some());
                 for id in loops {
                     let model = self
                         .loops
@@ -2267,6 +2275,9 @@ impl ApplicationModel {
                                 align_to_sync_at,
                             )
                             .map_err(|error| format!("could not transition loop {id}: {error}"))?;
+                        if let Some(repeat_sync) = repeat_sync {
+                            self.loops.get_mut(&id).unwrap().repeat_sync = repeat_sync;
+                        }
                     }
                 }
                 Ok(())
@@ -13028,6 +13039,154 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
 
         assert_eq!(state.mode, BackendLoopMode::Playing);
         assert_eq!(state.position, 0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn immediate_script_play_repeats_unsynced_and_later_policies_override_it() {
+        let mut backend = EngineBackend::new_dummy(1_000, 1).unwrap();
+        let mut model = ApplicationModel::initialize(
+            &mut backend,
+            Arc::new(Mutex::new(VecDeque::new())),
+            Arc::new(Mutex::new(VecDeque::new())),
+            false,
+        )
+        .unwrap();
+        model
+            .add_track(
+                &mut backend,
+                DirectTrackSpec {
+                    name: "Track".to_owned(),
+                    audio_channels: 1,
+                    midi: false,
+                },
+            )
+            .unwrap();
+        let sync = model.tracks[0].loops[0];
+        let loop_id = model.tracks[1].loops[0];
+        let sync_backend = model.loops[&sync].backend_id;
+        let loop_backend = model.loops[&loop_id].backend_id;
+        backend.set_loop_length(sync_backend, 10).unwrap();
+        backend.set_loop_length(loop_backend, 4).unwrap();
+        backend
+            .transition_loop(sync_backend, BackendLoopMode::Playing, None)
+            .unwrap();
+
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![loop_id],
+                    mode: LoopMode::Playing,
+                    cycles_delay: None,
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+        assert!(!model.loops[&loop_id].repeat_sync);
+        backend.advance(Duration::from_millis(4));
+        let snapshot = backend.poll().unwrap();
+        assert_eq!(snapshot.loops[&sync_backend].position, 4);
+        assert_eq!(snapshot.loops[&loop_backend].mode, BackendLoopMode::Playing);
+        assert_eq!(snapshot.loops[&loop_backend].position, 0);
+
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![loop_id],
+                    mode: LoopMode::Stopped,
+                    cycles_delay: None,
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![loop_id],
+                    mode: LoopMode::Playing,
+                    cycles_delay: Some(0),
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+        assert!(model.loops[&loop_id].repeat_sync);
+        backend.advance(Duration::from_millis(6));
+        let snapshot = backend.poll().unwrap();
+        assert_eq!(snapshot.loops[&sync_backend].position, 0);
+        assert_eq!(snapshot.loops[&loop_backend].mode, BackendLoopMode::Playing);
+        assert_eq!(snapshot.loops[&loop_backend].position, 0);
+        backend.advance(Duration::from_millis(4));
+        assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 4);
+
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::SetRepeatSync {
+                    loops: vec![loop_id],
+                    active: false,
+                },
+            )
+            .unwrap();
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![loop_id],
+                    mode: LoopMode::Stopped,
+                    cycles_delay: None,
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![loop_id],
+                    mode: LoopMode::Playing,
+                    cycles_delay: None,
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+        backend.advance(Duration::from_millis(4));
+        assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 0);
+        assert!(!model.loops[&loop_id].repeat_sync);
+
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::SetRepeatSync {
+                    loops: vec![loop_id],
+                    active: true,
+                },
+            )
+            .unwrap();
+        backend.advance(Duration::from_millis(4));
+        assert_eq!(backend.poll().unwrap().loops[&loop_backend].position, 4);
+        assert!(model.loops[&loop_id].repeat_sync);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn immediate_composite_transition_does_not_change_primitive_repeat_policy() {
+        let (mut backend, mut model, _, target, _) = engine_model_with_regular_composite();
+        let repeat_sync = model.loops[&target].repeat_sync;
+
+        model
+            .apply_script_operation(
+                &mut backend,
+                ControlOperation::Transition {
+                    loops: vec![target],
+                    mode: LoopMode::Playing,
+                    cycles_delay: None,
+                    align_to_sync_at: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(model.loops[&target].repeat_sync, repeat_sync);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -1544,6 +1544,76 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn immediate_worklet_play_repeats_before_its_sync_source() {
+        let mut host = WorkletHost::new(1_000, 8).unwrap();
+        assert!(matches!(
+            command(
+                &mut host,
+                1,
+                Command::CreateTrack {
+                    expected_track_id: 1,
+                    expected_loop_ids: vec![1, 2],
+                    port_name_base: "unsynced".to_owned(),
+                    topology: WireTrackTopology::Direct {
+                        audio_channels: 0,
+                        midi: false,
+                    },
+                },
+            )
+            .event,
+            Event::Ack
+        ));
+        for (sequence, loop_id, length) in [(2, 1, 10), (3, 2, 4)] {
+            assert!(matches!(
+                command(
+                    &mut host,
+                    sequence,
+                    Command::SetLoopLength { loop_id, length },
+                )
+                .event,
+                Event::Ack
+            ));
+        }
+        assert!(matches!(
+            command(
+                &mut host,
+                4,
+                Command::SetLoopSyncSource {
+                    loop_id: 2,
+                    source: Some(1),
+                },
+            )
+            .event,
+            Event::Ack
+        ));
+        for (sequence, loop_id) in [(5, 1), (6, 2)] {
+            assert!(matches!(
+                command(
+                    &mut host,
+                    sequence,
+                    Command::TransitionLoop {
+                        loop_id,
+                        mode: WireLoopMode::Playing,
+                        cycles_delay: None,
+                    },
+                )
+                .event,
+                Event::Ack
+            ));
+        }
+
+        assert!(host.process(0, 0, 4));
+        let Event::Snapshot(snapshot) = command(&mut host, 7, Command::Poll).event else {
+            panic!("poll did not return a snapshot");
+        };
+        let sync = snapshot.loops.iter().find(|loop_| loop_.id == 1).unwrap();
+        let follower = snapshot.loops.iter().find(|loop_| loop_.id == 2).unwrap();
+        assert_eq!(sync.position, 4);
+        assert_eq!(follower.mode, WireLoopMode::Playing);
+        assert_eq!(follower.position, 0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn worklet_applies_zero_and_nonzero_loop_smoothing_values() {
         let mut host = WorkletHost::new(48_000, 128).unwrap();
         assert!(matches!(

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -4827,15 +4827,10 @@ impl Backend for EngineBackend {
         ) {
             self.prepare_recording_storage(loop_id, mode == BackendLoopMode::Replacing)?;
         }
-        if let Some(delay) = cycles_delay {
-            self.session
-                .loop_mut(engine_loop)
-                .ok_or_else(|| anyhow!("missing engine loop"))?
-                .plan_transition(to_engine_mode(mode), Some(delay), None);
-        } else {
-            self.session
-                .set_loop_mode(engine_loop, to_engine_mode(mode))?;
-        }
+        self.session
+            .loop_mut(engine_loop)
+            .ok_or_else(|| anyhow!("missing engine loop"))?
+            .plan_transition(to_engine_mode(mode), cycles_delay, None);
         Ok(())
     }
 

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -4227,16 +4227,12 @@ impl Loop {
             let Some(idx) = control.ready_id().map(ObjectIdentity::index) else {
                 return;
             };
-            if !immediate {
-                if let Some(l) = s.loop_mut(idx) {
-                    l.plan_transition(
-                        to_mode.into(),
-                        (maybe_cycles_delay >= 0).then_some(maybe_cycles_delay as u32),
-                        (maybe_to_sync_at_cycle >= 0).then_some(maybe_to_sync_at_cycle as u32),
-                    );
-                }
-            } else {
-                let _ = s.set_loop_mode(idx, to_mode.into());
+            if let Some(l) = s.loop_mut(idx) {
+                l.plan_transition(
+                    to_mode.into(),
+                    (maybe_cycles_delay >= 0).then_some(maybe_cycles_delay as u32),
+                    (maybe_to_sync_at_cycle >= 0).then_some(maybe_to_sync_at_cycle as u32),
+                );
             }
         })?;
         if immediate {

--- a/src/rust/shoop_engine/src/audio_midi_loop.rs
+++ b/src/rust/shoop_engine/src/audio_midi_loop.rs
@@ -330,6 +330,9 @@ impl AudioMidiLoop {
         self.loop_.set_sync_source(src);
         self.resync_poi();
     }
+    pub fn set_repeat_sync(&mut self, active: bool) {
+        self.loop_.set_repeat_sync(active);
+    }
     pub fn set_mode(&mut self, mode: LoopMode) {
         if mode != self.active_latency_mode {
             self.latch_latency_for_mode(mode);

--- a/src/rust/shoop_engine/src/audio_midi_loop.rs
+++ b/src/rust/shoop_engine/src/audio_midi_loop.rs
@@ -354,6 +354,13 @@ impl AudioMidiLoop {
         n_cycles_delay: Option<u32>,
         to_sync_cycle: Option<u32>,
     ) {
+        let immediately = (self.loop_.sync_source().is_none()
+            && self.loop_.mode() != LoopMode::Playing)
+            || n_cycles_delay.is_none()
+            || to_sync_cycle.is_some();
+        if immediately && mode != self.active_latency_mode {
+            self.latch_latency_for_mode(mode);
+        }
         self.loop_
             .plan_transition(mode, n_cycles_delay, to_sync_cycle);
         self.resync_poi();

--- a/src/rust/shoop_engine/src/basic_loop.rs
+++ b/src/rust/shoop_engine/src/basic_loop.rs
@@ -952,6 +952,23 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn immediate_aligned_transition_repeats_at_own_boundary() {
+        let mut l = BasicLoop::default();
+        let mut sync = playing_sync_source(false).unwrap();
+        sync.position = 2;
+        l.set_sync_source(Some(sync));
+        l.set_length(4);
+
+        l.plan_transition(LoopMode::Playing, None, Some(0));
+        check!(l.position() == 2);
+        l.process(2);
+
+        check!(l.mode() == LoopMode::Playing);
+        check!(l.position() == 0);
+        check!(l.cycle_count == 1);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn synchronized_playing_transition_waits_at_own_boundary() {
         let mut l = BasicLoop::default();
         l.set_sync_source(playing_sync_source(false));

--- a/src/rust/shoop_engine/src/basic_loop.rs
+++ b/src/rust/shoop_engine/src/basic_loop.rs
@@ -912,10 +912,36 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
-    fn immediate_playing_transition_repeats_at_own_boundary() {
+    fn immediate_playing_transitions_repeat_at_own_boundary() {
+        for mode in [
+            LoopMode::Playing,
+            LoopMode::Replacing,
+            LoopMode::PlayingDryThroughWet,
+            LoopMode::RecordingDryIntoWet,
+        ] {
+            let mut l = BasicLoop::default();
+            l.set_sync_source(playing_sync_source(false));
+            l.set_length(4);
+
+            l.plan_transition(mode, None, None);
+            l.process(4);
+
+            check!(l.mode() == mode);
+            check!(l.position() == 0);
+            check!(l.cycle_count == 1);
+        }
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn immediate_same_mode_transition_changes_repeat_policy() {
         let mut l = BasicLoop::default();
         l.set_sync_source(playing_sync_source(false));
         l.set_length(4);
+        l.plan_transition(LoopMode::Playing, Some(0), None);
+        l.set_sync_source(playing_sync_source(true));
+        l.handle_sync();
+        l.process(0);
+        l.set_sync_source(playing_sync_source(false));
 
         l.plan_transition(LoopMode::Playing, None, None);
         l.process(4);

--- a/src/rust/shoop_engine/src/basic_loop.rs
+++ b/src/rust/shoop_engine/src/basic_loop.rs
@@ -81,6 +81,7 @@ pub struct BasicLoop {
     mode: LoopMode,
     triggering_now: bool,
     already_triggered: bool,
+    repeat_unsynced: bool,
     length: u32,
     position: u32,
     cycle_count: u64,
@@ -238,8 +239,9 @@ impl BasicLoop {
             if let Some(poi) = self.next_poi.as_mut() {
                 poi.flags = poi.flags.without(PoiFlags::LOOP_END);
             }
-            // Trigger ourselves only when no active sync source will do it.
-            if self.sync_source.is_none_or(|s| !s.mode.is_playing_mode()) {
+            // Trigger ourselves only when repeating independently or no active
+            // sync source will do it.
+            if self.repeat_unsynced || self.sync_source.is_none_or(|s| !s.mode.is_playing_mode()) {
                 self.trigger(true);
             }
             changed = true;
@@ -289,7 +291,7 @@ impl BasicLoop {
         }
         while self.planned_countdowns.front().is_some_and(|c| *c < 0) {
             let mode = self.planned_modes[0];
-            self.handle_transition(mode);
+            self.apply_planned_transition(mode, false);
             self.planned_countdowns.pop_front();
             self.planned_modes.pop_front();
         }
@@ -300,6 +302,13 @@ impl BasicLoop {
         if self.sync_source.is_some_and(|s| s.triggering_now) {
             self.trigger(true);
         }
+    }
+
+    fn apply_planned_transition(&mut self, new_mode: LoopMode, repeat_unsynced: bool) {
+        if new_mode.is_playing_mode() {
+            self.repeat_unsynced = repeat_unsynced;
+        }
+        self.handle_transition(new_mode);
     }
 
     pub fn handle_transition(&mut self, new_mode: LoopMode) {
@@ -460,7 +469,7 @@ impl BasicLoop {
             || to_sync_cycle.is_some();
 
         if immediately {
-            self.handle_transition(mode);
+            self.apply_planned_transition(mode, n_cycles_delay.is_none());
             if let (Some(cycle), Some(sync)) = (to_sync_cycle, self.sync_source) {
                 let pos = sync.position + cycle * sync.length;
                 if mode == LoopMode::Recording {
@@ -531,6 +540,10 @@ impl BasicLoop {
 
     pub fn set_mode(&mut self, mode: LoopMode) {
         self.handle_transition(mode);
+    }
+
+    pub fn set_repeat_sync(&mut self, active: bool) {
+        self.repeat_unsynced = !active;
     }
 }
 
@@ -886,5 +899,87 @@ mod tests {
         l.plan_transition(LoopMode::Stopped, Some(5), None);
         check!(l.mode() == LoopMode::Stopped);
         check!(l.n_planned_transitions() == 0);
+    }
+
+    fn playing_sync_source(triggering_now: bool) -> Option<SyncSourceState> {
+        Some(SyncSourceState {
+            mode: LoopMode::Playing,
+            triggering_now,
+            next_trigger_eta: Some(10),
+            position: 0,
+            length: 10,
+        })
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn immediate_playing_transition_repeats_at_own_boundary() {
+        let mut l = BasicLoop::default();
+        l.set_sync_source(playing_sync_source(false));
+        l.set_length(4);
+
+        l.plan_transition(LoopMode::Playing, None, None);
+        l.process(4);
+
+        check!(l.mode() == LoopMode::Playing);
+        check!(l.position() == 0);
+        check!(l.cycle_count == 1);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn synchronized_playing_transition_waits_at_own_boundary() {
+        let mut l = BasicLoop::default();
+        l.set_sync_source(playing_sync_source(false));
+        l.set_length(4);
+        l.plan_transition(LoopMode::Playing, Some(0), None);
+        l.set_sync_source(playing_sync_source(true));
+        l.handle_sync();
+        l.set_sync_source(playing_sync_source(false));
+
+        l.process(4);
+
+        check!(l.mode() == LoopMode::Playing);
+        check!(l.position() == 4);
+        check!(l.cycle_count == 0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn synchronized_start_restores_repeat_sync_after_immediate_start() {
+        let mut l = BasicLoop::default();
+        l.set_sync_source(playing_sync_source(false));
+        l.set_length(4);
+        l.plan_transition(LoopMode::Playing, None, None);
+        l.process(4);
+        check!(l.position() == 0);
+
+        l.plan_transition(LoopMode::Stopped, None, None);
+        l.plan_transition(LoopMode::Playing, Some(0), None);
+        l.process(0);
+        l.set_sync_source(playing_sync_source(true));
+        l.handle_sync();
+        l.set_sync_source(playing_sync_source(false));
+        l.process(4);
+
+        check!(l.mode() == LoopMode::Playing);
+        check!(l.position() == 4);
+        check!(l.cycle_count == 1);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn non_playing_transitions_preserve_repeat_policy() {
+        let mut l = BasicLoop::default();
+        l.set_sync_source(playing_sync_source(false));
+        l.set_length(4);
+        l.plan_transition(LoopMode::Playing, None, None);
+        check!(l.repeat_unsynced);
+
+        l.plan_transition(LoopMode::Stopped, None, None);
+        check!(l.repeat_unsynced);
+        l.plan_transition(LoopMode::Recording, None, None);
+        check!(l.repeat_unsynced);
+
+        l.set_repeat_sync(true);
+        check!(!l.repeat_unsynced);
+        l.set_repeat_sync(false);
+        check!(l.repeat_unsynced);
     }
 }

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1515,6 +1515,7 @@ impl Session {
         }
         // A loop with no sync source transitions immediately rather than waiting
         // for a trigger, so this changes behaviour and not just wiring.
+        self.loops[loop_idx].set_repeat_sync(source.is_some());
         self.loops[loop_idx].set_sync_source(source.map(|_| SyncSourceState::default()));
         Ok(())
     }


### PR DESCRIPTION
## Summary

- latch independent repeat behavior when a primitive enters a playing mode without waiting for sync
- restore synchronized repeating through later synchronized starts or explicit repeat-sync controls
- keep application repeat-policy bookkeeping aligned while leaving composite behavior unchanged
- document the Lua transition semantics and retain the completed implementation plan in `UNSYNC.md`

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `python3 scripts/check_shoop_test_usage.py`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` — 1,623 passed, 4 permitted host-facility skips
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `cargo check -p shoopdaloop --no-default-features --target wasm32-unknown-unknown`
- `cargo build -p shoop_audio_worklet --target wasm32-unknown-unknown --release`
- `python3 scripts/run_wasm_tests.py --runtime node --profile dev --package shoop_engine` — 836 passed
