### PR TITLE
Report retained audio ringbuffer state

### DIFF
--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -5849,11 +5849,7 @@ impl AudioPort {
         &self,
         n: u32,
     ) -> std::result::Result<CommandSequence, SendError> {
-        let result = self.with_audio_mut(move |a| a.set_ringbuffer_n_samples(n as usize));
-        if result.is_ok() {
-            self.control.mirror.set_ringbuffer_n_samples(n);
-        }
-        result
+        self.with_audio_mut(move |a| a.set_ringbuffer_n_samples(n as usize))
     }
     pub fn direction(&self) -> PortDirection {
         self.direction

--- a/src/rust/shoop_engine/src/state_mirror.rs
+++ b/src/rust/shoop_engine/src/state_mirror.rs
@@ -718,10 +718,6 @@ impl AudioPortStateMirror {
         self.passthrough_muted.store(muted, Ordering::Relaxed);
     }
 
-    pub fn set_ringbuffer_n_samples(&self, samples: u32) {
-        self.ringbuffer_n_samples.store(samples, Ordering::Relaxed);
-    }
-
     pub fn publish_peaks(&self, input: f32, output: f32) {
         atomic_max_f32(&self.input_peak, input);
         atomic_max_f32(&self.output_peak, output);

--- a/src/rust/shoop_engine/tests/control.rs
+++ b/src/rust/shoop_engine/tests/control.rs
@@ -239,19 +239,23 @@ fn handles_can_be_shared_across_threads() {
 #[shoop_wasm_test_support::shoop_test]
 fn a_port_reports_its_state() {
     let (_exclusive, driver, b) = backend();
+    driver.dummy_enter_controlled_mode();
+    driver.dummy_wait_controlled_mode();
 
     assert2::assert!(let Ok(p) = AudioPort::new_driver_port(&b, &driver, "in", &PortDirection::Input, 4));
 
     p.set_gain(0.5).expect("queue gain");
-    p.set_ringbuffer_n_samples(128).expect("queue ring size");
+    let sequence = p.set_ringbuffer_n_samples(128).expect("queue ring size");
+    b.wait_for_command(sequence, std::time::Duration::from_secs(1))
+        .expect("ring size command");
     assert2::assert!(let Ok(state) = p.get_state());
     check!(state.gain == 0.5);
     check!(!state.muted);
     // The name comes from this side, not from the audio thread, which cannot publish a
     // `String` -- so it is worth asserting it survives the round trip.
     check!(state.name == "in");
-    // Accepted value intent is visible immediately, without waiting for the audio thread.
-    check!(state.ringbuffer_n_samples == 128);
+    // Resizing discards retained audio; the requested window is not retained state.
+    check!(state.ringbuffer_n_samples == 0);
 }
 
 #[shoop_wasm_test_support::shoop_test]


### PR DESCRIPTION
## Summary

- stop publishing a requested audio capture window as retained ringbuffer state
- let the realtime audio port remain the sole publisher of retained sample count
- restore control-path coverage that resizing an audio ringbuffer reports zero retained samples

## Diagnosis

The Linux debug failure trace from master run 33484638755 showed the control-side mirror write racing the realtime ringbuffer resize. The control side published the requested value `128`, while resizing discarded retained audio and correctly published `0`. Which write won determined whether `a_port_reports_its_state` passed.

`AudioPortState::ringbuffer_n_samples` is documented and used by retrospective audio grab as the number of samples currently retained, separately from ringbuffer capacity. Removing the optimistic requested-value write restores that contract.

## Verification

- traced targeted regression: 20/20 passes
- `cargo fmt --all`
- `python3 scripts/check_shoop_test_usage.py`
- `python3 scripts/check_tracing_coverage.py --require-closed`
- `RUSTFLAGS="-D warnings" cargo build --workspace`
- `SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci` (1637 passed, 4 skipped)
