### PR TITLE
Wait for self-contained browser page load

### DIFF
--- a/src/rust/shoopdaloop/browser_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_smoke.mjs
@@ -14,7 +14,8 @@ const debugPort = Number(process.env.DEBUG_PORT || 9222);
 const chrome = process.env.CHROME_BIN || 'google-chrome';
 const browserSize = process.env.BROWSER_SIZE || '900,600';
 const selfContained = process.env.SELF_CONTAINED === '1';
-const protocolTimeout = Number(process.env.CDP_TIMEOUT_MS || (selfContained ? 30_000 : 15_000));
+const protocolTimeout = Number(process.env.CDP_TIMEOUT_MS || 15_000);
+const pageLoadTimeout = Number(process.env.PAGE_LOAD_TIMEOUT_MS || (selfContained ? 90_000 : 30_000));
 const outputOnly = process.env.OUTPUT_ONLY === '1';
 const workerEngine = process.env.WORKER_ENGINE === '1';
 const directFileMicrophone = process.env.DIRECT_FILE_MIC === '1';
@@ -168,6 +169,7 @@ try {
 
   let nextId = 1;
   const pending = new Map();
+  const eventWaiters = new Map();
   const failures = [];
   websocket.onmessage = event => {
     const message = JSON.parse(event.data);
@@ -177,6 +179,12 @@ try {
       request.resolve(message);
       pending.delete(message.id);
       return;
+    }
+    if (eventWaiters.has(message.method)) {
+      const waiter = eventWaiters.get(message.method);
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+      eventWaiters.delete(message.method);
     }
     if (message.method === 'Runtime.exceptionThrown') failures.push(message);
     if (message.method === 'Runtime.consoleAPICalled' && message.params.type === 'error') {
@@ -189,6 +197,11 @@ try {
       request.reject(new Error('Chrome DevTools WebSocket closed'));
     }
     pending.clear();
+    for (const waiter of eventWaiters.values()) {
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error('Chrome DevTools WebSocket closed'));
+    }
+    eventWaiters.clear();
   };
 
   function call(method, params = {}) {
@@ -206,6 +219,16 @@ try {
         pending.delete(id);
         reject(error);
       }
+    });
+  }
+
+  function waitForEvent(method, timeoutMilliseconds) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        eventWaiters.delete(method);
+        reject(new Error(`timed out waiting for Chrome DevTools ${method}`));
+      }, timeoutMilliseconds);
+      eventWaiters.set(method, { resolve, reject, timer });
     });
   }
 
@@ -390,7 +413,10 @@ try {
             ? `${origin}/?web-midi-test=1`
             : `${origin}/?self-test=1${stress ? '&stress=1' : ''}${browserSize === '360,200' ? '&session-only=1' : ''}`;
   }
-  await call('Page.navigate', { url: entryUrl });
+  await Promise.all([
+    waitForEvent('Page.loadEventFired', pageLoadTimeout),
+    call('Page.navigate', { url: entryUrl }),
+  ]);
 
   const statusExpression = `({
     url: location.href,

--- a/src/rust/shoopdaloop/browser_smoke.mjs
+++ b/src/rust/shoopdaloop/browser_smoke.mjs
@@ -15,7 +15,7 @@ const chrome = process.env.CHROME_BIN || 'google-chrome';
 const browserSize = process.env.BROWSER_SIZE || '900,600';
 const selfContained = process.env.SELF_CONTAINED === '1';
 const protocolTimeout = Number(process.env.CDP_TIMEOUT_MS || 15_000);
-const pageLoadTimeout = Number(process.env.PAGE_LOAD_TIMEOUT_MS || (selfContained ? 90_000 : 30_000));
+const pageLoadTimeout = Number(process.env.PAGE_LOAD_TIMEOUT_MS || (selfContained ? 180_000 : 30_000));
 const outputOnly = process.env.OUTPUT_ONLY === '1';
 const workerEngine = process.env.WORKER_ENGINE === '1';
 const directFileMicrophone = process.env.DIRECT_FILE_MIC === '1';


### PR DESCRIPTION
## Summary
- restore the short per-command CDP timeout instead of extending it for every command
- wait explicitly for `Page.loadEventFired` after navigation before polling application state
- give the large self-contained HTML artifact a separate 90-second page-load budget
- reject outstanding event waits promptly if Chrome closes

## Root cause
The follow-up master run proved that doubling the generic CDP timeout was insufficient: the first `Runtime.evaluate` still timed out after 30 seconds while Chrome was loading the large self-contained debug HTML. Polling the runtime before the page load event made a normal long page load look like a hung CDP command.

The same run also had an unrelated Linux test failure in `a_controlled_request_advances_the_session_by_exactly_that_many_frames` (96 versus 160 frames); this change does not hide or modify that separate failure.

## Testing
- `node --check src/rust/shoopdaloop/browser_smoke.mjs`
- `python3 scripts/check_wasm_smoke_budget.py`
- `git diff --check`
- targeted Rust test attempted, but the host lacks the JACK development package and cargo-nextest
