### PR TITLE
Keep track-default bus text empty and route sync to Master

### DIFF
--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -12154,6 +12154,19 @@ fn new_session_document(sample_rate: u32) -> SessionDocument {
             fx_chain: None,
         }],
     });
+    document.mixer_routes = document
+        .buses
+        .first()
+        .map(|bus| {
+            bus.channels
+                .iter()
+                .map(|channel| MixerRouteDocument {
+                    source_port_id: 2,
+                    destination_channel_id: channel.id,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     document
 }
 
@@ -14891,6 +14904,8 @@ mod tests {
             IoTaskStatus::Completed
         );
         assert_eq!(snapshot.connections.pending_links.len(), 2);
+        assert_eq!(snapshot.connections.mixer_links.len(), 2);
+        assert!(snapshot.connections.pending_mixer_links.is_empty());
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_egui/src/settings_dialog.rs
+++ b/src/rust/shoop_egui/src/settings_dialog.rs
@@ -18,8 +18,7 @@ use shoop_settings::{
 
 use crate::{
     app_widget::{
-        format_output_bus_names, parse_output_bus_names, show_new_track_configuration, BusOption,
-        NewTrackConfiguration,
+        parse_output_bus_names, show_new_track_configuration, BusOption, NewTrackConfiguration,
     },
     audio_driver_config_from_draft, colors, AppAction, AudioDriverKind, AudioDriverRuntimeState,
     ScriptId, ScriptKind, ScriptLifecycle, ScriptLogLevel, ScriptState, ScriptingState,
@@ -862,10 +861,6 @@ impl SettingsDialog {
             ui.colored_label(colors::ERROR, "Invalid new-track settings");
             return;
         };
-        if configuration.output_bus_text.is_empty() {
-            configuration.output_bus_text =
-                format_output_bus_names(&configuration.output_bus_names);
-        }
         show_new_track_configuration(
             ui,
             "settings_track_defaults",


### PR DESCRIPTION
Track defaults already show selected output buses separately, so leave the
extra-bus text box empty instead of echoing the selection.

New sessions start with mono sync output fanned out to stereo Master.
