### PR TITLE
Center sidebar logo vertically

### DIFF
--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -2141,7 +2141,7 @@ impl AppWidget {
     }
 
     fn show_logo(&mut self, ui: &mut egui::Ui, state: &AppState) {
-        ui.add_space(6.0);
+        ui.add_space(12.0);
         if let Some(logo) = &self.logo {
             let size = logo.size_vec2();
             let width = (ui.available_width() - 12.0).max(1.0).min(128.0);


### PR DESCRIPTION
### Motivation
- Nudge the sidebar logo slightly downward so it sits visually centered between the sync track and the bottom status bar.

### Description
- Increase the top spacer in `fn show_logo` from `6.0` to `12.0` in `src/rust/shoop_egui/src/app_widget.rs` to move the logo lower inside its reserved area.

### Testing
- Ran `cargo test -p shoop_egui` (all tests passed), `cargo test -p shoop_egui complete_application_state_produces_paint_commands` (passed), `cargo fmt --all -- --check` (passed), and `RUSTFLAGS="-D warnings" cargo build --workspace` (build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a968beaa3088328a7e3b1119d81ff72)