### PR TITLE
Preserve pending port control state

### DIFF
--- a/src/rust/shoop_engine/src/midi_port.rs
+++ b/src/rust/shoop_engine/src/midi_port.rs
@@ -74,6 +74,12 @@ impl MidiPort {
         self.publish_state();
     }
 
+    pub(crate) fn adopt_state_mirror(&mut self, state: Arc<MidiPortStateMirror>) {
+        (self.muted, self.passthrough_muted) = state.control_values();
+        self.state = state;
+        self.publish_runtime_state();
+    }
+
     fn publish_state(&self) {
         self.state.publish_values(
             self.n_notes_active(),
@@ -82,6 +88,11 @@ impl MidiPort {
             self.passthrough_muted,
             self.ringbuffer_n_samples(),
         );
+    }
+
+    fn publish_runtime_state(&self) {
+        self.state
+            .publish_runtime_values(self.n_notes_active(), 0, self.ringbuffer_n_samples());
     }
 
     pub fn data_type(&self) -> PortDataType {
@@ -93,7 +104,7 @@ impl MidiPort {
     }
     pub fn set_muted(&mut self, muted: bool) {
         self.muted = muted;
-        self.publish_state();
+        self.state.set_muted(muted);
     }
     pub fn passthrough_muted(&self) -> bool {
         self.passthrough_muted
@@ -105,7 +116,7 @@ impl MidiPort {
             self.passthrough_cleanup_pending = !self.passthrough_cleanup.is_empty();
         }
         self.passthrough_muted = muted;
-        self.publish_state();
+        self.state.set_passthrough_muted(muted);
     }
 
     pub(crate) fn record_passthrough(&mut self, events: &[MidiStorageElem]) {
@@ -166,7 +177,7 @@ impl MidiPort {
         if let Some(r) = self.ringbuffer.as_mut() {
             r.set_n_samples(n);
         }
-        self.publish_state();
+        self.publish_runtime_state();
     }
 
     /// Copies the capture window into `target`, rebased to start at zero.
@@ -198,7 +209,7 @@ impl MidiPort {
         }
 
         let Some(events) = input else {
-            self.publish_state();
+            self.publish_runtime_state();
             return;
         };
         if let Some(message) = events
@@ -224,7 +235,7 @@ impl MidiPort {
 
         if self.muted {
             self.state.record_events(input_count, 0);
-            self.publish_state();
+            self.publish_runtime_state();
             return;
         }
         let mut output_count = 0;
@@ -236,7 +247,7 @@ impl MidiPort {
             }
         }
         self.state.record_events(input_count, output_count);
-        self.publish_state();
+        self.publish_runtime_state();
     }
 }
 
@@ -248,6 +259,25 @@ mod tests {
 
     fn port() -> MidiPort {
         MidiPort::with_ringbuffer_capacity(TrackWhat::ALL, 64)
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn adopted_control_state_survives_stale_runtime_publication() {
+        let state = Arc::new(MidiPortStateMirror::default());
+        state.set_muted(true);
+        state.set_passthrough_muted(true);
+        let mut p = port();
+        p.adopt_state_mirror(Arc::clone(&state));
+
+        check!(p.muted());
+        check!(p.passthrough_muted());
+
+        state.set_muted(false);
+        state.set_passthrough_muted(false);
+        p.process(1, None, None);
+        let published = state.read(String::new());
+        check!(!published.muted);
+        check!(!published.passthrough_muted);
     }
 
     fn ev(time: u32, data: &[u8]) -> MidiStorageElem {

--- a/src/rust/shoop_engine/src/port.rs
+++ b/src/rust/shoop_engine/src/port.rs
@@ -112,6 +112,12 @@ impl AudioPort {
         self.publish_state();
     }
 
+    pub(crate) fn adopt_state_mirror(&mut self, state: Arc<AudioPortStateMirror>) {
+        (self.gain, self.muted, self.passthrough_muted) = state.control_values();
+        self.state = state;
+        self.publish_runtime_state();
+    }
+
     fn publish_state(&self) {
         self.state.publish_values(
             self.gain,
@@ -119,6 +125,11 @@ impl AudioPort {
             self.passthrough_muted,
             self.ringbuffer.n_samples(),
         );
+    }
+
+    fn publish_runtime_state(&self) {
+        self.state
+            .publish_runtime_values(self.ringbuffer.n_samples());
     }
 
     pub fn data_type(&self) -> PortDataType {
@@ -130,21 +141,21 @@ impl AudioPort {
     }
     pub fn set_gain(&mut self, gain: f32) {
         self.gain = gain;
-        self.publish_state();
+        self.state.set_gain(gain);
     }
     pub fn muted(&self) -> bool {
         self.muted
     }
     pub fn set_muted(&mut self, muted: bool) {
         self.muted = muted;
-        self.publish_state();
+        self.state.set_muted(muted);
     }
     pub fn passthrough_muted(&self) -> bool {
         self.passthrough_muted
     }
     pub fn set_passthrough_muted(&mut self, muted: bool) {
         self.passthrough_muted = muted;
-        self.publish_state();
+        self.state.set_passthrough_muted(muted);
     }
 
     pub fn input_peak(&self) -> f32 {
@@ -169,7 +180,7 @@ impl AudioPort {
     }
     pub fn set_ringbuffer_n_samples(&mut self, n: usize) {
         self.ringbuffer.set_min_n_samples(n);
-        self.publish_state();
+        self.publish_runtime_state();
     }
     pub fn ringbuffer_contents(&self) -> Snapshot {
         self.ringbuffer.snapshot()
@@ -258,7 +269,7 @@ impl AudioPort {
         if self.ringbuffer.max_buffers() > 0 {
             self.ringbuffer.put(buf);
         }
-        self.publish_state();
+        self.publish_runtime_state();
     }
 }
 
@@ -334,6 +345,29 @@ mod tests {
 
     fn port() -> AudioPort {
         AudioPort::new(4)
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn adopted_control_state_survives_stale_runtime_publication() {
+        let state = Arc::new(AudioPortStateMirror::default());
+        state.set_gain(0.25);
+        state.set_muted(true);
+        state.set_passthrough_muted(true);
+        let mut p = port();
+        p.adopt_state_mirror(Arc::clone(&state));
+
+        check!(p.gain() == 0.25);
+        check!(p.muted());
+        check!(p.passthrough_muted());
+
+        state.set_gain(0.5);
+        state.set_muted(false);
+        state.set_passthrough_muted(false);
+        p.process(&mut [1.0]);
+        let published = state.read(String::new());
+        check!(published.gain == 0.5);
+        check!(!published.muted);
+        check!(!published.passthrough_muted);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1101,7 +1101,7 @@ impl Session {
     ) -> Result<usize, SessionError> {
         port.audio_mut()
             .ok_or(SessionError::NoSuchPort(self.ports.len()))?
-            .set_state_mirror(state);
+            .adopt_state_mirror(state);
         Ok(self.add_port(port))
     }
 
@@ -1112,7 +1112,7 @@ impl Session {
     ) -> Result<usize, SessionError> {
         port.midi_mut()
             .ok_or(SessionError::NoSuchPort(self.ports.len()))?
-            .set_state_mirror(state);
+            .adopt_state_mirror(state);
         Ok(self.add_port(port))
     }
 

--- a/src/rust/shoop_engine/src/state_mirror.rs
+++ b/src/rust/shoop_engine/src/state_mirror.rs
@@ -706,6 +706,19 @@ impl AudioPortStateMirror {
             .store(ring as u32, Ordering::Relaxed);
     }
 
+    pub(crate) fn control_values(&self) -> (f32, bool, bool) {
+        (
+            f32::from_bits(self.gain.load(Ordering::Relaxed)),
+            self.muted.load(Ordering::Relaxed),
+            self.passthrough_muted.load(Ordering::Relaxed),
+        )
+    }
+
+    pub(crate) fn publish_runtime_values(&self, ring: usize) {
+        self.ringbuffer_n_samples
+            .store(ring as u32, Ordering::Relaxed);
+    }
+
     pub fn set_gain(&self, gain: f32) {
         self.gain.store(gain.to_bits(), Ordering::Relaxed);
     }
@@ -764,6 +777,21 @@ impl MidiPortStateMirror {
         self.muted.store(muted, Ordering::Relaxed);
         self.passthrough_muted
             .store(passthrough_muted, Ordering::Relaxed);
+        self.ringbuffer_n_samples.store(ring, Ordering::Relaxed);
+    }
+
+    pub(crate) fn control_values(&self) -> (bool, bool) {
+        (
+            self.muted.load(Ordering::Relaxed),
+            self.passthrough_muted.load(Ordering::Relaxed),
+        )
+    }
+
+    pub(crate) fn publish_runtime_values(&self, input_notes: u32, output_notes: u32, ring: u32) {
+        self.n_input_notes_active
+            .store(input_notes, Ordering::Relaxed);
+        self.n_output_notes_active
+            .store(output_notes, Ordering::Relaxed);
         self.ringbuffer_n_samples.store(ring, Ordering::Relaxed);
     }
 


### PR DESCRIPTION
## Summary

- adopt optimistic audio and MIDI control values when pending ports attach their engine state mirrors
- publish runtime port state independently so an older callback or creation publication cannot overwrite newer gain/mute intent
- add deterministic audio and MIDI regression coverage for stale runtime publication

## Diagnosis

Perfetto capture from master run [33602554805](https://github.com/SanderVocke/shoopdaloop/actions/runs/33602554805) showed the Linux release engine beginning a command drain while the audio mute command was still being enqueued. The creation command then published the port's default `muted = false` over the newer optimistic mirror value before the next drain applied the mute.

## Verification

- targeted audio/MIDI regression tests and `muting_applies_to_whichever_kind_the_port_is`: 3 passed
- release-mode direct stress run of `muting_applies_to_whichever_kind_the_port_is`: 500/500 passed
- full workspace suite excluding the host JACK binary: 1697 passed, 4 skipped
- JACK integration binary serialized to avoid local server contention: 7/7 passed
- `RUSTFLAGS="-D warnings" cargo build --locked --workspace`
- `cargo fmt --all -- --check`
- `python3 scripts/check_shoop_test_usage.py`
