### PR TITLE
Hide browser runtime status overlay

### DIFF
--- a/src/rust/shoopdaloop/index.html
+++ b/src/rust/shoopdaloop/index.html
@@ -61,14 +61,6 @@
         touch-action: none;
       }
 
-      #runtime_status {
-        position: fixed;
-        right: 8px;
-        bottom: 6px;
-        color: #aaa;
-        font-size: 11px;
-      }
-
       #browser_permissions_dialog {
         position: fixed;
         inset: 0;
@@ -207,7 +199,7 @@
         </div>
       </div>
     </div>
-    <span id="runtime_status" data-driver-state="starting">Starting browser application…</span>
+    <span id="runtime_status" data-driver-state="starting" hidden></span>
     <noscript>This application requires JavaScript and WebAssembly. Browser audio availability depends on browser origin policy.</noscript>
   </body>
 </html>

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -5687,6 +5687,7 @@ mod tests {
         assert!(html.contains("data-trunk"));
         assert!(html.contains(&format!("id=\"{WEB_CANVAS_ID}\"")));
         assert!(html.contains("id=\"browser_permissions_dialog\""));
+        assert!(html.contains("id=\"runtime_status\" data-driver-state=\"starting\" hidden"));
         assert!(html.contains("Browser audio and MIDI permissions"));
         assert!(html.contains("Enable microphone audio"));
         assert!(html.contains("Enable output-only audio"));


### PR DESCRIPTION
## Summary
- hide the browser runtime diagnostics element so it no longer overlays the application bottom bar
- keep its data attributes available for browser smoke tests and assert that it remains hidden

## Testing
- `cargo fmt --all -- --check`
- `python3 scripts/check_shoop_test_usage.py`
- `cargo test -p shoopdaloop web_shell_targets_the_application_canvas`
- `git diff --check`

## Notes
- `RUSTFLAGS="-D warnings" cargo build --workspace` was started after installing missing ALSA/JACK development libraries but did not complete within the execution window.