### PR TITLE
Hide browser runtime status overlay

### DIFF
--- a/src/rust/shoopdaloop/index.html
+++ b/src/rust/shoopdaloop/index.html
@@ -61,14 +61,6 @@
         touch-action: none;
       }
 
-      #runtime_status {
-        position: fixed;
-        right: 8px;
-        bottom: 6px;
-        color: #aaa;
-        font-size: 11px;
-      }
-
       #browser_permissions_dialog {
         position: fixed;
         inset: 0;
@@ -207,7 +199,7 @@
         </div>
       </div>
     </div>
-    <span id="runtime_status" data-driver-state="starting">Starting browser application…</span>
+    <span id="runtime_status" data-driver-state="starting" hidden></span>
     <noscript>This application requires JavaScript and WebAssembly. Browser audio availability depends on browser origin policy.</noscript>
   </body>
 </html>

--- a/src/rust/shoopdaloop/src/main.rs
+++ b/src/rust/shoopdaloop/src/main.rs
@@ -5687,6 +5687,7 @@ mod tests {
         assert!(html.contains("data-trunk"));
         assert!(html.contains(&format!("id=\"{WEB_CANVAS_ID}\"")));
         assert!(html.contains("id=\"browser_permissions_dialog\""));
+        assert!(html.contains("id=\"runtime_status\" data-driver-state=\"starting\" hidden"));
         assert!(html.contains("Browser audio and MIDI permissions"));
         assert!(html.contains("Enable microphone audio"));
         assert!(html.contains("Enable output-only audio"));


### PR DESCRIPTION
### Motivation

- Prevent the browser runtime status text (e.g. "Browser audio: running") from overlaying the app bottom bar while keeping its diagnostic attributes available for automated checks.

### Description

- Replaced the visible `#runtime_status` presentation with a hidden element by changing the span to `<span id="runtime_status" data-driver-state="starting" hidden></span>` and removed the `#runtime_status` CSS rules in `src/rust/shoopdaloop/index.html`, and updated the unit test in `src/rust/shoopdaloop/src/main.rs` to assert the hidden element is present.

### Testing

- Ran `cargo fmt --all -- --check` (success), `python3 scripts/check_shoop_test_usage.py` (success), and `cargo test -p shoopdaloop web_shell_targets_the_application_canvas` (test passed); a full `RUSTFLAGS="-D warnings" cargo build --workspace` was started but did not complete within the execution window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9689c3d2408328aaf54e960dbb141c)