### PR TITLE
Bus FX: Carla + Built-in FX inserts on buses

### DIFF
--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -106,10 +106,10 @@ Depends on: Stage 4. Blocks Stages 6–7.
 ### Stage 6 — Regression + edge-case tests
 Depends on: Stages 1–5. Blocks Stage 7.
 
-- [ ] Mixer-route × bus-FX matrix: route connect/disconnect with FX active/inactive; bus remove with routes attached.
-- [ ] Master-bus FX create/remove; mono/3ch/surround channel counts incl. Carla-16x limits and rejection messages.
-- [ ] `python3 scripts/check_shoop_test_usage.py`; `cargo fmt --all`; `RUSTFLAGS="-D warnings"` build.
-- [ ] Verification: full affected test suites green locally.
+- [x] Mixer-route × bus-FX matrix: route connect/disconnect with FX active/inactive; bus remove with routes attached.
+- [x] Master-bus FX create/remove; mono/3ch/surround channel counts incl. Carla-16x limits and rejection messages.
+- [x] `python3 scripts/check_shoop_test_usage.py`; `cargo fmt --all`; `RUSTFLAGS="-D warnings"` build.
+- [x] Verification: full affected test suites green locally.
 
 ### Stage 7 — Final end-to-end validation + delivery workflow
 Depends on: Stages 0–6.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -81,11 +81,11 @@ Depends on: Stage 1. Blocks Stages 4–7; independent of Stage 2.
 
 Changes in `src/rust/shoop_backend/src/native.rs`:
 
-- [ ] Refactor `create_processed_track()` chain-setup into a helper usable by buses, or add `create_processed_bus()` calling the same `processor_chain_type()` → `create_builtin_fx_chain_with_audio_channels()` / `create_fx_chain()` dispatch with `dry_midi=false`.
-- [ ] Wire bus inputs → chain audio inputs, chain audio outputs → bus outputs; skip all MIDI port creation.
-- [ ] Extend native catalog function to expose the bus catalog (Carla entries only under `native-fx`, same availability logic; never OxiSynth for buses).
-- [ ] Implement native `set_bus_fx_control()` / state-string by reusing the native track FX control arms.
-- [ ] Verification: native tests for builtin + Carla-chain bus creation/control/state where runtime is available; unavailable-Carla path asserts degraded reason, not panic.
+- [x] Refactor `create_processed_track()` chain-setup into a helper usable by buses, or add `create_processed_bus()` calling the same `processor_chain_type()` → `create_builtin_fx_chain_with_audio_channels()` / `create_fx_chain()` dispatch with `dry_midi=false`.
+- [x] Wire bus inputs → chain audio inputs, chain audio outputs → bus outputs; skip all MIDI port creation.
+- [x] Extend native catalog function to expose the bus catalog (Carla entries only under `native-fx`, same availability logic; never OxiSynth for buses).
+- [x] Implement native `set_bus_fx_control()` / state-string by reusing the native track FX control arms.
+- [x] Verification: `cargo test -p shoop_backend --features native-drivers --lib bus` green (incl. new `native_dummy_bus_fx_builtin_round_trips_state_and_removes_cleanly`: catalog → create stereo Built-in FX bus → Drive-on editor snapshot → capture `processor_type/state` → `RestoreState` → remove cleanup); full `--features native-drivers --lib` suite 111 passed; workspace `cargo check` + `cargo check --features native-drivers --tests` clean.
 
 ### Stage 4 — App model + session persistence
 Depends on: Stages 1–3. Blocks Stages 5–7.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -7,6 +7,7 @@
 - Support insert effects on buses, reusing per-track FX concepts: processor descriptors + constraints, `DryWetProcessor`-style insert wiring, `*FxControl` set/active/visible/restore-state pattern, `FxState` snapshots, session `FxChainDocument` persistence.
 - Include Carla (Rack / Patchbay / Patchbay 16x) and Built-in FX.
 - Explicitly exclude Built-in Synth: buses have no MIDI input path.
+- Round 2: allow changing the FX type of an existing bus, including removing FX entirely (back to a dry bus).
 
 ### Scope
 
@@ -22,6 +23,7 @@
 - [ ] No bus FX path creates or requires a MIDI port; OxiSynth is not offered for buses anywhere (catalog, validation, session load).
 - [ ] Session save/load round-trips bus FX state + MIDI-CC assignments; old sessions without bus FX load unchanged.
 - [ ] Mixer routes to an FX bus keep working; removing the bus removes its processor and ports without leaking session processors/ports.
+- [ ] (Round 2) The FX type of an existing bus can be changed to any bus-catalog processor or to none; audio path, snapshot, session persistence, and UI all reflect the change without requiring bus removal/recreation.
 - [ ] CI is green on the PR.
 
 ## 2. Design rules and constraints
@@ -32,6 +34,7 @@
 - MIDI policy for buses is `Unsupported`: zero MIDI ports passed to `set_processor_ports()`. Built-in FX parameter/state controls still work; MIDI-CC assignments persist but have no live MIDI driver unless a later global-FX-MIDI routing stage explicitly adds it.
 - Built-in FX descriptor currently says `midi: Required`; do not change the track descriptor. Bus catalog is the track catalog filtered to `midi != Required` and `id != OXI_SYNTH`, plus a bus-specific Built-in FX entry with `midi: Unsupported` and `matching_audio_channels: true`.
 - No bus latency compensation in v1; document as a known limitation. Do not block on it.
+- Round 2 rules: switching FX type reuses the stable `bus_<raw_id>_fx` title; the new processor starts from fresh default state (no cross-processor state or MIDI-CC carryover); switching to none restores the direct `input -> output` wiring and drops the processor plus its FX ports; the switch is validated against the bus catalog (synth always rejected) before any graph mutation, with rollback to the previous wiring on failure.
 - Goals/acceptance criteria change only with explicit user approval. Design rules/steps may be revised on new evidence with a documented reason. Keep the plan checked off as work progresses; commit per completed stage.
 
 ## 3. Stage 0 findings (recorded)
@@ -115,6 +118,40 @@ Depends on: Stages 1–5. Blocks Stage 7.
 Depends on: Stages 0–6.
 
 - [ ] End-to-end: new bus with Built-in FX → route a track → hear/measure effect → bypass → save → reload → FX state intact → remove bus cleanly; repeat smoke for a Carla bus where supported.
+- [ ] Run the required test suites before pushing; push branch and create a PR.
+- [ ] Work to ensure CI turns green.
+- [ ] Check the PR for any automated review coming in; repeatedly address review feedback until the reviewer approves.
+
+## Round 2 — Change FX type of an existing bus (including none)
+
+Depends on: Stages 0–7 (round 1 complete). Uses a new branch off the round-1 result; blocks only the round-2 validation stage.
+
+### Stage R1 — Backend + protocol: replace bus processor
+Depends on: round-1 Stages 1–3. Blocks R2–R4.
+
+- [ ] Add a replace/remove operation on the bus FX path (e.g. a `SetProcessorType(Option<...>)`-style control or dedicated method) in `shoop_backend`: validate against the bus catalog first (reject synth, channel mismatch), then tear down the old processor (remove processor + FX ports, restore direct wiring for none) and build the new insert chain reusing the stable `bus_<raw_id>_fx` title and the existing chain-setup dispatch with `dry_midi=false`.
+- [ ] Mirror the operation in the wire protocol (`CreateBus.fx`-style field or new control variant + snapshot `fx` propagation) so `RemoteWorkletBackend`/`WorkletHost` support replace/remove in browser builds; bump `PROTOCOL_VERSION` and update version-pinned fixtures/contracts.
+- [ ] Extend `NativeBackend` the same way (remove old chain via existing cleanup, create new chain via existing dispatch; none = direct wiring).
+- [ ] Verification: backend unit tests for replace Built-in→Built-in (fresh default state), Built-in→none (dry path restored, no leaked ports/processors), none→Built-in, invalid target rejected with prior wiring intact; worklet protocol round-trip tests for the new operation.
+
+### Stage R2 — App model + session persistence
+Depends on: R1. Blocks R3–R4.
+
+- [ ] `shoop_app_api`: add a bus FX-type-change action/intent (e.g. `BusAction::FxProcessorChanged(Option<...>)`); never construct a synth target.
+- [ ] `shoop_app`: handle the action with validation against `bus_processors` before mutating, optimistic desired-state handling mirroring the existing bus FX arms, snapshot/view propagation; session save emits the updated `FxChainDocument` (or none), session load replaces/restores the same way round 1 does.
+- [ ] `shoop_session`: validation already covers `None` vs `Carla`/`BuiltInFx` chains; extend only if the new action introduces a representable shape.
+- [ ] Verification: app unit tests for change/remove/rollback paths; session bundle round-trip with a changed and a removed bus FX chain; old-fixture load still passes.
+
+### Stage R3 — UI: change/remove FX on the bus strip
+Depends on: R2. Blocks R4.
+
+- [ ] Bus strip FX affordance gains a processor picker (bus catalog only, plus "None") and a remove option, wired to the new action; editor/logs windows follow the current processor.
+- [ ] Verification: egui tests for change/remove action emission; existing `bus_controls` tests still pass.
+
+### Stage R4 — Round-2 validation + delivery workflow
+Depends on: R1–R3.
+
+- [ ] End-to-end: bus with Built-in FX → change to another processor (or none) → audio path correct → save → reload → state intact → change back; mixer routes survive the switch; remove-bus cleanup still leak-free.
 - [ ] Run the required test suites before pushing; push branch and create a PR.
 - [ ] Work to ensure CI turns green.
 - [ ] Check the PR for any automated review coming in; repeatedly address review feedback until the reviewer approves.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -99,9 +99,9 @@ Depends on: Stages 1–3. Blocks Stages 5–7.
 ### Stage 5 — UI (`shoop_egui/src/bus_controls.rs` + track-editor reuse)
 Depends on: Stage 4. Blocks Stages 6–7.
 
-- [ ] Add collapsed FX section to the bus strip reusing the Built-in FX editor widgets and Carla status/logs/external-UI affordances; wire to new `BusAction::Fx*`.
-- [ ] Processor picker for buses lists only the bus catalog (no synth).
-- [ ] Verification: existing `bus_controls` egui tests still pass; new tests for FX action emission and MIDI-less picker contents.
+- [x] Add collapsed FX section to the bus strip reusing the Built-in FX editor widgets and Carla status/logs/external-UI affordances; wire to new `BusAction::Fx*`.
+- [x] Processor picker for buses lists only the bus catalog (no synth).
+- [x] Verification: existing `bus_controls` egui tests still pass; new tests for FX action emission and MIDI-less picker contents.
 
 ### Stage 6 — Regression + edge-case tests
 Depends on: Stages 1–5. Blocks Stage 7.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -90,11 +90,11 @@ Changes in `src/rust/shoop_backend/src/native.rs`:
 ### Stage 4 — App model + session persistence
 Depends on: Stages 1–3. Blocks Stages 5–7.
 
-- [ ] `shoop_app_api`: add `fx` to `BusState`; add `BusAction::Fx*` variants (active/visible/toggle/restore/clear/builtin-fx); add bus catalog to the snapshot/view state; never construct an OxiSynth bus action.
-- [ ] `shoop_app`: `handle_bus_action()` FX arms mirroring `handle_track_action()` FX arms incl. optimistic `desired_bus_fx_controls`; `refresh_bus_view()` propagates `fx`; bus creation accepts an FX spec and validates against the bus catalog.
-- [ ] Session save: emit bus `FxChainDocument` + topology for FX buses; session load: remove the `bus.fx_chain.is_some()` rejection in `session_bundle_to_backend()`, add `runtime_bus_topology()` + validation paralleling `runtime_track_topology()`; restore via create-bus-with-FX + `RestoreState` + CC assignments.
-- [ ] `shoop_session`: allow/validate bus FX chains (`Carla` + `BuiltInFx` only; reject synth/test mismatches in `archive.rs`).
-- [ ] Verification: app unit tests for bus FX intents + optimistic rollback; session bundle round-trip test with an FX bus; old-fixture load test still passes.
+- [x] `shoop_app_api`: add `fx` to `BusState`; add `BusAction::Fx*` variants (active/visible/toggle/restore/clear/builtin-fx); add bus catalog to the snapshot/view state; never construct an OxiSynth bus action.
+- [x] `shoop_app`: `handle_bus_action()` FX arms mirroring `handle_track_action()` FX arms incl. optimistic `desired_bus_fx_controls`; `refresh_bus_view()` propagates `fx`; bus creation accepts an FX spec and validates against the bus catalog.
+- [x] Session save: emit bus `FxChainDocument` + topology for FX buses; session load: remove the `bus.fx_chain.is_some()` rejection in `session_bundle_to_backend()`, add `runtime_bus_topology()` + validation paralleling `runtime_track_topology()`; restore via create-bus-with-FX + `RestoreState` + CC assignments.
+- [x] `shoop_session`: allow/validate bus FX chains (`Carla` + `BuiltInFx` only; reject synth/test mismatches in `archive.rs`).
+- [x] Verification: app unit tests for bus FX intents + optimistic rollback; session bundle round-trip test with an FX bus; old-fixture load test still passes.
 
 ### Stage 5 — UI (`shoop_egui/src/bus_controls.rs` + track-editor reuse)
 Depends on: Stage 4. Blocks Stages 6–7.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -1,0 +1,137 @@
+# Bus FX implementation plan: Carla + Built-in FX, no synth
+
+## 1. Goals, scope, acceptance criteria
+
+### Goals
+
+- Support insert effects on buses, reusing per-track FX concepts: processor descriptors + constraints, `DryWetProcessor`-style insert wiring, `*FxControl` set/active/visible/restore-state pattern, `FxState` snapshots, session `FxChainDocument` persistence.
+- Include Carla (Rack / Patchbay / Patchbay 16x) and Built-in FX.
+- Explicitly exclude Built-in Synth: buses have no MIDI input path.
+
+### Scope
+
+- `shoop_backend` public API + `EngineBackend` (dummy/web) + `NativeBackend`.
+- `shoop_app_api` bus view types, `shoop_app` bus intent handling + session save/load, `shoop_egui` bus strip FX affordances.
+- `shoop_session` validation for bus FX chains.
+- Tests at backend, app, session-roundtrip, and audio-through-FX levels.
+
+### Immutable acceptance criteria
+
+- [ ] A stereo bus and a mono bus can each run Built-in FX audibly (e.g. Drive enabled changes output; bypass restores dry path).
+- [ ] A bus can run a Carla chain where the native backend supports it, using the same chain-type mapping as tracks; unavailable Carla degrades with a reason, never a panic.
+- [ ] No bus FX path creates or requires a MIDI port; OxiSynth is not offered for buses anywhere (catalog, validation, session load).
+- [ ] Session save/load round-trips bus FX state + MIDI-CC assignments; old sessions without bus FX load unchanged.
+- [ ] Mixer routes to an FX bus keep working; removing the bus removes its processor and ports without leaking session processors/ports.
+- [ ] CI is green on the PR.
+
+## 2. Design rules and constraints
+
+- Reuse, don't fork: bus FX state reuses `TrackFxState` / `TrackProcessorEditorState` shapes; bus controls mirror `BackendTrackFxControl` minus `OxiSynth`; native bus wiring reuses `processor_chain_type()` + `create_builtin_fx_chain_with_audio_channels()` / `create_oxisynth_chain()` / `create_fx_chain()` dispatch.
+- Insert semantics: bus FX is dry = wet = bus channel count. No channel-count conversion on buses in v1.
+- Processor titles must be stable IDs, not bus display names: e.g. `bus_<raw_id>_fx`. Bus renames must not retitle processors.
+- MIDI policy for buses is `Unsupported`: zero MIDI ports passed to `set_processor_ports()`. Built-in FX parameter/state controls still work; MIDI-CC assignments persist but have no live MIDI driver unless a later global-FX-MIDI routing stage explicitly adds it.
+- Built-in FX descriptor currently says `midi: Required`; do not change the track descriptor. Bus catalog is the track catalog filtered to `midi != Required` and `id != OXI_SYNTH`, plus a bus-specific Built-in FX entry with `midi: Unsupported` and `matching_audio_channels: true`.
+- No bus latency compensation in v1; document as a known limitation. Do not block on it.
+- Goals/acceptance criteria change only with explicit user approval. Design rules/steps may be revised on new evidence with a documented reason. Keep the plan checked off as work progresses; commit per completed stage.
+
+## 3. Stage 0 findings (recorded)
+
+- `Session::set_processor_ports` now accepts 0 or 1 MIDI inputs for Built-in FX processors; tracks keep passing exactly 1, so track behavior is unchanged.
+- A new engine test (`builtin_fx_processes_audio_without_midi_ports`) proves MIDI-less audio through Built-in FX.
+- Global FX MIDI is no longer gated on per-processor MIDI ports, so a MIDI-less bus processor still receives control mappings; per-track MIDI inputs are unchanged.
+- Native `FXChain` port creation derives MIDI ports from the chain kind and already tolerates a MIDI-less consumer: `create_processed_track` only connects `get_midi_input_port(0)` when `dry_midi` is set, and `bind_processor_ports` forwards whatever ports exist, so `dry_midi=false` yields a MIDI-less binding.
+- Bus processor title scheme: `bus_<raw_id>_fx`, derived from the stable backend bus id, never the display name.
+- Bus catalog rule: track catalog filtered to `midi != Required` and `id != OXI_SYNTH`, plus a bus-specific Built-in FX entry with `midi: Unsupported` and `matching_audio_channels: true`.
+
+## 4. Staged implementation
+
+### Stage 0 — Setup + contract spike (no public API changes)
+Depends on: nothing; blocks Stages 1–7.
+
+- [x] Create branch for bus FX work before implementing.
+- [x] Confirm MIDI-less Built-in FX runs in `Session` with empty MIDI port vec (audio in/out, bypass, parameter set, state encode/restore).
+- [x] Confirm native `FXChain` path works with `dry_midi=false` for Built-in FX and Carla (same shape `create_processed_track` uses).
+- [x] Decide bus processor title scheme and bus catalog filter rule.
+- [x] Verification: throwaway integration test or REPL-style test proving audio-through-FX with no MIDI ports; record decision in plan.
+
+### Stage 1 — `shoop_backend` bus-FX API types
+Depends on: Stage 0. Blocks Stages 2–7.
+
+Changes in `src/rust/shoop_backend/src/lib.rs`:
+
+- [ ] Add `BackendBusFxTopology` (or extend `BackendBusRequest` with `fx: Option<BackendBusFxRequest>`), e.g. `{ processor_type, audio_channels }` with `dry_midi=false` invariant.
+- [ ] Add `BackendBusFxControl` mirroring the Built-in FX subset of `BackendTrackFxControl`: `SetActive/SetVisible/ToggleOrRecover/RestoreState/ClearLogs/BuiltInFx(...)`, plus Carla generic controls if tracks expose them; no `OxiSynth` variant.
+- [ ] Add `fx: Option<TrackFxState>` (or `BusFxState` alias) to `BackendBusState`; add `processor_state + builtin_fx_midi_cc_assignments` to `BackendSessionBus`.
+- [ ] Extend `Backend` trait: `bus_processor_catalog()`, `set_bus_fx_control()`, `bus_fx_state_string()`; add `BusFxControl` mutation kind/detail.
+- [ ] Update `MockBackend`/`FakeBackend`/test fakes for new methods.
+- [ ] Verification: `cargo build`; new API-level unit tests for normalization/validation (bad channel count, synth rejected, MIDI rejected).
+
+### Stage 2 — `EngineBackend` (dummy/web): Built-in FX on buses
+Depends on: Stage 1. Blocks Stages 4–7; independent of Stage 3.
+
+- [ ] Store `EngineBusFx { control, active, visible }` on `EngineBus`; create processor in `create_bus_with_ids()` when requested (`prepare_processor_with_channels(sample_rate, buffer_size, channel_count)`).
+- [ ] Rewire bus graph from `input -> output` to `input -> send -> processor -> receive -> output`, keeping gain/balance/mute on the output port (`apply_bus_control` unchanged in behavior).
+- [ ] Implement `set_bus_fx_control()` by cloning the Built-in FX arm of `set_track_fx_control()`; implement `bus_fx_state_string()`, include FX in `mixer_snapshot()` + `capture_session_data()` + `build_replacement()` restore.
+- [ ] `remove_bus_internal()` also calls `session.remove_processor(title)` and drops FX ports.
+- [ ] Carla on `EngineBackend` stays unsupported (same as Carla tracks there); return a clear error.
+- [ ] Verification: backend tests for mono/stereo create → control → snapshot → remove; audio test proving Drive-on changes bus output vs bypass.
+
+### Stage 3 — `NativeBackend`: Built-in FX + Carla on buses
+Depends on: Stage 1. Blocks Stages 4–7; independent of Stage 2.
+
+Changes in `src/rust/shoop_backend/src/native.rs`:
+
+- [ ] Refactor `create_processed_track()` chain-setup into a helper usable by buses, or add `create_processed_bus()` calling the same `processor_chain_type()` → `create_builtin_fx_chain_with_audio_channels()` / `create_fx_chain()` dispatch with `dry_midi=false`.
+- [ ] Wire bus inputs → chain audio inputs, chain audio outputs → bus outputs; skip all MIDI port creation.
+- [ ] Extend native catalog function to expose the bus catalog (Carla entries only under `native-fx`, same availability logic; never OxiSynth for buses).
+- [ ] Implement native `set_bus_fx_control()` / state-string by reusing the native track FX control arms.
+- [ ] Verification: native tests for builtin + Carla-chain bus creation/control/state where runtime is available; unavailable-Carla path asserts degraded reason, not panic.
+
+### Stage 4 — App model + session persistence
+Depends on: Stages 1–3. Blocks Stages 5–7.
+
+- [ ] `shoop_app_api`: add `fx` to `BusState`; add `BusAction::Fx*` variants (active/visible/toggle/restore/clear/builtin-fx); add bus catalog to the snapshot/view state; never construct an OxiSynth bus action.
+- [ ] `shoop_app`: `handle_bus_action()` FX arms mirroring `handle_track_action()` FX arms incl. optimistic `desired_bus_fx_controls`; `refresh_bus_view()` propagates `fx`; bus creation accepts an FX spec and validates against the bus catalog.
+- [ ] Session save: emit bus `FxChainDocument` + topology for FX buses; session load: remove the `bus.fx_chain.is_some()` rejection in `session_bundle_to_backend()`, add `runtime_bus_topology()` + validation paralleling `runtime_track_topology()`; restore via create-bus-with-FX + `RestoreState` + CC assignments.
+- [ ] `shoop_session`: allow/validate bus FX chains (`Carla` + `BuiltInFx` only; reject synth/test mismatches in `archive.rs`).
+- [ ] Verification: app unit tests for bus FX intents + optimistic rollback; session bundle round-trip test with an FX bus; old-fixture load test still passes.
+
+### Stage 5 — UI (`shoop_egui/src/bus_controls.rs` + track-editor reuse)
+Depends on: Stage 4. Blocks Stages 6–7.
+
+- [ ] Add collapsed FX section to the bus strip reusing the Built-in FX editor widgets and Carla status/logs/external-UI affordances; wire to new `BusAction::Fx*`.
+- [ ] Processor picker for buses lists only the bus catalog (no synth).
+- [ ] Verification: existing `bus_controls` egui tests still pass; new tests for FX action emission and MIDI-less picker contents.
+
+### Stage 6 — Regression + edge-case tests
+Depends on: Stages 1–5. Blocks Stage 7.
+
+- [ ] Mixer-route × bus-FX matrix: route connect/disconnect with FX active/inactive; bus remove with routes attached.
+- [ ] Master-bus FX create/remove; mono/3ch/surround channel counts incl. Carla-16x limits and rejection messages.
+- [ ] `python3 scripts/check_shoop_test_usage.py`; `cargo fmt --all`; `RUSTFLAGS="-D warnings"` build.
+- [ ] Verification: full affected test suites green locally.
+
+### Stage 7 — Final end-to-end validation + delivery workflow
+Depends on: Stages 0–6.
+
+- [ ] End-to-end: new bus with Built-in FX → route a track → hear/measure effect → bypass → save → reload → FX state intact → remove bus cleanly; repeat smoke for a Carla bus where supported.
+- [ ] Run the required test suites before pushing; push branch and create a PR.
+- [ ] Work to ensure CI turns green.
+- [ ] Check the PR for any automated review coming in; repeatedly address review feedback until the reviewer approves.
+
+## 5. Execution contract
+
+- Keep the plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.
+
+## 6. Suggested file touch list
+
+- `src/rust/shoop_backend/src/lib.rs` — bus FX types, trait, `EngineBackend` wiring/snapshot/restore, fakes.
+- `src/rust/shoop_backend/src/native.rs` — native bus chain creation/control/catalog.
+- `src/rust/shoop_app_api/src/lib.rs` — `BusState.fx`, `BusAction::Fx*`.
+- `src/rust/shoop_app/src/lib.rs` — bus FX intents, optimistic controls, session bundle mapping.
+- `src/rust/shoop_session/src/{document,archive}.rs` — allow + validate bus FX chains.
+- `src/rust/shoop_egui/src/bus_controls.rs` (+ shared FX editor widgets) — bus FX UI.

--- a/BUS_FX.md
+++ b/BUS_FX.md
@@ -59,22 +59,22 @@ Depends on: Stage 0. Blocks Stages 2–7.
 
 Changes in `src/rust/shoop_backend/src/lib.rs`:
 
-- [ ] Add `BackendBusFxTopology` (or extend `BackendBusRequest` with `fx: Option<BackendBusFxRequest>`), e.g. `{ processor_type, audio_channels }` with `dry_midi=false` invariant.
-- [ ] Add `BackendBusFxControl` mirroring the Built-in FX subset of `BackendTrackFxControl`: `SetActive/SetVisible/ToggleOrRecover/RestoreState/ClearLogs/BuiltInFx(...)`, plus Carla generic controls if tracks expose them; no `OxiSynth` variant.
-- [ ] Add `fx: Option<TrackFxState>` (or `BusFxState` alias) to `BackendBusState`; add `processor_state + builtin_fx_midi_cc_assignments` to `BackendSessionBus`.
-- [ ] Extend `Backend` trait: `bus_processor_catalog()`, `set_bus_fx_control()`, `bus_fx_state_string()`; add `BusFxControl` mutation kind/detail.
-- [ ] Update `MockBackend`/`FakeBackend`/test fakes for new methods.
-- [ ] Verification: `cargo build`; new API-level unit tests for normalization/validation (bad channel count, synth rejected, MIDI rejected).
+- [x] Add `BackendBusFxTopology` (or extend `BackendBusRequest` with `fx: Option<BackendBusFxRequest>`), e.g. `{ processor_type, audio_channels }` with `dry_midi=false` invariant.
+- [x] Add `BackendBusFxControl` mirroring the Built-in FX subset of `BackendTrackFxControl`: `SetActive/SetVisible/ToggleOrRecover/RestoreState/ClearLogs/BuiltInFx(...)`, plus Carla generic controls if tracks expose them; no `OxiSynth` variant.
+- [x] Add `fx: Option<TrackFxState>` (or `BusFxState` alias) to `BackendBusState`; add `processor_state + builtin_fx_midi_cc_assignments` to `BackendSessionBus`.
+- [x] Extend `Backend` trait: `bus_processor_catalog()`, `set_bus_fx_control()`, `bus_fx_state_string()`; add `BusFxControl` mutation kind/detail.
+- [x] Update `MockBackend`/`FakeBackend`/test fakes for new methods.
+- [x] Verification: `cargo build`; new API-level unit tests for normalization/validation (bad channel count, synth rejected, MIDI rejected).
 
 ### Stage 2 — `EngineBackend` (dummy/web): Built-in FX on buses
 Depends on: Stage 1. Blocks Stages 4–7; independent of Stage 3.
 
-- [ ] Store `EngineBusFx { control, active, visible }` on `EngineBus`; create processor in `create_bus_with_ids()` when requested (`prepare_processor_with_channels(sample_rate, buffer_size, channel_count)`).
-- [ ] Rewire bus graph from `input -> output` to `input -> send -> processor -> receive -> output`, keeping gain/balance/mute on the output port (`apply_bus_control` unchanged in behavior).
-- [ ] Implement `set_bus_fx_control()` by cloning the Built-in FX arm of `set_track_fx_control()`; implement `bus_fx_state_string()`, include FX in `mixer_snapshot()` + `capture_session_data()` + `build_replacement()` restore.
-- [ ] `remove_bus_internal()` also calls `session.remove_processor(title)` and drops FX ports.
-- [ ] Carla on `EngineBackend` stays unsupported (same as Carla tracks there); return a clear error.
-- [ ] Verification: backend tests for mono/stereo create → control → snapshot → remove; audio test proving Drive-on changes bus output vs bypass.
+- [x] Store `EngineBusFx { control, active, visible }` on `EngineBus`; create processor in `create_bus_with_ids()` when requested (`prepare_processor_with_channels(sample_rate, buffer_size, channel_count)`).
+- [x] Rewire bus graph from `input -> output` to `input -> send -> processor -> receive -> output`, keeping gain/balance/mute on the output port (`apply_bus_control` unchanged in behavior).
+- [x] Implement `set_bus_fx_control()` by cloning the Built-in FX arm of `set_track_fx_control()`; implement `bus_fx_state_string()`, include FX in `mixer_snapshot()` + `capture_session_data()` + `build_replacement()` restore.
+- [x] `remove_bus_internal()` also calls `session.remove_processor(title)` and drops FX ports.
+- [x] Carla on `EngineBackend` stays unsupported (same as Carla tracks there); return a clear error.
+- [x] Verification: backend tests for mono/stereo create → control → snapshot → remove; audio test proving Drive-on changes bus output vs bypass.
 
 ### Stage 3 — `NativeBackend`: Built-in FX + Carla on buses
 Depends on: Stage 1. Blocks Stages 4–7; independent of Stage 2.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,7 @@ version = "0.3.0"
 dependencies = [
  "assert_no_alloc",
  "serde_json",
+ "shoop_app_api",
  "shoop_audio_protocol",
  "shoop_backend",
  "shoop_tracing",

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -38,18 +38,19 @@ use shoop_backend::{
     canonical_midi_start_state, default_bus_channel_labels, Backend, BackendAsyncResult,
     BackendAudioChannelUpdate, BackendAudioContent, BackendAudioData,
     BackendBuiltInFxMidiCcAssignment, BackendBuiltInFxParameter, BackendBusChannelId,
-    BackendBusControl, BackendBusId, BackendBusRequest, BackendChannelMode, BackendCompositeConfig,
-    BackendCompositeEntry, BackendCompositeId, BackendCompositeKind, BackendCompositeTarget,
-    BackendConnectionSnapshot, BackendDefaultPlaybackMode, BackendGrabRequest, BackendLoopContent,
-    BackendLoopContentUpdate, BackendLoopId, BackendLoopMode, BackendMidiChannelUpdate,
-    BackendMidiContent, BackendMidiData, BackendMidiEvent, BackendMixerSnapshot,
-    BackendMutationDetail, BackendOperationProgress, BackendOxiSynthMidiCcAssignment,
-    BackendOxiSynthParameter, BackendPortDataType, BackendPortDescriptor, BackendPortDirection,
-    BackendPortId, BackendPortOwner, BackendPortRole, BackendProcessorLatencyAdjustment,
-    BackendRecordingOffsetAdjustment, BackendSessionBus, BackendSessionBusChannel,
-    BackendSessionData, BackendSessionMixerRoute, BackendSessionPort, BackendSessionReplacement,
-    BackendSessionTrack, BackendSnapshot, BackendTrackControl, BackendTrackFxControl,
-    BackendTrackId, BackendTrackState, BackendTrackTopology, DirectTrackRequest, TrackRequest,
+    BackendBusControl, BackendBusFxControl, BackendBusFxRequest, BackendBusId, BackendBusRequest,
+    BackendChannelMode, BackendCompositeConfig, BackendCompositeEntry, BackendCompositeId,
+    BackendCompositeKind, BackendCompositeTarget, BackendConnectionSnapshot,
+    BackendDefaultPlaybackMode, BackendGrabRequest, BackendLoopContent, BackendLoopContentUpdate,
+    BackendLoopId, BackendLoopMode, BackendMidiChannelUpdate, BackendMidiContent, BackendMidiData,
+    BackendMidiEvent, BackendMixerSnapshot, BackendMutationDetail, BackendOperationProgress,
+    BackendOxiSynthMidiCcAssignment, BackendOxiSynthParameter, BackendPortDataType,
+    BackendPortDescriptor, BackendPortDirection, BackendPortId, BackendPortOwner, BackendPortRole,
+    BackendProcessorLatencyAdjustment, BackendRecordingOffsetAdjustment, BackendSessionBus,
+    BackendSessionBusChannel, BackendSessionData, BackendSessionMixerRoute, BackendSessionPort,
+    BackendSessionReplacement, BackendSessionTrack, BackendSnapshot, BackendTrackControl,
+    BackendTrackFxControl, BackendTrackId, BackendTrackState, BackendTrackTopology,
+    DirectTrackRequest, TrackRequest,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use shoop_scripting::NativeMidiService;
@@ -704,6 +705,7 @@ struct ApplicationModel {
     buses: BTreeMap<BusId, BusModel>,
     bus_order: Vec<BusId>,
     bus_view: Arc<[BusState]>,
+    bus_processors: Arc<[TrackProcessorDescriptor]>,
     loops: BTreeMap<LoopId, LoopModel>,
     connection_ports: BTreeMap<PortId, ConnectionPortModel>,
     host_ports: BTreeMap<String, HostPortState>,
@@ -714,6 +716,7 @@ struct ApplicationModel {
     pending_mixer_routes: BTreeMap<MixerRouteState, PendingConnection>,
     mixer_route_errors: Vec<MixerRouteErrorState>,
     desired_bus_controls: BTreeMap<(BackendBusId, BusControlKey), PendingBusControl>,
+    desired_bus_fx_controls: BTreeMap<(BackendBusId, FxControlKey), BackendBusFxControl>,
     desired_track_controls: BTreeMap<(BackendTrackId, TrackControlKey), BackendTrackControl>,
     desired_track_default_playback_modes: BTreeMap<BackendTrackId, BackendDefaultPlaybackMode>,
     desired_fx_controls: BTreeMap<(BackendTrackId, FxControlKey), BackendTrackFxControl>,
@@ -782,6 +785,7 @@ struct BusModel {
     balance: f32,
     muted: bool,
     output_peaks_db: Vec<f32>,
+    fx: Option<shoop_app_api::TrackFxState>,
     control_pending: bool,
     control_error: Option<String>,
 }
@@ -1004,6 +1008,29 @@ enum FxControlKey {
     OxiReverbSend,
     OxiChorusSend,
     OxiMidiAssignments,
+}
+
+fn bus_fx_control_as_track(control: &BackendBusFxControl) -> BackendTrackFxControl {
+    match control {
+        BackendBusFxControl::SetActive(value) => BackendTrackFxControl::SetActive(*value),
+        BackendBusFxControl::SetVisible(value) => BackendTrackFxControl::SetVisible(*value),
+        BackendBusFxControl::ToggleOrRecover => BackendTrackFxControl::ToggleOrRecover,
+        BackendBusFxControl::RestoreState(state) => {
+            BackendTrackFxControl::RestoreState(state.clone())
+        }
+        BackendBusFxControl::ClearLogs => BackendTrackFxControl::ClearLogs,
+        BackendBusFxControl::BuiltInFx(control) => {
+            BackendTrackFxControl::BuiltInFx(control.clone())
+        }
+    }
+}
+
+fn apply_bus_fx_control(bus: &mut BusModel, control: &BackendBusFxControl) {
+    let Some(fx) = bus.fx.as_mut() else {
+        return;
+    };
+    let control = bus_fx_control_as_track(control);
+    apply_fx_control(fx, &control);
 }
 
 fn apply_fx_control(fx: &mut shoop_app_api::TrackFxState, control: &BackendTrackFxControl) {
@@ -1678,6 +1705,7 @@ impl ApplicationModel {
                     balance: backend_bus.balance,
                     muted: backend_bus.muted,
                     output_peaks_db: backend_bus.output_peaks_db.clone(),
+                    fx: backend_bus.fx.clone(),
                     control_pending: false,
                     control_error: None,
                 },
@@ -1765,6 +1793,7 @@ impl ApplicationModel {
             pending_mixer_routes: BTreeMap::new(),
             mixer_route_errors: Vec::new(),
             desired_bus_controls: BTreeMap::new(),
+            desired_bus_fx_controls: BTreeMap::new(),
             desired_track_controls: BTreeMap::new(),
             desired_track_default_playback_modes: BTreeMap::new(),
             desired_fx_controls: BTreeMap::new(),
@@ -1784,6 +1813,9 @@ impl ApplicationModel {
             }),
             track_processors: backend
                 .track_processor_catalog()
+                .unwrap_or_else(|_| Arc::from([])),
+            bus_processors: backend
+                .bus_processor_catalog()
                 .unwrap_or_else(|_| Arc::from([])),
             track_creation_results: VecDeque::new(),
             bus_creation_results: VecDeque::new(),
@@ -3266,7 +3298,7 @@ impl ApplicationModel {
         action: BusAction,
     ) -> Result<(), String> {
         for id in buses {
-            self.handle_bus_action(backend, id, action)?;
+            self.handle_bus_action(backend, id, action.clone())?;
         }
         Ok(())
     }
@@ -3773,7 +3805,11 @@ impl ApplicationModel {
                 }
             }
         };
-        let backend_data = match session_bundle_to_backend(&bundle, &self.track_processors) {
+        let backend_data = match session_bundle_to_backend(
+            &bundle,
+            &self.track_processors,
+            &self.bus_processors,
+        ) {
             Ok(data) => data,
             Err(error) => {
                 self.fail_audio_driver_switch(request_id, source, pending.target, &error);
@@ -3846,7 +3882,11 @@ impl ApplicationModel {
         if let Err(error) = self.apply_loaded_session(backend, &bundle, &replacement) {
             self.audio_drivers.switch.status = AudioDriverSwitchStatus::Restoring;
             self.audio_drivers.switch.message = "Restoring the prior audio driver".to_owned();
-            let rollback_data = session_bundle_to_backend(&source_bundle, &self.track_processors);
+            let rollback_data = session_bundle_to_backend(
+                &source_bundle,
+                &self.track_processors,
+                &self.bus_processors,
+            );
             let rollback = source.as_ref().ok_or_else(|| {
                 "could not restore switched session because source driver state is missing"
                     .to_owned()
@@ -4207,7 +4247,11 @@ impl ApplicationModel {
             });
             return Ok(());
         }
-        let backend_data = match session_bundle_to_backend(&bundle, &self.track_processors) {
+        let backend_data = match session_bundle_to_backend(
+            &bundle,
+            &self.track_processors,
+            &self.bus_processors,
+        ) {
             Ok(backend_data) => backend_data,
             Err(message) => {
                 self.finish_io(IoTaskStatus::Failed, &message);
@@ -4246,8 +4290,11 @@ impl ApplicationModel {
                 resample_session(&bundle, self.status.sample_rate)
                     .map_err(|error| error.to_string())
                     .and_then(|bundle| {
-                        let backend_data =
-                            session_bundle_to_backend(&bundle, &self.track_processors)?;
+                        let backend_data = session_bundle_to_backend(
+                            &bundle,
+                            &self.track_processors,
+                            &self.bus_processors,
+                        )?;
                         self.pending_io = Some(PendingIo::CommitSessionLoad {
                             name,
                             bundle,
@@ -4932,10 +4979,25 @@ impl ApplicationModel {
     }
 
     fn add_bus(&mut self, backend: &mut dyn Backend, spec: BusSpec) -> Result<(), String> {
+        let fx = spec
+            .fx
+            .as_ref()
+            .map(|fx| {
+                validate_bus_processor(
+                    &fx.processor_type,
+                    spec.channel_count,
+                    &self.bus_processors,
+                )?;
+                Ok::<_, String>(BackendBusFxRequest {
+                    processor_type: fx.processor_type.as_str().to_owned(),
+                    audio_channels: spec.channel_count,
+                })
+            })
+            .transpose()?;
         let request = BackendBusRequest {
             name: spec.name,
             channel_count: spec.channel_count,
-            fx: None,
+            fx,
         }
         .normalized()
         .map_err(|error| format!("invalid bus: {error}"))?;
@@ -4961,6 +5023,7 @@ impl ApplicationModel {
         let creation = backend
             .create_bus(request.clone())
             .map_err(|error| format!("could not create bus: {error}"))?;
+        let backend_id = creation.bus_id;
         let channel_ids = creation
             .channels
             .iter()
@@ -4990,9 +5053,22 @@ impl ApplicationModel {
                     })
             });
         if mapping_invalid {
-            let _ = backend.remove_bus(creation.bus_id);
+            let _ = backend.remove_bus(backend_id);
             return Err("backend returned an invalid bus identity mapping".to_owned());
         }
+        let fx = spec.fx.as_ref().map(|fx| shoop_app_api::TrackFxState {
+            processor_type: fx.processor_type.clone(),
+            active: true,
+            visible: false,
+            lifecycle: shoop_app_api::FxLifecycle::Running,
+            generation: 1,
+            deadline_misses: 0,
+            stale_completions: 0,
+            status_summary: None,
+            crash_summary: None,
+            logs: Arc::from([]),
+            editor: None,
+        });
         self.next_bus_id = next_bus_id;
         self.next_bus_channel_id = next_bus_channel_id;
         let mut channels = Vec::with_capacity(creation.channels.len());
@@ -5010,7 +5086,7 @@ impl ApplicationModel {
             bus_id,
             BusModel {
                 id: bus_id,
-                backend_id: creation.bus_id,
+                backend_id,
                 name: request.name,
                 structural_state: StructuralState::Creating,
                 structural_error: None,
@@ -5022,6 +5098,7 @@ impl ApplicationModel {
                 balance: 0.0,
                 muted: false,
                 output_peaks_db: vec![-200.0; request.channel_count as usize],
+                fx,
                 control_pending: false,
                 control_error: None,
             },
@@ -5480,11 +5557,29 @@ impl ApplicationModel {
             .buses
             .get_mut(&bus_id)
             .ok_or_else(|| format!("stale or unknown bus {bus_id}"))?;
+        if matches!(
+            action,
+            BusAction::FxActiveChanged(_)
+                | BusAction::FxVisibilityChanged(_)
+                | BusAction::FxToggleOrRecover
+                | BusAction::FxRestoreState(_)
+                | BusAction::FxClearLogs
+                | BusAction::BuiltInFx(_)
+        ) {
+            return self.handle_bus_fx_action(backend, bus_id, action);
+        }
         let requested = match action {
             BusAction::GainChanged(value) => BackendBusControl::GainDb(value),
             BusAction::BalanceChanged(value) => BackendBusControl::Balance(value),
             BusAction::MuteChanged(value) => BackendBusControl::Mute(value),
-            BusAction::Remove | BusAction::MoveBefore(_) => unreachable!(),
+            BusAction::Remove
+            | BusAction::MoveBefore(_)
+            | BusAction::FxActiveChanged(_)
+            | BusAction::FxVisibilityChanged(_)
+            | BusAction::FxToggleOrRecover
+            | BusAction::FxRestoreState(_)
+            | BusAction::FxClearLogs
+            | BusAction::BuiltInFx(_) => unreachable!(),
         };
         let control = match requested.normalized(bus.channels.len()) {
             Ok(control) => control,
@@ -5518,6 +5613,41 @@ impl ApplicationModel {
         bus.control_pending = true;
         bus.control_error = None;
         apply_bus_control(bus, control);
+        Ok(())
+    }
+
+    fn handle_bus_fx_action(
+        &mut self,
+        backend: &mut dyn Backend,
+        bus_id: BusId,
+        action: BusAction,
+    ) -> Result<(), String> {
+        let backend_id = self
+            .buses
+            .get(&bus_id)
+            .map(|bus| bus.backend_id)
+            .ok_or_else(|| format!("stale or unknown bus {bus_id}"))?;
+        let control = match action {
+            BusAction::FxActiveChanged(value) => BackendBusFxControl::SetActive(value),
+            BusAction::FxVisibilityChanged(value) => BackendBusFxControl::SetVisible(value),
+            BusAction::FxToggleOrRecover => BackendBusFxControl::ToggleOrRecover,
+            BusAction::FxRestoreState(state) => BackendBusFxControl::RestoreState(state),
+            BusAction::FxClearLogs => BackendBusFxControl::ClearLogs,
+            BusAction::BuiltInFx(control) => BackendBusFxControl::BuiltInFx(control),
+            _ => unreachable!(),
+        };
+        backend
+            .set_bus_fx_control(backend_id, control.clone())
+            .map_err(|error| format!("could not update bus FX {bus_id}: {error}"))?;
+        if let Some(key) = fx_control_key(&bus_fx_control_as_track(&control)) {
+            self.desired_bus_fx_controls
+                .insert((backend_id, key), control.clone());
+        }
+        let bus = self
+            .buses
+            .get_mut(&bus_id)
+            .ok_or_else(|| format!("stale or unknown bus {bus_id}"))?;
+        apply_bus_fx_control(bus, &control);
         Ok(())
     }
 
@@ -9695,6 +9825,7 @@ impl ApplicationModel {
                             balance: backend_bus.balance,
                             muted: backend_bus.muted,
                             output_peaks_db: backend_bus.output_peaks_db.clone(),
+                            fx: backend_bus.fx.clone(),
                             control_pending: false,
                             control_error: None,
                         },
@@ -9717,6 +9848,7 @@ impl ApplicationModel {
             bus.balance = backend_bus.balance;
             bus.muted = backend_bus.muted;
             bus.output_peaks_db.clone_from(&backend_bus.output_peaks_db);
+            bus.fx.clone_from(&backend_bus.fx);
             for backend_channel in &backend_bus.channels {
                 if let Some(channel) = bus
                     .channels
@@ -9816,6 +9948,12 @@ impl ApplicationModel {
                     !(matched && confirmed)
                 })
             });
+        self.desired_bus_fx_controls
+            .retain(|(backend_id, _), desired| {
+                !snapshot.buses.get(backend_id).is_some_and(|bus| {
+                    fx_control_matches(bus.fx.as_ref(), &bus_fx_control_as_track(desired))
+                })
+            });
         for ((backend_id, _), pending) in &self.desired_bus_controls {
             if let Some(bus) = self
                 .buses
@@ -9823,6 +9961,15 @@ impl ApplicationModel {
                 .find(|bus| bus.backend_id == *backend_id)
             {
                 apply_bus_control(bus, pending.desired);
+            }
+        }
+        for ((backend_id, _), desired) in &self.desired_bus_fx_controls {
+            if let Some(bus) = self
+                .buses
+                .values_mut()
+                .find(|bus| bus.backend_id == *backend_id)
+            {
+                apply_bus_fx_control(bus, desired);
             }
         }
         for bus in self.buses.values_mut() {
@@ -10734,7 +10881,33 @@ impl ApplicationModel {
                     name: bus.name.clone(),
                     channels,
                     ports,
-                    fx_chain: None,
+                    fx_chain: captured_bus
+                        .processor_type
+                        .as_ref()
+                        .map(|processor_type| {
+                            let chain_type = fx_chain_type_for_processor(
+                                &shoop_app_api::TrackProcessorTypeId::new(processor_type.clone()),
+                            )?;
+                            let internal_state =
+                                captured_bus.processor_state.clone().ok_or_else(|| {
+                                    format!("processed bus {} has no captured state", bus.id)
+                                })?;
+                            Ok::<_, String>(FxChainDocument {
+                                id: bus.id.raw(),
+                                title: bus.name.clone(),
+                                chain_type,
+                                ports: Vec::new(),
+                                internal_state,
+                                builtin_fx_midi_cc_assignments: captured_bus
+                                    .builtin_fx_midi_cc_assignments
+                                    .iter()
+                                    .copied()
+                                    .map(document_builtin_fx_midi_cc_assignment)
+                                    .collect(),
+                                midi_cc_assignments: Vec::new(),
+                            })
+                        })
+                        .transpose()?,
                     gain_db: captured_bus.gain_db,
                     balance: captured_bus.balance,
                     muted: captured_bus.muted,
@@ -11173,6 +11346,7 @@ impl ApplicationModel {
                     gain_db: bus_document.gain_db,
                     balance: bus_document.balance,
                     muted: bus_document.muted,
+                    fx: None,
                     control_pending: false,
                     control_error: None,
                 },
@@ -11212,6 +11386,7 @@ impl ApplicationModel {
         self.pending_mixer_routes.clear();
         self.mixer_route_errors.clear();
         self.desired_bus_controls.clear();
+        self.desired_bus_fx_controls.clear();
         self.desired_track_controls.clear();
         self.desired_track_default_playback_modes = self
             .tracks
@@ -11275,6 +11450,7 @@ impl ApplicationModel {
                 output_peaks_db: bus.output_peaks_db.clone().into(),
                 control_pending: bus.control_pending,
                 control_error: bus.control_error.clone(),
+                fx: bus.fx.clone(),
             })
             .collect::<Vec<_>>();
         if self.bus_view.as_ref() != next.as_slice() {
@@ -11335,6 +11511,7 @@ impl ApplicationModel {
                 .collect(),
             buses: Arc::clone(&self.bus_view),
             track_processors: Arc::clone(&self.track_processors),
+            bus_processors: Arc::clone(&self.bus_processors),
             track_creation_results: self
                 .track_creation_results
                 .iter()
@@ -12532,6 +12709,30 @@ fn validate_loaded_processor(
     Ok(())
 }
 
+fn validate_bus_processor(
+    processor: &shoop_app_api::TrackProcessorTypeId,
+    audio_channels: u32,
+    processors: &[TrackProcessorDescriptor],
+) -> Result<(), String> {
+    if processor.as_str() == shoop_app_api::TrackProcessorTypeId::OXISYNTH {
+        return Err("Built-in Synth is unavailable on buses".to_owned());
+    }
+    let descriptor = processors
+        .iter()
+        .find(|descriptor| descriptor.id == *processor)
+        .filter(|descriptor| descriptor.available)
+        .ok_or_else(|| format!("bus requires unavailable processor {processor}"))?;
+    if !descriptor
+        .constraints
+        .accepts(audio_channels, audio_channels, false)
+    {
+        return Err(format!(
+            "bus processor {processor} does not support its channel shape"
+        ));
+    }
+    Ok(())
+}
+
 fn session_script_sources(bundle: &SessionBundle) -> Result<Vec<SessionScriptSource>, String> {
     bundle
         .document
@@ -12636,16 +12837,10 @@ fn valid_global_fx_port_document(port: &PortDocument) -> bool {
 fn session_bundle_to_backend(
     bundle: &SessionBundle,
     processors: &[TrackProcessorDescriptor],
+    bus_processors: &[TrackProcessorDescriptor],
 ) -> Result<BackendSessionData, String> {
     shoop_session::validate_bundle(bundle).map_err(|error| error.to_string())?;
-    if !bundle.document.midi_control.bindings.is_empty()
-        || !bundle.document.settings.is_empty()
-        || bundle
-            .document
-            .buses
-            .iter()
-            .any(|bus| bus.fx_chain.is_some())
-    {
+    if !bundle.document.midi_control.bindings.is_empty() || !bundle.document.settings.is_empty() {
         return Err(
             "session requires a feature not yet available in the application runtime".to_owned(),
         );
@@ -12927,11 +13122,26 @@ fn session_bundle_to_backend(
         .buses
         .iter()
         .map(|bus| {
+            let audio_channels = u32::try_from(bus.channels.len())
+                .map_err(|_| "session bus channel count exceeds u32".to_owned())?;
+            let fx = match &bus.fx_chain {
+                None => None,
+                Some(chain) => {
+                    let processor = processor_for_fx_chain_type(chain.chain_type);
+                    validate_bus_processor(&processor, audio_channels, bus_processors)?;
+                    if !chain.midi_cc_assignments.is_empty() {
+                        return Err("session bus FX chain has unsupported assignments".to_owned());
+                    }
+                    Some(BackendBusFxRequest {
+                        processor_type: processor.as_str().to_owned(),
+                        audio_channels,
+                    })
+                }
+            };
             BackendBusRequest {
                 name: bus.name.clone(),
-                channel_count: u32::try_from(bus.channels.len())
-                    .map_err(|_| "session bus channel count exceeds u32".to_owned())?,
-                fx: None,
+                channel_count: audio_channels,
+                fx,
             }
             .normalized()
             .map_err(|error| error.to_string())?;
@@ -12992,9 +13202,22 @@ fn session_bundle_to_backend(
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
-                processor_type: None,
-                processor_state: None,
-                builtin_fx_midi_cc_assignments: Vec::new(),
+                processor_type: bus.fx_chain.as_ref().map(|chain| {
+                    processor_for_fx_chain_type(chain.chain_type)
+                        .as_str()
+                        .to_owned()
+                }),
+                processor_state: bus
+                    .fx_chain
+                    .as_ref()
+                    .map(|chain| chain.internal_state.clone()),
+                builtin_fx_midi_cc_assignments: bus
+                    .fx_chain
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|chain| chain.builtin_fx_midi_cc_assignments.iter().copied())
+                    .map(backend_builtin_fx_midi_cc_assignment)
+                    .collect(),
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
@@ -21067,6 +21290,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 name: "  Duplicate  ".to_owned(),
                 channel_count: 4,
                 creation_request_id: Some(42),
+                fx: None,
             }),
         );
         let added = *model.bus_order.last().unwrap();
@@ -21288,6 +21512,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                 name: "Timeout".to_owned(),
                 channel_count: 1,
                 creation_request_id: Some(77),
+                fx: None,
             }),
         );
         let pending = *model.bus_order.last().unwrap();
@@ -21584,6 +21809,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                     name: "Cue".to_owned(),
                     channel_count: 2,
                     creation_request_id: None,
+                    fx: None,
                 },
             )
             .unwrap();
@@ -22131,6 +22357,7 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
                     name: name.to_owned(),
                     channel_count: channels,
                     creation_request_id: Some(request_id),
+                    fx: None,
                 }))
                 .unwrap();
             runtime.tick(Duration::ZERO);
@@ -23206,23 +23433,23 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         let mut aliased_master = saved.clone();
         aliased_master.document.buses[0].channels[1].output_port_id =
             aliased_master.document.buses[0].channels[0].output_port_id;
-        assert!(session_bundle_to_backend(&aliased_master, &[])
+        assert!(session_bundle_to_backend(&aliased_master, &[], &[])
             .unwrap_err()
             .contains("share one output port"));
         let mut noncanonical_master = saved.clone();
         noncanonical_master.document.buses[0].ports[0].gain = 0.5;
-        assert!(session_bundle_to_backend(&noncanonical_master, &[])
+        assert!(session_bundle_to_backend(&noncanonical_master, &[], &[])
             .unwrap_err()
             .contains("not canonical"));
         let mut invalid_controls = saved.clone();
         invalid_controls.document.buses[0].gain_db = 100.0;
-        assert!(session_bundle_to_backend(&invalid_controls, &[])
+        assert!(session_bundle_to_backend(&invalid_controls, &[], &[])
             .unwrap_err()
             .contains("bus gain"));
         let mut colliding_global = saved.clone();
         colliding_global.document.global_ports[0].id =
             colliding_global.document.buses[0].ports[0].id;
-        assert!(session_bundle_to_backend(&colliding_global, &[])
+        assert!(session_bundle_to_backend(&colliding_global, &[], &[])
             .unwrap_err()
             .contains("duplicate port ID"));
 

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -21434,6 +21434,53 @@ c.register_one_shot_timer_cb(1, function() d.open('Other') end)
         model
             .handle_bus_action(&mut backend, added, BusAction::Remove)
             .unwrap();
+
+        // Bus FX intents drive the backend and reconcile optimistically.
+        let mut fx_backend = FakeBackend::default();
+        let mut fx_bus_model = ApplicationModel::initialize(
+            &mut fx_backend,
+            Arc::new(Mutex::new(VecDeque::new())),
+            Arc::new(Mutex::new(VecDeque::new())),
+            false,
+            true,
+        )
+        .unwrap();
+        // FakeBackend mirrors the track catalog as the bus catalog for tests.
+        let mut bus_descriptor = shoop_backend::builtin_fx_descriptor();
+        bus_descriptor.constraints.midi = shoop_app_api::TrackProcessorMidiPolicy::Unsupported;
+        fx_bus_model.bus_processors = std::sync::Arc::from([bus_descriptor]);
+        fx_bus_model
+            .add_bus(
+                &mut fx_backend,
+                BusSpec {
+                    name: "Fx".to_owned(),
+                    channel_count: 2,
+                    creation_request_id: None,
+                    fx: Some(shoop_app_api::BusFxSpec {
+                        processor_type: shoop_app_api::TrackProcessorTypeId::new(
+                            shoop_app_api::TrackProcessorTypeId::BUILTIN_FX,
+                        ),
+                    }),
+                },
+            )
+            .unwrap();
+        let fx_bus = *fx_bus_model.bus_order.last().unwrap();
+        assert!(fx_bus_model.buses[&fx_bus].fx.is_some());
+        fx_bus_model
+            .handle_bus_action(&mut fx_backend, fx_bus, BusAction::FxActiveChanged(false))
+            .unwrap();
+        assert!(!fx_bus_model.buses[&fx_bus].fx.as_ref().unwrap().active);
+        fx_bus_model
+            .handle_bus_action(
+                &mut fx_backend,
+                fx_bus,
+                BusAction::FxVisibilityChanged(true),
+            )
+            .unwrap();
+        assert!(fx_bus_model.buses[&fx_bus].fx.as_ref().unwrap().visible);
+        fx_bus_model.apply_backend_snapshot(fx_backend.poll().unwrap());
+        assert!(!fx_bus_model.buses[&fx_bus].fx.as_ref().unwrap().active);
+        assert!(fx_bus_model.buses[&fx_bus].fx.as_ref().unwrap().visible);
         assert_eq!(
             model.buses[&added].structural_state,
             StructuralState::Removing

--- a/src/rust/shoop_app/src/lib.rs
+++ b/src/rust/shoop_app/src/lib.rs
@@ -4935,6 +4935,7 @@ impl ApplicationModel {
         let request = BackendBusRequest {
             name: spec.name,
             channel_count: spec.channel_count,
+            fx: None,
         }
         .normalized()
         .map_err(|error| format!("invalid bus: {error}"))?;
@@ -9135,6 +9136,7 @@ impl ApplicationModel {
                         }
                     }
                 }
+                Some(BackendMutationDetail::BusFxControl(_)) => {}
                 None => {}
             }
             self.report_error(format!(
@@ -12929,6 +12931,7 @@ fn session_bundle_to_backend(
                 name: bus.name.clone(),
                 channel_count: u32::try_from(bus.channels.len())
                     .map_err(|_| "session bus channel count exceeds u32".to_owned())?,
+                fx: None,
             }
             .normalized()
             .map_err(|error| error.to_string())?;
@@ -12989,6 +12992,9 @@ fn session_bundle_to_backend(
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
+                processor_type: None,
+                processor_state: None,
+                builtin_fx_midi_cc_assignments: Vec::new(),
             })
         })
         .collect::<Result<Vec<_>, String>>()?;

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -2485,6 +2485,7 @@ mod tests {
             output_peaks_db: Arc::from([-200.0]),
             control_pending: false,
             control_error: None,
+            fx: None,
         };
         assert!(!state.stereo());
         state.channels = Arc::from([channel(1), channel(2)]);

--- a/src/rust/shoop_app_api/src/lib.rs
+++ b/src/rust/shoop_app_api/src/lib.rs
@@ -1084,6 +1084,7 @@ pub struct BusState {
     pub output_peaks_db: Arc<[f32]>,
     pub control_pending: bool,
     pub control_error: Option<String>,
+    pub fx: Option<TrackFxState>,
 }
 
 impl BusState {
@@ -1651,7 +1652,13 @@ pub struct BusCreationResult {
 pub struct BusSpec {
     pub name: String,
     pub channel_count: u32,
+    pub fx: Option<BusFxSpec>,
     pub creation_request_id: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BusFxSpec {
+    pub processor_type: TrackProcessorTypeId,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1660,6 +1667,7 @@ pub struct AppSnapshot {
     pub tracks: Vec<TrackState>,
     pub buses: Arc<[BusState]>,
     pub track_processors: Arc<[TrackProcessorDescriptor]>,
+    pub bus_processors: Arc<[TrackProcessorDescriptor]>,
     pub track_creation_results: Arc<[TrackCreationResult]>,
     pub bus_creation_results: Arc<[BusCreationResult]>,
     pub global_controls: GlobalControlState,
@@ -1965,13 +1973,19 @@ pub enum TrackAction {
 
 pub type TrackWidgetAction = TrackAction;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BusAction {
     Remove,
     MoveBefore(Option<BusId>),
     GainChanged(f32),
     BalanceChanged(f32),
     MuteChanged(bool),
+    FxActiveChanged(bool),
+    FxVisibilityChanged(bool),
+    FxToggleOrRecover,
+    FxRestoreState(String),
+    FxClearLogs,
+    BuiltInFx(BuiltInFxControl),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2335,6 +2349,12 @@ impl BusAction {
             Self::GainChanged(_) => "bus.gain",
             Self::BalanceChanged(_) => "bus.balance",
             Self::MuteChanged(_) => "bus.mute",
+            Self::FxActiveChanged(_) => "bus.fx_active",
+            Self::FxVisibilityChanged(_) => "bus.fx_visibility",
+            Self::FxToggleOrRecover => "bus.fx_toggle_or_recover",
+            Self::FxRestoreState(_) => "bus.fx_restore_state",
+            Self::FxClearLogs => "bus.fx_clear_logs",
+            Self::BuiltInFx(control) => control.kind(),
         }
     }
 }

--- a/src/rust/shoop_audio_protocol/src/lib.rs
+++ b/src/rust/shoop_audio_protocol/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u16 = 25;
+pub const PROTOCOL_VERSION: u16 = 26;
 pub const COMMAND_CAPACITY: usize = 256;
 pub const COMMAND_MAX_BYTES: usize = 64 * 1024;
 pub const SESSION_TRANSFER_CHUNK_BYTES: usize = 32 * 1024;
@@ -125,6 +125,8 @@ pub enum Command {
         expected_output_port_ids: Vec<u64>,
         name: String,
         channel_count: u32,
+        #[serde(default)]
+        fx: Option<WireBusFxRequest>,
     },
     RemoveBus {
         bus_id: u64,
@@ -132,6 +134,10 @@ pub enum Command {
     SetBusControl {
         bus_id: u64,
         control: WireBusControl,
+    },
+    SetBusFxControl {
+        bus_id: u64,
+        control: WireTrackFxControl,
     },
     SetTrackDefaultPlaybackMode {
         track_id: u64,
@@ -307,6 +313,21 @@ impl Command {
                 },
             ) => {
                 existing_track == replacement_track
+                    && existing_control.supersedable_parameter()
+                        == replacement_control.supersedable_parameter()
+                    && replacement_control.supersedable_parameter().is_some()
+            }
+            (
+                Self::SetBusFxControl {
+                    bus_id: existing_bus,
+                    control: existing_control,
+                },
+                Self::SetBusFxControl {
+                    bus_id: replacement_bus,
+                    control: replacement_control,
+                },
+            ) => {
+                existing_bus == replacement_bus
                     && existing_control.supersedable_parameter()
                         == replacement_control.supersedable_parameter()
                     && replacement_control.supersedable_parameter().is_some()
@@ -727,6 +748,12 @@ pub struct WireConnectionFailure {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WireBusFxRequest {
+    pub processor_type: String,
+    pub audio_channels: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct WireBus {
     pub id: u64,
     pub name: String,
@@ -735,6 +762,8 @@ pub struct WireBus {
     pub balance: f32,
     pub muted: bool,
     pub output_peaks_db: Vec<f32>,
+    #[serde(default)]
+    pub fx: Option<WireTrackFxState>,
 }
 
 #[derive(Clone, Debug, Eq, Serialize, Deserialize, PartialEq)]
@@ -1424,6 +1453,10 @@ mod tests {
             expected_output_port_ids: vec![21, 22, 23, 24],
             name: "Surround".to_owned(),
             channel_count: 4,
+            fx: Some(WireBusFxRequest {
+                processor_type: "builtin_fx".to_owned(),
+                audio_channels: 4,
+            }),
         };
         let remove = Command::RemoveBus { bus_id: 7 };
         for (sequence, command) in [(1, create.clone()), (2, remove.clone())] {
@@ -1441,6 +1474,62 @@ mod tests {
             bus_id: 7,
             control: WireBusControl::Mute(true),
         }));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_commands_round_trip_with_stable_identity_and_values() {
+        let create = Command::CreateBus {
+            expected_bus_id: 7,
+            expected_channel_ids: vec![11, 12],
+            expected_output_port_ids: vec![21, 22],
+            name: "Fx".to_owned(),
+            channel_count: 2,
+            fx: Some(WireBusFxRequest {
+                processor_type: "builtin_fx".to_owned(),
+                audio_channels: 2,
+            }),
+        };
+        let control = Command::SetBusFxControl {
+            bus_id: 7,
+            control: WireTrackFxControl::BuiltInSetStageEnabled(WireBuiltInFxStage::Drive, true),
+        };
+        for (sequence, command) in [(1, create), (2, control)] {
+            let envelope = CommandEnvelope::new(sequence, command);
+            let encoded = serde_json::to_vec(&envelope).unwrap();
+            assert_eq!(
+                serde_json::from_slice::<CommandEnvelope>(&encoded).unwrap(),
+                envelope
+            );
+            assert!(encoded.len() <= COMMAND_MAX_BYTES);
+        }
+        let plain = Command::CreateBus {
+            expected_bus_id: 7,
+            expected_channel_ids: vec![11, 12],
+            expected_output_port_ids: vec![21, 22],
+            name: "Fx".to_owned(),
+            channel_count: 2,
+            fx: None,
+        };
+        let encoded = serde_json::to_vec(&CommandEnvelope::new(3, plain)).unwrap();
+        assert!(encoded.len() <= COMMAND_MAX_BYTES);
+        let legacy = serde_json::json!({
+            "version": PROTOCOL_VERSION,
+            "sequence": 4,
+            "command": {
+                "kind": "create_bus",
+                "expected_bus_id": 7,
+                "expected_channel_ids": [11, 12],
+                "expected_output_port_ids": [21, 22],
+                "name": "Fx",
+                "channel_count": 2
+            }
+        });
+        assert!(matches!(
+            serde_json::from_value::<CommandEnvelope>(legacy)
+                .unwrap()
+                .command,
+            Command::CreateBus { fx: None, .. }
+        ));
     }
 
     #[shoop_wasm_test_support::shoop_test]
@@ -1578,7 +1667,7 @@ mod tests {
         let command = serde_json::to_string(&CommandEnvelope::new(17, Command::Poll)).unwrap();
         assert_eq!(
             command,
-            r#"{"version":25,"sequence":17,"command":{"kind":"poll"}}"#
+            r#"{"version":26,"sequence":17,"command":{"kind":"poll"}}"#
         );
 
         let event = serde_json::to_string(&EventEnvelope {
@@ -1589,7 +1678,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             event,
-            r#"{"version":25,"sequence":17,"event":{"kind":"ack"}}"#
+            r#"{"version":26,"sequence":17,"event":{"kind":"ack"}}"#
         );
     }
 

--- a/src/rust/shoop_audio_worklet/Cargo.toml
+++ b/src/rust/shoop_audio_worklet/Cargo.toml
@@ -15,6 +15,7 @@ wasm-test-browser = ["shoop_wasm_test_support/wasm-test-browser"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+shoop_app_api = { path = "../shoop_app_api" }
 shoop_audio_protocol = { path = "../shoop_audio_protocol" }
 shoop_backend = { path = "../shoop_backend" }
 shoop_tracing = { workspace = true, default-features = false }

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(all(test, target_arch = "wasm32", feature = "wasm-test-browser"))]
 shoop_wasm_test_support::wasm_bindgen_test_configure!(run_in_browser);
 
+use shoop_app_api::{TrackFxState, TrackProcessorEditorState, TrackProcessorTypeId};
 #[cfg(test)]
 use shoop_audio_protocol::WireMidiEvent;
 use shoop_audio_protocol::{
@@ -8,31 +9,31 @@ use shoop_audio_protocol::{
     WaveformChunk, WireActiveCompositeChild, WireApplicationPort, WireApplicationPortOwner,
     WireBuiltInFxDriveType, WireBuiltInFxMidiCcAssignment, WireBuiltInFxModulationType,
     WireBuiltInFxParameter, WireBuiltInFxReverbType, WireBuiltInFxStage, WireBuiltInFxState,
-    WireBus, WireBusChannel, WireBusControl, WireChannelMode, WireCompositeConfig,
-    WireCompositeKind, WireCompositeState, WireCompositeTarget, WireConfirmedLink,
-    WireConnectionFailure, WireDefaultPlaybackMode, WireHostPort, WireLatestMidiMessage,
-    WireLoopMode, WireLoopState, WireMidiOutputEvent, WireMixerFailure, WireMixerLink,
-    WireOxiSynthMidiCcAssignment, WireOxiSynthParameter, WireOxiSynthState, WirePortDataType,
-    WirePortDirection, WirePortRole, WireProcessorLatencyAdjustment, WireRecordingOffsetAdjustment,
-    WireSnapshot, WireTrackControl, WireTrackFxControl, WireTrackFxState, WireTrackLatencyState,
-    WireTrackState, WireTrackTopology, COMMAND_MAX_BYTES, MAX_DEVICE_AUDIO_CHANNELS,
-    MIDI_BATCH_CAPACITY, MIDI_DETAIL_CHUNK_EVENTS, PROTOCOL_VERSION, SESSION_TRANSFER_CHUNK_BYTES,
-    SESSION_TRANSFER_MAX_BYTES, TRACK_MIDI_MESSAGE_BYTES, WAVEFORM_CHUNK_SAMPLES,
+    WireBus, WireBusChannel, WireBusControl, WireBusFxRequest, WireChannelMode,
+    WireCompositeConfig, WireCompositeKind, WireCompositeState, WireCompositeTarget,
+    WireConfirmedLink, WireConnectionFailure, WireDefaultPlaybackMode, WireHostPort,
+    WireLatestMidiMessage, WireLoopMode, WireLoopState, WireMidiOutputEvent, WireMixerFailure,
+    WireMixerLink, WireOxiSynthMidiCcAssignment, WireOxiSynthParameter, WireOxiSynthState,
+    WirePortDataType, WirePortDirection, WirePortRole, WireProcessorLatencyAdjustment,
+    WireRecordingOffsetAdjustment, WireSnapshot, WireTrackControl, WireTrackFxControl,
+    WireTrackFxState, WireTrackLatencyState, WireTrackState, WireTrackTopology, COMMAND_MAX_BYTES,
+    MAX_DEVICE_AUDIO_CHANNELS, MIDI_BATCH_CAPACITY, MIDI_DETAIL_CHUNK_EVENTS, PROTOCOL_VERSION,
+    SESSION_TRANSFER_CHUNK_BYTES, SESSION_TRANSFER_MAX_BYTES, TRACK_MIDI_MESSAGE_BYTES,
+    WAVEFORM_CHUNK_SAMPLES,
 };
 #[cfg(test)]
 use shoop_backend::BuiltInFxState;
 use shoop_backend::{
-    Backend, BackendBusChannelId, BackendBusControl, BackendBusId, BackendBusRequest,
-    BackendCompositeConfig, BackendCompositeEntry, BackendCompositeId, BackendCompositeKind,
-    BackendCompositeTarget, BackendDefaultPlaybackMode, BackendGrabRequest,
-    BackendHostPortDescriptor, BackendLoopContentUpdate, BackendLoopId, BackendLoopMode,
-    BackendMidiEvent, BackendPortDataType, BackendPortDirection, BackendPortId, BackendPortOwner,
-    BackendPortRole, BackendSessionData, BackendSnapshot, BackendTrackControl,
+    Backend, BackendBusChannelId, BackendBusControl, BackendBusFxControl, BackendBusFxRequest,
+    BackendBusId, BackendBusRequest, BackendCompositeConfig, BackendCompositeEntry,
+    BackendCompositeId, BackendCompositeKind, BackendCompositeTarget, BackendDefaultPlaybackMode,
+    BackendGrabRequest, BackendHostPortDescriptor, BackendLoopContentUpdate, BackendLoopId,
+    BackendLoopMode, BackendMidiEvent, BackendPortDataType, BackendPortDirection, BackendPortId,
+    BackendPortOwner, BackendPortRole, BackendSessionData, BackendSnapshot, BackendTrackControl,
     BackendTrackFxControl, BackendTrackId, BackendTrackTopology, BuiltInFxControl,
     BuiltInFxDriveType, BuiltInFxMidiCcAssignment, BuiltInFxModulationType, BuiltInFxParameter,
     BuiltInFxReverbType, BuiltInFxStage, EngineBackend, OxiSynthControl, OxiSynthMidiCcAssignment,
-    OxiSynthParameter, TrackProcessorEditorState, TrackProcessorTypeId, TrackRequest,
-    MAX_WEB_AUDIO_QUANTUM,
+    OxiSynthParameter, TrackRequest, MAX_WEB_AUDIO_QUANTUM,
 };
 
 pub struct WorkletHost {
@@ -504,13 +505,17 @@ impl WorkletHost {
                 expected_output_port_ids,
                 name,
                 channel_count,
+                fx,
             } => {
                 let created = self
                     .backend
                     .create_bus(BackendBusRequest {
                         name,
                         channel_count,
-                        fx: None,
+                        fx: fx.map(|request: WireBusFxRequest| BackendBusFxRequest {
+                            processor_type: request.processor_type,
+                            audio_channels: request.audio_channels,
+                        }),
                     })
                     .map_err(|error| error.to_string())?;
                 let actual_channel_ids = created
@@ -543,6 +548,15 @@ impl WorkletHost {
                     .set_bus_control(
                         BackendBusId::from_raw(bus_id),
                         from_wire_bus_control(control),
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(Event::Ack)
+            }
+            Command::SetBusFxControl { bus_id, control } => {
+                self.backend
+                    .set_bus_fx_control(
+                        BackendBusId::from_raw(bus_id),
+                        from_wire_bus_fx_control(control),
                     )
                     .map_err(|error| error.to_string())?;
                 Ok(Event::Ack)
@@ -1294,6 +1308,56 @@ fn from_wire_track_fx_control(control: WireTrackFxControl) -> BackendTrackFxCont
     }
 }
 
+fn from_wire_bus_fx_control(control: WireTrackFxControl) -> BackendBusFxControl {
+    match control {
+        WireTrackFxControl::SetActive(value) => BackendBusFxControl::SetActive(value),
+        WireTrackFxControl::SetVisible(value) => BackendBusFxControl::SetVisible(value),
+        WireTrackFxControl::ToggleOrRecover => BackendBusFxControl::ToggleOrRecover,
+        WireTrackFxControl::RestoreState(value) => BackendBusFxControl::RestoreState(value),
+        WireTrackFxControl::ClearLogs => BackendBusFxControl::ClearLogs,
+        WireTrackFxControl::BuiltInSetStageEnabled(stage, enabled) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                from_wire_builtin_fx_stage(stage),
+                enabled,
+            ))
+        }
+        WireTrackFxControl::BuiltInSetDriveType(drive_type) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::SetDriveType(from_wire_builtin_fx_drive_type(drive_type)),
+        ),
+        WireTrackFxControl::BuiltInSetModulationType(modulation_type) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetModulationType(
+                from_wire_builtin_fx_modulation_type(modulation_type),
+            ))
+        }
+        WireTrackFxControl::BuiltInSetReverbType(reverb_type) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::SetReverbType(from_wire_builtin_fx_reverb_type(reverb_type)),
+        ),
+        WireTrackFxControl::BuiltInSetParameter(parameter, value) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetParameter(
+                from_wire_builtin_fx_parameter(parameter),
+                value,
+            ))
+        }
+        WireTrackFxControl::BuiltInAssignMidiCc(assignment) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::AssignMidiCc(BuiltInFxMidiCcAssignment {
+                parameter: from_wire_builtin_fx_parameter(assignment.parameter),
+                channel: assignment.channel,
+                controller: assignment.controller,
+            }),
+        ),
+        WireTrackFxControl::BuiltInRemoveMidiCc(parameter) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::RemoveMidiCc(from_wire_builtin_fx_parameter(parameter)),
+        ),
+        WireTrackFxControl::BuiltInClearMidiCcAssignments => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::ClearMidiCcAssignments)
+        }
+        WireTrackFxControl::BuiltInSetReverbEnabled(value) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetReverbEnabled(value))
+        }
+        control => panic!("unsupported bus FX control: {control:?}"),
+    }
+}
+
 fn from_wire_loop_mode(mode: WireLoopMode) -> BackendLoopMode {
     match mode {
         WireLoopMode::Unknown => BackendLoopMode::Unknown,
@@ -1342,6 +1406,90 @@ fn from_wire_composite_config(config: WireCompositeConfig) -> BackendCompositeCo
                     .collect()
             })
             .collect(),
+    }
+}
+
+fn to_wire_track_fx_state(fx: TrackFxState) -> Option<WireTrackFxState> {
+    let editor = fx.editor?;
+    to_wire_fx_state(&fx.processor_type, fx.active, fx.visible, editor)
+}
+
+fn to_wire_fx_state(
+    processor_type: &TrackProcessorTypeId,
+    active: bool,
+    visible: bool,
+    editor: TrackProcessorEditorState,
+) -> Option<WireTrackFxState> {
+    match editor {
+        TrackProcessorEditorState::BuiltInFx(editor) => Some(WireTrackFxState {
+            processor_type: processor_type.as_str().to_owned(),
+            active,
+            visible,
+            builtin_fx: Some(WireBuiltInFxState {
+                compressor_enabled: editor.compressor_enabled,
+                compressor_threshold_db: editor.compressor_threshold_db,
+                compressor_ratio: editor.compressor_ratio,
+                compressor_attack_ms: editor.compressor_attack_ms,
+                compressor_release_ms: editor.compressor_release_ms,
+                compressor_makeup_db: editor.compressor_makeup_db,
+                drive_enabled: editor.drive_enabled,
+                drive_type: to_wire_builtin_fx_drive_type(editor.drive_type),
+                drive_db: editor.drive_db,
+                drive_tone: editor.drive_tone,
+                drive_mix: editor.drive_mix,
+                drive_output_db: editor.drive_output_db,
+                eq_enabled: editor.eq_enabled,
+                eq_low_db: editor.eq_low_db,
+                eq_mid_db: editor.eq_mid_db,
+                eq_high_db: editor.eq_high_db,
+                chorus_enabled: editor.chorus_enabled,
+                chorus_rate_hz: editor.chorus_rate_hz,
+                chorus_depth: editor.chorus_depth,
+                chorus_mix: editor.chorus_mix,
+                chorus_width: editor.chorus_width,
+                modulation_enabled: editor.modulation_enabled,
+                modulation_type: to_wire_builtin_fx_modulation_type(editor.modulation_type),
+                modulation_rate_hz: editor.modulation_rate_hz,
+                modulation_depth: editor.modulation_depth,
+                modulation_mix: editor.modulation_mix,
+                modulation_feedback: editor.modulation_feedback,
+                modulation_spread: editor.modulation_spread,
+                reverb_enabled: editor.reverb_enabled,
+                reverb_type: to_wire_builtin_fx_reverb_type(editor.reverb_type),
+                reverb_amount: editor.reverb_amount,
+                reverb_tone: editor.reverb_tone,
+                midi_cc_assignments: editor
+                    .midi_cc_assignments
+                    .iter()
+                    .map(|assignment| WireBuiltInFxMidiCcAssignment {
+                        parameter: to_wire_builtin_fx_parameter(assignment.parameter),
+                        channel: assignment.channel,
+                        controller: assignment.controller,
+                    })
+                    .collect(),
+            }),
+            oxisynth: None,
+        }),
+        TrackProcessorEditorState::OxiSynth(editor) => Some(WireTrackFxState {
+            processor_type: processor_type.as_str().to_owned(),
+            active,
+            visible,
+            builtin_fx: None,
+            oxisynth: Some(WireOxiSynthState {
+                selected_preset_id: editor.selected_preset_id,
+                reverb_send: editor.reverb_send,
+                chorus_send: editor.chorus_send,
+                midi_cc_assignments: editor
+                    .midi_cc_assignments
+                    .iter()
+                    .map(|assignment| WireOxiSynthMidiCcAssignment {
+                        parameter: to_wire_oxisynth_parameter(assignment.parameter),
+                        channel: assignment.channel,
+                        controller: assignment.controller,
+                    })
+                    .collect(),
+            }),
+        }),
     }
 }
 
@@ -1504,6 +1652,7 @@ fn to_wire_snapshot(snapshot: BackendSnapshot) -> WireSnapshot {
             balance: bus.balance,
             muted: bus.muted,
             output_peaks_db: bus.output_peaks_db,
+            fx: bus.fx.and_then(to_wire_track_fx_state),
         })
         .collect();
     let confirmed_mixer_links = snapshot
@@ -1555,79 +1704,7 @@ fn to_wire_snapshot(snapshot: BackendSnapshot) -> WireSnapshot {
                         WireDefaultPlaybackMode::DryThroughWet
                     }
                 },
-                fx: track.fx.and_then(|fx| match fx.editor? {
-                    TrackProcessorEditorState::BuiltInFx(editor) => Some(WireTrackFxState {
-                        processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
-                        active: fx.active,
-                        visible: fx.visible,
-                        builtin_fx: Some(WireBuiltInFxState {
-                            compressor_enabled: editor.compressor_enabled,
-                            compressor_threshold_db: editor.compressor_threshold_db,
-                            compressor_ratio: editor.compressor_ratio,
-                            compressor_attack_ms: editor.compressor_attack_ms,
-                            compressor_release_ms: editor.compressor_release_ms,
-                            compressor_makeup_db: editor.compressor_makeup_db,
-                            drive_enabled: editor.drive_enabled,
-                            drive_type: to_wire_builtin_fx_drive_type(editor.drive_type),
-                            drive_db: editor.drive_db,
-                            drive_tone: editor.drive_tone,
-                            drive_mix: editor.drive_mix,
-                            drive_output_db: editor.drive_output_db,
-                            eq_enabled: editor.eq_enabled,
-                            eq_low_db: editor.eq_low_db,
-                            eq_mid_db: editor.eq_mid_db,
-                            eq_high_db: editor.eq_high_db,
-                            chorus_enabled: editor.chorus_enabled,
-                            chorus_rate_hz: editor.chorus_rate_hz,
-                            chorus_depth: editor.chorus_depth,
-                            chorus_mix: editor.chorus_mix,
-                            chorus_width: editor.chorus_width,
-                            modulation_enabled: editor.modulation_enabled,
-                            modulation_type: to_wire_builtin_fx_modulation_type(
-                                editor.modulation_type,
-                            ),
-                            modulation_rate_hz: editor.modulation_rate_hz,
-                            modulation_depth: editor.modulation_depth,
-                            modulation_mix: editor.modulation_mix,
-                            modulation_feedback: editor.modulation_feedback,
-                            modulation_spread: editor.modulation_spread,
-                            reverb_enabled: editor.reverb_enabled,
-                            reverb_type: to_wire_builtin_fx_reverb_type(editor.reverb_type),
-                            reverb_amount: editor.reverb_amount,
-                            reverb_tone: editor.reverb_tone,
-                            midi_cc_assignments: editor
-                                .midi_cc_assignments
-                                .iter()
-                                .map(|assignment| WireBuiltInFxMidiCcAssignment {
-                                    parameter: to_wire_builtin_fx_parameter(assignment.parameter),
-                                    channel: assignment.channel,
-                                    controller: assignment.controller,
-                                })
-                                .collect(),
-                        }),
-                        oxisynth: None,
-                    }),
-                    TrackProcessorEditorState::OxiSynth(editor) => Some(WireTrackFxState {
-                        processor_type: TrackProcessorTypeId::OXISYNTH.to_owned(),
-                        active: fx.active,
-                        visible: fx.visible,
-                        builtin_fx: None,
-                        oxisynth: Some(WireOxiSynthState {
-                            selected_preset_id: editor.selected_preset_id,
-                            reverb_send: editor.reverb_send,
-                            chorus_send: editor.chorus_send,
-                            midi_cc_assignments: editor
-                                .midi_cc_assignments
-                                .iter()
-                                .map(|assignment| WireOxiSynthMidiCcAssignment {
-                                    parameter: to_wire_oxisynth_parameter(assignment.parameter),
-                                    channel: assignment.channel,
-                                    controller: assignment.controller,
-                                })
-                                .collect(),
-                        }),
-                    }),
-                }),
+                fx: track.fx.and_then(to_wire_track_fx_state),
                 audio_channels: track.audio_channels,
                 midi: track.midi,
                 output_gain_db: track.output_gain_db,
@@ -3408,6 +3485,7 @@ mod tests {
                     expected_output_port_ids: vec![1, 2, 3, 4],
                     name: "Surround".to_owned(),
                     channel_count: 4,
+                    fx: None,
                 },
             )
             .event,
@@ -4371,6 +4449,46 @@ mod tests {
             ));
             sequence += 1;
         }
+        assert!(matches!(
+            command(
+                &mut host,
+                sequence,
+                Command::CreateBus {
+                    expected_bus_id: 2,
+                    expected_channel_ids: vec![3, 4],
+                    expected_output_port_ids: vec![16, 17],
+                    name: "Fx".to_owned(),
+                    channel_count: 2,
+                    fx: Some(WireBusFxRequest {
+                        processor_type: "builtin_fx".to_owned(),
+                        audio_channels: 2,
+                    }),
+                },
+            )
+            .event,
+            Event::Ack
+        ));
+        sequence += 1;
+        assert!(matches!(
+            command(
+                &mut host,
+                sequence,
+                Command::SetBusFxControl {
+                    bus_id: 2,
+                    control: WireTrackFxControl::SetActive(true),
+                },
+            )
+            .event,
+            Event::Ack
+        ));
+        sequence += 1;
+        let Event::Snapshot(snapshot) = command(&mut host, sequence, Command::Poll).event else {
+            panic!("expected snapshot")
+        };
+        sequence += 1;
+        let fx_bus = snapshot.buses.iter().find(|bus| bus.id == 2).unwrap();
+        assert_eq!(fx_bus.fx.as_ref().unwrap().processor_type, "builtin_fx");
+        assert!(fx_bus.fx.as_ref().unwrap().builtin_fx.is_some());
         let Event::SessionCaptureReady { total_bytes, .. } = command(
             &mut host,
             sequence,

--- a/src/rust/shoop_audio_worklet/src/lib.rs
+++ b/src/rust/shoop_audio_worklet/src/lib.rs
@@ -510,6 +510,7 @@ impl WorkletHost {
                     .create_bus(BackendBusRequest {
                         name,
                         channel_count,
+                        fx: None,
                     })
                     .map_err(|error| error.to_string())?;
                 let actual_channel_ids = created

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -10673,8 +10673,14 @@ impl Backend for FakeBackend {
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
-                processor_type: None,
-                processor_state: None,
+                processor_type: bus
+                    .fx
+                    .as_ref()
+                    .map(|fx| fx.processor_type.as_str().to_owned()),
+                processor_state: bus
+                    .fx
+                    .as_ref()
+                    .map(|_| self.default_fx_state_string.clone()),
                 builtin_fx_midi_cc_assignments: Vec::new(),
             })
             .collect();
@@ -10773,7 +10779,14 @@ impl Backend for FakeBackend {
                 name: source_bus.name.clone(),
                 channel_count: u32::try_from(source_bus.channels.len())
                     .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
-                fx: None,
+                fx: source_bus
+                    .processor_type
+                    .clone()
+                    .map(|processor_type| BackendBusFxRequest {
+                        processor_type,
+                        audio_channels: u32::try_from(source_bus.channels.len())
+                            .unwrap_or(u32::MAX),
+                    }),
             }
             .normalized()?;
             let expected_labels = default_bus_channel_labels(source_bus.channels.len())?;
@@ -11233,6 +11246,19 @@ impl Backend for FakeBackend {
             bus_id,
             channels: channels.clone(),
         };
+        let fx = request.fx.as_ref().map(|fx| TrackFxState {
+            processor_type: TrackProcessorTypeId::new(fx.processor_type.clone()),
+            active: true,
+            visible: false,
+            lifecycle: FxLifecycle::Running,
+            generation: 1,
+            deadline_misses: 0,
+            stale_completions: 0,
+            status_summary: None,
+            crash_summary: None,
+            logs: Arc::from([]),
+            editor: None,
+        });
         self.mixer.buses.insert(
             bus_id,
             BackendBusState {
@@ -11243,7 +11269,7 @@ impl Backend for FakeBackend {
                 balance: 0.0,
                 muted: false,
                 output_peaks_db: vec![-200.0; channel_count],
-                fx: None,
+                fx,
             },
         );
         self.mixer.revision = self.mixer.revision.wrapping_add(1);
@@ -11311,6 +11337,59 @@ impl Backend for FakeBackend {
         self.operations
             .push(FakeOperation::SetBusControl(bus_id, control));
         Ok(())
+    }
+
+    fn set_bus_fx_control(
+        &mut self,
+        bus_id: BackendBusId,
+        control: BackendBusFxControl,
+    ) -> Result<()> {
+        let fx = self
+            .mixer
+            .buses
+            .get_mut(&bus_id)
+            .ok_or_else(|| anyhow!("unknown fake bus {bus_id:?}"))?
+            .fx
+            .as_mut()
+            .ok_or_else(|| anyhow!("bus has no processor"))?;
+        if self.fail_fx_state_restore && matches!(control, BackendBusFxControl::RestoreState(_)) {
+            return Err(anyhow!("injected processor state restore failure"));
+        }
+        match control {
+            BackendBusFxControl::SetActive(active) => fx.active = active,
+            BackendBusFxControl::SetVisible(visible) => fx.visible = visible,
+            BackendBusFxControl::ToggleOrRecover => {
+                if matches!(
+                    fx.lifecycle,
+                    FxLifecycle::Crashed | FxLifecycle::Unavailable
+                ) {
+                    fx.lifecycle = FxLifecycle::Running;
+                    fx.generation = fx.generation.saturating_add(1);
+                    fx.visible = true;
+                } else {
+                    fx.visible = !fx.visible;
+                }
+            }
+            BackendBusFxControl::RestoreState(_) => {}
+            BackendBusFxControl::ClearLogs => fx.logs = Arc::from([]),
+            BackendBusFxControl::BuiltInFx(control) => {
+                let Some(TrackProcessorEditorState::BuiltInFx(editor)) = fx.editor.as_mut() else {
+                    return Err(anyhow!("Built-in FX editor state is unavailable"));
+                };
+                apply_app_builtin_fx_control(editor, control);
+            }
+        }
+        self.mixer.revision = self.mixer.revision.wrapping_add(1);
+        Ok(())
+    }
+
+    fn bus_fx_state_string(&mut self, bus_id: BackendBusId) -> Result<Option<String>> {
+        Ok(Some(self.default_fx_state_string.clone()).filter(|_| {
+            self.mixer
+                .buses
+                .get(&bus_id)
+                .is_some_and(|bus| bus.fx.is_some())
+        }))
     }
 
     fn advance(&mut self, _elapsed: Duration) {}

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -232,7 +232,7 @@ pub enum BackendBusFxControl {
 pub struct BackendBusRequest {
     pub name: String,
     pub channel_count: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub fx: Option<BackendBusFxRequest>,
 }
 
@@ -998,9 +998,9 @@ pub struct BackendSessionBus {
     pub balance: f32,
     #[serde(default)]
     pub muted: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub processor_type: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub processor_state: Option<String>,
     #[serde(default)]
     pub builtin_fx_midi_cc_assignments: Vec<BackendBuiltInFxMidiCcAssignment>,

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -11567,6 +11567,98 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_mixer_routes_keep_working_and_remove_cleans_up() {
+        use crate::BackendBusFxControl;
+        use shoop_app_api::BuiltInFxControl;
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 4).unwrap();
+        let creation = backend
+            .create_bus(BackendBusRequest {
+                name: "FxBus".to_owned(),
+                channel_count: 2,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 2,
+                }),
+            })
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    shoop_app_api::BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(true))
+            .unwrap();
+        let track = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "routed".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 1,
+            })
+            .unwrap();
+        load_direct_loop(&mut backend, track.loops[0], 0.5);
+        let source = track
+            .ports
+            .iter()
+            .find(|port| port.role == BackendPortRole::AudioOutput)
+            .unwrap()
+            .id;
+        let left = backend.buses[&creation.bus_id].channels[0].id;
+        let right = backend.buses[&creation.bus_id].channels[1].id;
+        backend.set_mixer_route(source, left, true).unwrap();
+        backend.set_mixer_route(source, right, true).unwrap();
+        assert_eq!(backend.mixer_snapshot().confirmed_links.len(), 2);
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(false))
+            .unwrap();
+        backend.set_mixer_route(source, right, false).unwrap();
+        assert_eq!(backend.mixer_snapshot().confirmed_links.len(), 1);
+        backend.remove_bus(creation.bus_id).unwrap();
+        assert!(!backend.buses.contains_key(&creation.bus_id));
+        assert!(backend.mixer_snapshot().confirmed_links.is_empty());
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_master_and_wide_channel_shapes_create_and_remove() {
+        for channels in [1_u32, 2, 3, 6, 64] {
+            let mut backend = EngineBackend::new_dummy_runtime(48_000, 4).unwrap();
+            let creation = backend
+                .create_bus(BackendBusRequest {
+                    name: format!("Wide{channels}"),
+                    channel_count: channels,
+                    fx: Some(BackendBusFxRequest {
+                        processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                        audio_channels: channels,
+                    }),
+                })
+                .unwrap();
+            assert_eq!(
+                backend.buses[&creation.bus_id].channels.len(),
+                channels as usize
+            );
+            assert!(backend.mixer_snapshot().buses[&creation.bus_id]
+                .fx
+                .is_some());
+            backend.remove_bus(creation.bus_id).unwrap();
+        }
+        assert!(BackendBusRequest {
+            name: "TooWide".to_owned(),
+            channel_count: 65,
+            fx: Some(BackendBusFxRequest {
+                processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                audio_channels: 65,
+            }),
+        }
+        .normalized()
+        .is_err());
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn bus_definition_contract_and_fake_lifecycle_are_bounded_and_exact() {
         assert_eq!(
             BackendBusRequest {

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -7499,6 +7499,9 @@ impl Backend for EngineBackend {
                     BuiltInFxControl::SetParameter(parameter, value) => {
                         fx.control
                             .set_parameter(engine_builtin_fx_parameter(parameter), value)?;
+                        processor
+                            .set_parameter(engine_builtin_fx_parameter(parameter), value)
+                            .map_err(|error| anyhow!("could not set bus parameter: {error}"))?;
                     }
                     BuiltInFxControl::AssignMidiCc(assignment) => {
                         let assignment = engine_builtin_fx_midi_cc_assignment(assignment);
@@ -11484,10 +11487,215 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_drive_changes_dummy_output_bypass_restores_and_remove_cleans_up() {
+        use crate::BackendBusFxControl;
+        use shoop_app_api::{BuiltInFxControl, BuiltInFxParameter};
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 4).unwrap();
+        let creation = backend
+            .create_bus(BackendBusRequest {
+                name: "FxBus".to_owned(),
+                channel_count: 2,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 2,
+                }),
+            })
+            .unwrap();
+        let track = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "drive-source".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 1,
+            })
+            .unwrap();
+        load_direct_loop(&mut backend, track.loops[0], 0.5);
+        let source = track
+            .ports
+            .iter()
+            .find(|port| port.role == BackendPortRole::AudioOutput)
+            .unwrap()
+            .id;
+        let left = backend.buses[&creation.bus_id].channels[0].id;
+        let right = backend.buses[&creation.bus_id].channels[1].id;
+        backend.set_mixer_route(source, left, true).unwrap();
+        backend.set_mixer_route(source, right, true).unwrap();
+        let output = backend.buses[&creation.bus_id].channels[0].output;
+        let source_index = backend.connection_ports[&source].engine_port_index;
+        let render = |backend: &mut EngineBackend| {
+            for channel in backend.buses.values().flat_map(|bus| &bus.channels) {
+                backend
+                    .session
+                    .port_mut(channel.output)
+                    .unwrap()
+                    .as_dummy_mut()
+                    .unwrap()
+                    .request_data(4);
+            }
+            backend
+                .session
+                .port_mut(source_index)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .request_data(4);
+            backend.advance_frames(4);
+            backend
+                .session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .dequeue_data(4)
+                .unwrap()
+        };
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetReverbEnabled(false)),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(true))
+            .unwrap();
+        let dry = render(&mut backend);
+        assert_eq!(dry, vec![0.5; 4]);
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    shoop_app_api::BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetParameter(
+                    BuiltInFxParameter::Drive,
+                    20.0,
+                )),
+            )
+            .unwrap();
+        let wet = render(&mut backend);
+        assert_ne!(wet, dry);
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    shoop_app_api::BuiltInFxStage::Drive,
+                    false,
+                )),
+            )
+            .unwrap();
+        assert_eq!(render(&mut backend), dry);
+        assert!(backend
+            .bus_fx_state_string(creation.bus_id)
+            .unwrap()
+            .is_some());
+        backend.remove_bus(creation.bus_id).unwrap();
+        assert!(!backend.buses.contains_key(&creation.bus_id));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_mono_drive_changes_dummy_output_and_remove_cleans_up() {
+        use crate::BackendBusFxControl;
+        use shoop_app_api::{BuiltInFxControl, BuiltInFxParameter};
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 4).unwrap();
+        let creation = backend
+            .create_bus(BackendBusRequest {
+                name: "MonoFx".to_owned(),
+                channel_count: 1,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 1,
+                }),
+            })
+            .unwrap();
+        let track = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "mono-source".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 1,
+            })
+            .unwrap();
+        load_direct_loop(&mut backend, track.loops[0], 0.5);
+        let source = track
+            .ports
+            .iter()
+            .find(|port| port.role == BackendPortRole::AudioOutput)
+            .unwrap()
+            .id;
+        let destination = backend.buses[&creation.bus_id].channels[0].id;
+        backend.set_mixer_route(source, destination, true).unwrap();
+        let output = backend.buses[&creation.bus_id].channels[0].output;
+        let source_index = backend.connection_ports[&source].engine_port_index;
+        let render = |backend: &mut EngineBackend| {
+            backend
+                .session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .request_data(4);
+            backend
+                .session
+                .port_mut(source_index)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .request_data(4);
+            backend.advance_frames(4);
+            backend
+                .session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .dequeue_data(4)
+                .unwrap()
+        };
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetReverbEnabled(false)),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(true))
+            .unwrap();
+        let dry = render(&mut backend);
+        assert_eq!(dry, vec![0.5; 4]);
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    shoop_app_api::BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetParameter(
+                    BuiltInFxParameter::Drive,
+                    20.0,
+                )),
+            )
+            .unwrap();
+        assert_ne!(render(&mut backend), dry);
+        backend.remove_bus(creation.bus_id).unwrap();
+        assert!(!backend.buses.contains_key(&creation.bus_id));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn bus_fx_drive_changes_dummy_output_and_remove_cleans_up() {
         use crate::BackendBusFxControl;
         use shoop_app_api::BuiltInFxControl;
-        let mut backend = EngineBackend::new_dummy_runtime(48_000, 128).unwrap();
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 4).unwrap();
         let creation = backend
             .create_bus(BackendBusRequest {
                 name: "FxBus".to_owned(),

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -196,9 +196,44 @@ pub struct BackendConnectionSnapshot {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BackendBusFxRequest {
+    pub processor_type: String,
+    pub audio_channels: u32,
+}
+
+impl BackendBusFxRequest {
+    pub fn normalized(self, channel_count: usize) -> Result<Self> {
+        let audio_channels = usize::try_from(self.audio_channels)
+            .map_err(|_| anyhow!("bus FX channel count exceeds this platform"))?;
+        if audio_channels != channel_count {
+            return Err(anyhow!("bus FX channels must match the bus channel count"));
+        }
+        if self.processor_type == TrackProcessorTypeId::OXISYNTH {
+            return Err(anyhow!("Built-in Synth is unavailable on buses"));
+        }
+        Ok(Self {
+            processor_type: self.processor_type,
+            audio_channels: self.audio_channels,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum BackendBusFxControl {
+    SetActive(bool),
+    SetVisible(bool),
+    ToggleOrRecover,
+    RestoreState(String),
+    ClearLogs,
+    BuiltInFx(BuiltInFxControl),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BackendBusRequest {
     pub name: String,
     pub channel_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fx: Option<BackendBusFxRequest>,
 }
 
 impl BackendBusRequest {
@@ -225,6 +260,7 @@ impl BackendBusRequest {
         Ok(Self {
             name,
             channel_count: self.channel_count,
+            fx: self.fx,
         })
     }
 }
@@ -296,6 +332,8 @@ pub struct BackendBusState {
     pub muted: bool,
     #[serde(default)]
     pub output_peaks_db: Vec<f32>,
+    #[serde(skip)]
+    pub fx: Option<TrackFxState>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -960,6 +998,12 @@ pub struct BackendSessionBus {
     pub balance: f32,
     #[serde(default)]
     pub muted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub processor_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub processor_state: Option<String>,
+    #[serde(default)]
+    pub builtin_fx_midi_cc_assignments: Vec<BackendBuiltInFxMidiCcAssignment>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1037,6 +1081,7 @@ pub enum BackendMutationKind {
     TrackControl,
     BusControl,
     TrackFxControl,
+    BusFxControl,
     MidiInput,
     LoopControl,
     LoopContent,
@@ -1057,6 +1102,7 @@ pub enum BackendMutationDetail {
     BusControl(BackendBusControl),
     TrackDefaultPlaybackMode(BackendDefaultPlaybackMode),
     TrackFxControl(BackendTrackFxControl),
+    BusFxControl(BackendBusFxControl),
     LoopGain(f32),
     LoopBalance(f32),
     LoopTiming,
@@ -1098,6 +1144,10 @@ pub trait Backend {
     }
 
     fn track_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
+        Ok(Arc::from([]))
+    }
+
+    fn bus_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
         Ok(Arc::from([]))
     }
 
@@ -1393,6 +1443,16 @@ pub trait Backend {
         let _ = (bus_id, control);
         Err(anyhow!("bus control is unavailable"))
     }
+    fn set_bus_fx_control(
+        &mut self,
+        _bus_id: BackendBusId,
+        _control: BackendBusFxControl,
+    ) -> Result<()> {
+        Err(anyhow!("bus FX controls are unavailable"))
+    }
+    fn bus_fx_state_string(&mut self, _bus_id: BackendBusId) -> Result<Option<String>> {
+        Ok(None)
+    }
     fn advance(&mut self, elapsed: Duration);
     fn poll(&mut self) -> Result<BackendSnapshot>;
     fn wait_idle(&mut self);
@@ -1483,6 +1543,30 @@ fn app_backend_oxisynth_midi_cc_assignment(
         channel: assignment.channel,
         controller: assignment.controller,
     }
+}
+
+fn validate_backend_bus_midi_cc_assignments(bus: &BackendSessionBus) -> Result<()> {
+    if !bus.builtin_fx_midi_cc_assignments.is_empty()
+        && bus.processor_type.as_deref() != Some(TrackProcessorTypeId::BUILTIN_FX)
+    {
+        return Err(anyhow!(
+            "Built-in FX MIDI CC assignments belong to a non-Built-in FX processor"
+        ));
+    }
+    let mut builtin_parameters = BTreeSet::new();
+    let mut builtin_sources = BTreeSet::new();
+    for assignment in &bus.builtin_fx_midi_cc_assignments {
+        if assignment.channel > 15
+            || assignment.controller > 127
+            || !builtin_parameters.insert(assignment.parameter)
+            || !builtin_sources.insert((assignment.channel, assignment.controller))
+        {
+            return Err(anyhow!(
+                "invalid or duplicate Built-in FX MIDI CC assignments"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validate_backend_midi_cc_assignments(track: &BackendSessionTrack) -> Result<()> {
@@ -2202,6 +2286,19 @@ struct EngineBus {
     gain_db: f32,
     balance: f32,
     muted: bool,
+    builtin_fx: Option<EngineBuiltInFx>,
+    fx_sends: Vec<usize>,
+    fx_receives: Vec<usize>,
+}
+
+fn bus_fx_title(bus_id: BackendBusId) -> String {
+    format!("bus_{}_fx", bus_id.raw())
+}
+
+fn bus_fx_descriptor() -> TrackProcessorDescriptor {
+    let mut descriptor = builtin_fx_descriptor();
+    descriptor.constraints.midi = shoop_app_api::TrackProcessorMidiPolicy::Unsupported;
+    descriptor
 }
 
 struct EngineBusChannel {
@@ -3094,6 +3191,7 @@ impl EngineBackend {
             BackendBusRequest {
                 name: MASTER_BUS_NAME.to_owned(),
                 channel_count: 2,
+                fx: None,
             },
             MASTER_BUS_ID,
             MASTER_BUS_CHANNEL_IDS.to_vec(),
@@ -3188,7 +3286,57 @@ impl EngineBackend {
                 "total bus channels exceed the {MAX_TOTAL_BUS_CHANNELS}-channel limit"
             ));
         }
+        let fx = request
+            .fx
+            .map(|fx| fx.normalized(channel_count))
+            .transpose()?;
+        if let Some(fx) = &fx {
+            if fx.processor_type != TrackProcessorTypeId::BUILTIN_FX {
+                return Err(anyhow!("unknown bus processor {}", fx.processor_type));
+            }
+            if !bus_fx_descriptor().constraints.accepts(
+                channel_count as u32,
+                channel_count as u32,
+                false,
+            ) {
+                return Err(anyhow!("bus processor does not accept this channel count"));
+            }
+        }
         let labels = default_bus_channel_labels(channel_count)?;
+        let mut sends = Vec::with_capacity(channel_count);
+        let mut receives = Vec::with_capacity(channel_count);
+        if fx.is_some() {
+            let title = bus_fx_title(bus_id);
+            let control = shoop_engine::builtin_fx::BuiltInFxControlState::default();
+            let processor = control.prepare_processor_with_channels(
+                self.sample_rate as f32,
+                self.buffer_size as usize,
+                channel_count,
+            )?;
+            let _ = self.session.set_builtin_fx_processor(title, processor);
+            for index in 0..channel_count {
+                sends.push(self.session.add_port(Port::Internal(InternalAudioPort::new(
+                    format!("bus_{}_fx:audio_in_{index}", bus_id.raw()),
+                    self.buffer_size as usize,
+                    shoop_engine::PortConnectability::INTERNAL,
+                    shoop_engine::PortConnectability::INTERNAL,
+                    0,
+                ))));
+                receives.push(self.session.add_port(Port::Internal(InternalAudioPort::new(
+                    format!("bus_{}_fx:audio_out_{index}", bus_id.raw()),
+                    self.buffer_size as usize,
+                    shoop_engine::PortConnectability::INTERNAL,
+                    shoop_engine::PortConnectability::INTERNAL,
+                    0,
+                ))));
+            }
+            self.session.set_processor_ports(
+                &bus_fx_title(bus_id),
+                sends.clone(),
+                receives.clone(),
+                Vec::new(),
+            )?;
+        }
         let mut channels: Vec<EngineBusChannel> = Vec::with_capacity(channel_count);
         for (index, ((id, output_port_id), label)) in channel_ids
             .into_iter()
@@ -3223,15 +3371,6 @@ impl EngineBackend {
                     1,
                 )))
             };
-            if let Err(error) = self.session.connect_ports_internal(input, output) {
-                let _ = self.session.remove_port(input);
-                let _ = self.session.remove_port(output);
-                for channel in channels {
-                    let _ = self.session.remove_port(channel.input);
-                    let _ = self.session.remove_port(channel.output);
-                }
-                return Err(error.into());
-            }
             channels.push(EngineBusChannel {
                 id,
                 label,
@@ -3241,11 +3380,60 @@ impl EngineBackend {
                 output_port_id,
             });
         }
+        if fx.is_some() {
+            for (index, channel) in channels.iter().enumerate() {
+                if let Err(error) = self
+                    .session
+                    .connect_ports_internal(channel.input, sends[index])
+                {
+                    for port in sends.iter().chain(&receives) {
+                        let _ = self.session.remove_port(*port);
+                    }
+                    self.session.remove_processor(&bus_fx_title(bus_id));
+                    for channel in channels {
+                        let _ = self.session.remove_port(channel.input);
+                        let _ = self.session.remove_port(channel.output);
+                    }
+                    return Err(error.into());
+                }
+                if let Err(error) = self
+                    .session
+                    .connect_ports_internal(receives[index], channel.output)
+                {
+                    for port in sends.iter().chain(&receives) {
+                        let _ = self.session.remove_port(*port);
+                    }
+                    self.session.remove_processor(&bus_fx_title(bus_id));
+                    for channel in channels {
+                        let _ = self.session.remove_port(channel.input);
+                        let _ = self.session.remove_port(channel.output);
+                    }
+                    return Err(error.into());
+                }
+            }
+        } else {
+            for channel in &channels {
+                if let Err(error) = self
+                    .session
+                    .connect_ports_internal(channel.input, channel.output)
+                {
+                    for channel in channels {
+                        let _ = self.session.remove_port(channel.input);
+                        let _ = self.session.remove_port(channel.output);
+                    }
+                    return Err(error.into());
+                }
+            }
+        }
         if let Err(error) = self.session.apply_graph_changes() {
-            for channel in channels {
+            for channel in &channels {
                 let _ = self.session.remove_port(channel.input);
                 let _ = self.session.remove_port(channel.output);
             }
+            for port in sends.iter().chain(&receives) {
+                let _ = self.session.remove_port(*port);
+            }
+            self.session.remove_processor(&bus_fx_title(bus_id));
             let _ = self.session.apply_graph_changes();
             return Err(error.into());
         }
@@ -3285,6 +3473,13 @@ impl EngineBackend {
                 gain_db: 0.0,
                 balance: 0.0,
                 muted: false,
+                builtin_fx: fx.map(|_| EngineBuiltInFx {
+                    control: shoop_engine::builtin_fx::BuiltInFxControlState::default(),
+                    active: false,
+                    visible: false,
+                }),
+                fx_sends: sends.clone(),
+                fx_receives: receives.clone(),
             },
         );
         self.connection_revision = self.connection_revision.wrapping_add(1);
@@ -3311,6 +3506,13 @@ impl EngineBackend {
         for channel in &bus.channels {
             self.session.remove_port(channel.input)?;
             self.session.remove_port(channel.output)?;
+        }
+        let had_fx = bus.builtin_fx.is_some();
+        for port in bus.fx_sends.iter().chain(&bus.fx_receives) {
+            let _ = self.session.remove_port(*port);
+        }
+        if had_fx {
+            self.session.remove_processor(&bus_fx_title(bus_id));
         }
         if let Err(error) = self.session.apply_graph_changes() {
             for channel in &bus.channels {
@@ -3395,6 +3597,7 @@ impl EngineBackend {
                     balance: bus.balance,
                     muted: bus.muted,
                     output_peaks_db,
+                    fx: bus.builtin_fx.as_ref().map(engine_builtin_fx_state),
                 },
             );
         }
@@ -4420,36 +4623,58 @@ impl EngineBackend {
         let buses = self
             .buses
             .values()
-            .map(|bus| BackendSessionBus {
-                source_id: bus.id.raw(),
-                name: bus.name.clone(),
-                channels: bus
-                    .channels
-                    .iter()
-                    .map(|channel| {
-                        let descriptor = self.connection_ports[&channel.output_port_id]
-                            .descriptor
-                            .clone();
-                        let external_connections = connections
-                            .confirmed_links
-                            .iter()
-                            .filter(|link| link.application_port_id == channel.output_port_id)
-                            .map(|link| link.host_port_id.clone())
-                            .collect();
-                        BackendSessionBusChannel {
-                            source_id: channel.id.raw(),
-                            label: channel.label.clone(),
-                            output_port: BackendSessionPort {
-                                source_id: channel.output_port_id.raw(),
-                                descriptor,
-                                external_connections,
-                            },
-                        }
+            .map(|bus| {
+                let builtin_fx_midi_cc_assignments = bus
+                    .builtin_fx
+                    .as_ref()
+                    .map(|fx| fx.control.midi_cc_assignments())
+                    .into_iter()
+                    .flat_map(|assignments| assignments.iter().collect::<Vec<_>>())
+                    .map(|assignment| BuiltInFxMidiCcAssignment {
+                        parameter: app_builtin_fx_parameter(assignment.parameter),
+                        channel: assignment.channel,
+                        controller: assignment.controller,
                     })
-                    .collect(),
-                gain_db: bus.gain_db,
-                balance: bus.balance,
-                muted: bus.muted,
+                    .map(backend_builtin_fx_midi_cc_assignment)
+                    .collect::<Vec<_>>();
+                let processor_state = bus.builtin_fx.as_ref().map(|fx| fx.control.encode());
+                BackendSessionBus {
+                    source_id: bus.id.raw(),
+                    name: bus.name.clone(),
+                    channels: bus
+                        .channels
+                        .iter()
+                        .map(|channel| {
+                            let descriptor = self.connection_ports[&channel.output_port_id]
+                                .descriptor
+                                .clone();
+                            let external_connections = connections
+                                .confirmed_links
+                                .iter()
+                                .filter(|link| link.application_port_id == channel.output_port_id)
+                                .map(|link| link.host_port_id.clone())
+                                .collect();
+                            BackendSessionBusChannel {
+                                source_id: channel.id.raw(),
+                                label: channel.label.clone(),
+                                output_port: BackendSessionPort {
+                                    source_id: channel.output_port_id.raw(),
+                                    descriptor,
+                                    external_connections,
+                                },
+                            }
+                        })
+                        .collect(),
+                    gain_db: bus.gain_db,
+                    balance: bus.balance,
+                    muted: bus.muted,
+                    processor_type: bus
+                        .builtin_fx
+                        .as_ref()
+                        .map(|_| TrackProcessorTypeId::BUILTIN_FX.to_owned()),
+                    processor_state,
+                    builtin_fx_midi_cc_assignments,
+                }
             })
             .collect();
         let mixer_routes = self
@@ -4483,6 +4708,9 @@ impl EngineBackend {
         }
         for track in &data.tracks {
             validate_backend_midi_cc_assignments(track)?;
+        }
+        for bus in &data.buses {
+            validate_backend_bus_midi_cc_assignments(bus)?;
         }
         if data.tracks.iter().any(|track| {
             let processor_state_valid = match &track.topology {
@@ -4534,10 +4762,27 @@ impl EngineBackend {
         staged.web_midi_hosts = self.web_midi_hosts.clone();
         staged.remove_bus_internal(MASTER_BUS_ID)?;
         for source_bus in &data.buses {
+            let mut fx = match source_bus.processor_type.as_deref() {
+                None => None,
+                Some(TrackProcessorTypeId::BUILTIN_FX) => {
+                    let state = source_bus
+                        .processor_state
+                        .clone()
+                        .ok_or_else(|| anyhow!("session bus processor state is missing"))?;
+                    Some((state, source_bus.builtin_fx_midi_cc_assignments.clone()))
+                }
+                Some(other) => {
+                    return Err(anyhow!("unsupported session bus processor {other}"));
+                }
+            };
             let request = BackendBusRequest {
                 name: source_bus.name.clone(),
                 channel_count: u32::try_from(source_bus.channels.len())
                     .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
+                fx: fx.as_ref().map(|_| BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: source_bus.channels.len() as u32,
+                }),
             }
             .normalized()?;
             let expected_labels = default_bus_channel_labels(source_bus.channels.len())?;
@@ -4614,6 +4859,18 @@ impl EngineBackend {
                 return Err(anyhow!("non-stereo session bus balance must be centered"));
             }
             staged.apply_bus_control(created.bus_id, BackendBusControl::Mute(source_bus.muted))?;
+            if let Some((state, assignments)) = fx.take() {
+                staged
+                    .set_bus_fx_control(created.bus_id, BackendBusFxControl::RestoreState(state))?;
+                for assignment in assignments {
+                    staged.set_bus_fx_control(
+                        created.bus_id,
+                        BackendBusFxControl::BuiltInFx(BuiltInFxControl::AssignMidiCc(
+                            app_backend_builtin_fx_midi_cc_assignment(assignment),
+                        )),
+                    )?;
+                }
+            }
         }
         for external in &source_global.external_connections {
             if let Err(error) = staged.set_port_connected(staged.global_fx_port, external, true) {
@@ -7173,6 +7430,110 @@ impl Backend for EngineBackend {
         self.apply_bus_control(bus_id, control)
     }
 
+    fn bus_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
+        Ok(vec![bus_fx_descriptor()].into())
+    }
+
+    fn set_bus_fx_control(
+        &mut self,
+        bus_id: BackendBusId,
+        control: BackendBusFxControl,
+    ) -> Result<()> {
+        let bus = self
+            .buses
+            .get_mut(&bus_id)
+            .ok_or_else(|| anyhow!("unknown backend bus {bus_id:?}"))?;
+        let Some(fx) = bus.builtin_fx.as_mut() else {
+            return Err(anyhow!("bus has no processor"));
+        };
+        let title = bus_fx_title(bus_id);
+        let channel_count = bus.channels.len();
+        match control {
+            BackendBusFxControl::SetActive(active) => {
+                fx.active = active;
+                self.session.set_builtin_fx_active(&title, active);
+            }
+            BackendBusFxControl::SetVisible(visible) => fx.visible = visible,
+            BackendBusFxControl::ToggleOrRecover => fx.visible = !fx.visible,
+            BackendBusFxControl::RestoreState(state) => {
+                let assignments = fx.control.midi_cc_assignments();
+                let mut replacement =
+                    shoop_engine::builtin_fx::BuiltInFxControlState::from_encoded(&state)?;
+                replacement.set_midi_cc_assignments(assignments);
+                let processor = replacement.prepare_processor_with_channels(
+                    self.sample_rate as f32,
+                    self.buffer_size as usize,
+                    channel_count,
+                )?;
+                let displaced = self.session.set_builtin_fx_processor(title, processor);
+                drop(displaced);
+                fx.control = replacement;
+            }
+            BackendBusFxControl::ClearLogs => {}
+            BackendBusFxControl::BuiltInFx(control) => {
+                let processor = self
+                    .session
+                    .builtin_fx_processor_mut(&title)
+                    .ok_or_else(|| anyhow!("missing Built-in FX processor"))?;
+                match control {
+                    BuiltInFxControl::SetStageEnabled(stage, enabled) => {
+                        let stage = engine_builtin_fx_stage(stage);
+                        fx.control.set_stage_enabled(stage, enabled);
+                        processor.set_stage_enabled(stage, enabled);
+                    }
+                    BuiltInFxControl::SetDriveType(drive_type) => {
+                        let drive_type = engine_builtin_fx_drive_type(drive_type);
+                        fx.control.set_drive_type(drive_type);
+                        processor.set_drive_type(drive_type);
+                    }
+                    BuiltInFxControl::SetModulationType(modulation_type) => {
+                        let modulation_type = engine_builtin_fx_modulation_type(modulation_type);
+                        fx.control.set_modulation_type(modulation_type);
+                        processor.set_modulation_type(modulation_type);
+                    }
+                    BuiltInFxControl::SetReverbType(reverb_type) => {
+                        let reverb_type = engine_builtin_fx_reverb_type(reverb_type);
+                        fx.control.set_reverb_type(reverb_type);
+                        processor.set_reverb_type(reverb_type);
+                    }
+                    BuiltInFxControl::SetParameter(parameter, value) => {
+                        fx.control
+                            .set_parameter(engine_builtin_fx_parameter(parameter), value)?;
+                    }
+                    BuiltInFxControl::AssignMidiCc(assignment) => {
+                        let assignment = engine_builtin_fx_midi_cc_assignment(assignment);
+                        if !fx.control.assign_midi_cc(assignment) {
+                            return Err(anyhow!("invalid Built-in FX MIDI CC assignment"));
+                        }
+                        processor.assign_midi_cc(assignment);
+                    }
+                    BuiltInFxControl::RemoveMidiCc(parameter) => {
+                        let parameter = engine_builtin_fx_parameter(parameter);
+                        fx.control.remove_midi_cc(parameter);
+                        processor.remove_midi_cc(parameter);
+                    }
+                    BuiltInFxControl::ClearMidiCcAssignments => {
+                        fx.control.clear_midi_cc_assignments();
+                        processor.clear_midi_cc_assignments();
+                    }
+                    BuiltInFxControl::SetReverbEnabled(enabled) => {
+                        fx.control.set_reverb_enabled(enabled);
+                        processor.set_reverb_enabled(enabled);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn bus_fx_state_string(&mut self, bus_id: BackendBusId) -> Result<Option<String>> {
+        let bus = self
+            .buses
+            .get(&bus_id)
+            .ok_or_else(|| anyhow!("unknown backend bus {bus_id:?}"))?;
+        Ok(bus.builtin_fx.as_ref().map(|fx| fx.control.encode()))
+    }
+
     fn advance(&mut self, _elapsed: Duration) {
         // Runtime progression is supplied explicitly by a driver. Local
         // elapsed-time behavior lives in LocalDummyBackend.
@@ -8168,6 +8529,7 @@ impl Default for FakeBackend {
                     balance: 0.0,
                     muted: false,
                     output_peaks_db: vec![-200.0; 2],
+                    fx: None,
                 },
             )]),
             ..Default::default()
@@ -10311,6 +10673,9 @@ impl Backend for FakeBackend {
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
+                processor_type: None,
+                processor_state: None,
+                builtin_fx_midi_cc_assignments: Vec::new(),
             })
             .collect();
         let mixer_routes = self
@@ -10408,6 +10773,7 @@ impl Backend for FakeBackend {
                 name: source_bus.name.clone(),
                 channel_count: u32::try_from(source_bus.channels.len())
                     .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
+                fx: None,
             }
             .normalized()?;
             let expected_labels = default_bus_channel_labels(source_bus.channels.len())?;
@@ -10877,6 +11243,7 @@ impl Backend for FakeBackend {
                 balance: 0.0,
                 muted: false,
                 output_peaks_db: vec![-200.0; channel_count],
+                fx: None,
             },
         );
         self.mixer.revision = self.mixer.revision.wrapping_add(1);
@@ -11016,17 +11383,124 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_requests_reject_channel_mismatch_and_synth() {
+        assert!(BackendBusFxRequest {
+            processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+            audio_channels: 2,
+        }
+        .normalized(2)
+        .is_ok());
+        assert!(BackendBusFxRequest {
+            processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+            audio_channels: 1,
+        }
+        .normalized(2)
+        .is_err());
+        assert!(BackendBusFxRequest {
+            processor_type: TrackProcessorTypeId::OXISYNTH.to_owned(),
+            audio_channels: 2,
+        }
+        .normalized(2)
+        .is_err());
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_drive_changes_dummy_output_and_remove_cleans_up() {
+        use crate::BackendBusFxControl;
+        use shoop_app_api::BuiltInFxControl;
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 128).unwrap();
+        let creation = backend
+            .create_bus(BackendBusRequest {
+                name: "FxBus".to_owned(),
+                channel_count: 2,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 2,
+                }),
+            })
+            .unwrap();
+        assert!(backend.mixer_snapshot().buses[&creation.bus_id]
+            .fx
+            .is_some());
+        assert_eq!(
+            Backend::bus_processor_catalog(&mut backend).unwrap().len(),
+            1
+        );
+        backend
+            .set_bus_fx_control(
+                creation.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    shoop_app_api::BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(true))
+            .unwrap();
+        assert!(backend
+            .bus_fx_state_string(creation.bus_id)
+            .unwrap()
+            .is_some());
+        backend.remove_bus(creation.bus_id).unwrap();
+        assert!(!backend.buses.contains_key(&creation.bus_id));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn bus_fx_round_trips_through_engine_session_replace() {
+        let mut backend = EngineBackend::new_dummy_runtime(48_000, 64).unwrap();
+        let creation = backend
+            .create_bus(BackendBusRequest {
+                name: "FxBus".to_owned(),
+                channel_count: 1,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 1,
+                }),
+            })
+            .unwrap();
+        backend
+            .set_bus_fx_control(creation.bus_id, BackendBusFxControl::SetActive(true))
+            .unwrap();
+        let captured = backend.capture_session().unwrap();
+        let fx_bus = captured
+            .buses
+            .iter()
+            .find(|bus| bus.name == "FxBus")
+            .unwrap();
+        assert_eq!(
+            fx_bus.processor_type.as_deref(),
+            Some(TrackProcessorTypeId::BUILTIN_FX)
+        );
+        assert!(fx_bus.processor_state.is_some());
+        backend.replace_session(&captured).unwrap();
+        let restored = backend.capture_session().unwrap();
+        let restored_bus = restored
+            .buses
+            .iter()
+            .find(|bus| bus.name == "FxBus")
+            .unwrap();
+        assert_eq!(
+            restored_bus.processor_type.as_deref(),
+            Some(TrackProcessorTypeId::BUILTIN_FX)
+        );
+        assert_eq!(restored_bus.processor_state, fx_bus.processor_state);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
     fn bus_definition_contract_and_fake_lifecycle_are_bounded_and_exact() {
         assert_eq!(
             BackendBusRequest {
                 name: "  Surround  ".to_owned(),
                 channel_count: 4,
+                fx: None,
             }
             .normalized()
             .unwrap(),
             BackendBusRequest {
                 name: "Surround".to_owned(),
                 channel_count: 4,
+                fx: None,
             }
         );
         assert_eq!(default_bus_channel_labels(1).unwrap(), ["Mono"]);
@@ -11039,22 +11513,27 @@ mod tests {
             BackendBusRequest {
                 name: " ".to_owned(),
                 channel_count: 2,
+                fx: None,
             },
             BackendBusRequest {
                 name: "x".repeat(MAX_BUS_NAME_BYTES + 1),
                 channel_count: 2,
+                fx: None,
             },
             BackendBusRequest {
                 name: "Control\nName".to_owned(),
                 channel_count: 2,
+                fx: None,
             },
             BackendBusRequest {
                 name: "Zero".to_owned(),
                 channel_count: 0,
+                fx: None,
             },
             BackendBusRequest {
                 name: "Too many".to_owned(),
                 channel_count: MAX_BUS_CHANNELS as u32 + 1,
+                fx: None,
             },
         ] {
             assert!(request.normalized().is_err());
@@ -11064,6 +11543,7 @@ mod tests {
         let request = BackendBusRequest {
             name: "  Surround  ".to_owned(),
             channel_count: 4,
+            fx: None,
         };
         let creation = backend.create_bus(request).unwrap();
         assert_ne!(creation.bus_id, MASTER_BUS_ID);
@@ -11103,6 +11583,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Exhausted".to_owned(),
                 channel_count: 1,
+                fx: None,
             })
             .is_err());
         assert_eq!(backend.mixer.buses.len(), bus_count);
@@ -11120,12 +11601,14 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Duplicate".to_owned(),
                 channel_count: 1,
+                fx: None,
             })
             .unwrap();
         let surround = backend
             .create_bus(BackendBusRequest {
                 name: "Duplicate".to_owned(),
                 channel_count: 4,
+                fx: None,
             })
             .unwrap();
         assert_ne!(mono.bus_id, surround.bus_id);
@@ -11221,12 +11704,14 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Duplicate".to_owned(),
                 channel_count: 1,
+                fx: None,
             })
             .unwrap();
         let surround = backend
             .create_bus(BackendBusRequest {
                 name: "Duplicate".to_owned(),
                 channel_count: 6,
+                fx: None,
             })
             .unwrap();
         backend

--- a/src/rust/shoop_backend/src/lib.rs
+++ b/src/rust/shoop_backend/src/lib.rs
@@ -2296,6 +2296,10 @@ fn bus_fx_title(bus_id: BackendBusId) -> String {
 }
 
 fn bus_fx_descriptor() -> TrackProcessorDescriptor {
+    bus_fx_descriptor_for_catalog()
+}
+
+pub fn bus_fx_descriptor_for_catalog() -> TrackProcessorDescriptor {
     let mut descriptor = builtin_fx_descriptor();
     descriptor.constraints.midi = shoop_app_api::TrackProcessorMidiPolicy::Unsupported;
     descriptor

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -665,6 +665,7 @@ impl NativeRuntime {
             BackendBusRequest {
                 name: MASTER_BUS_NAME.to_owned(),
                 channel_count: 2,
+                fx: None,
             },
             MASTER_BUS_ID,
             MASTER_BUS_CHANNEL_IDS.to_vec(),
@@ -1073,6 +1074,7 @@ impl NativeRuntime {
                         balance: bus.balance,
                         muted: bus.muted,
                         output_peaks_db,
+                        fx: None,
                     },
                 )
             })
@@ -1603,6 +1605,9 @@ impl NativeRuntime {
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
+                processor_type: None,
+                processor_state: None,
+                builtin_fx_midi_cc_assignments: Vec::new(),
             })
             .collect();
         let mixer_routes = self
@@ -1651,6 +1656,7 @@ impl NativeRuntime {
                 name: source_bus.name.clone(),
                 channel_count: u32::try_from(source_bus.channels.len())
                     .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
+                fx: None,
             }
             .normalized()?;
             let expected_labels = default_bus_channel_labels(source_bus.channels.len())?;

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -128,6 +128,7 @@ struct NativeRuntime {
     tracks: BTreeMap<BackendTrackId, NativeTrack>,
     global_fx_port: BackendPortId,
     buses: BTreeMap<BackendBusId, NativeBus>,
+    staged_bus_fx: BTreeMap<BackendBusId, NativeFx>,
     mixer_routes: BTreeSet<BackendMixerLink>,
     mixer_failures: Vec<BackendMixerFailure>,
     mixer_revision: u64,
@@ -172,7 +173,6 @@ struct NativeFx {
     last_confirmed_state: Option<String>,
 }
 
-#[derive(Clone)]
 struct NativeBus {
     id: BackendBusId,
     name: String,
@@ -180,6 +180,7 @@ struct NativeBus {
     gain_db: f32,
     balance: f32,
     muted: bool,
+    fx: Option<NativeFx>,
 }
 
 #[derive(Clone)]
@@ -188,6 +189,18 @@ struct NativeBusChannel {
     label: String,
     input: AudioPort,
     output_port_id: BackendPortId,
+}
+
+struct NativeBusSnapshot {
+    channels: Vec<NativeBusChannel>,
+}
+
+impl NativeBusSnapshot {
+    fn of(bus: &NativeBus) -> Self {
+        Self {
+            channels: bus.channels.clone(),
+        }
+    }
 }
 
 struct NativeComposite {
@@ -398,6 +411,7 @@ impl NativeRuntime {
             tracks: BTreeMap::new(),
             global_fx_port,
             buses: BTreeMap::new(),
+            staged_bus_fx: BTreeMap::new(),
             mixer_routes: BTreeSet::new(),
             mixer_failures: Vec::new(),
             mixer_revision: 1,
@@ -720,6 +734,119 @@ impl NativeRuntime {
         }
     }
 
+    fn create_native_bus_fx(
+        &mut self,
+        bus_id: BackendBusId,
+        fx_request: &BackendBusFxRequest,
+        channels: &mut [NativeBusChannel],
+    ) -> Result<()> {
+        let channel_count = channels.len();
+        let chain_type = processor_chain_type(&fx_request.processor_type)
+            .ok_or_else(|| anyhow!("unknown bus processor {}", fx_request.processor_type))?;
+        if chain_type == FXChainType::OxiSynth {
+            return Err(anyhow!("synth processors are unavailable on buses"));
+        }
+        if fx_request.audio_channels as usize != channel_count {
+            return Err(anyhow!("bus processor channel count must match the bus"));
+        }
+        let ring = self
+            .resolved
+            .sample_rate
+            .saturating_mul(INPUT_CAPTURE_CAPACITY_SECONDS);
+        let title = native_bus_fx_title(bus_id);
+        let chain =
+            match chain_type {
+                FXChainType::BuiltInFx => self
+                    .session
+                    .create_builtin_fx_chain_with_audio_channels(&title, ring, channel_count)?,
+                _ => self.session.create_fx_chain(chain_type, &title, ring)?,
+            };
+        let last_confirmed_state = chain.try_get_state_str().ok();
+        let mut rewired: Vec<(NativeBusChannel, AudioPort)> = Vec::with_capacity(channel_count);
+        for (index, channel) in channels.iter().enumerate() {
+            if self
+                .rewire_bus_channel_for_fx(&chain, channel, index)
+                .is_err()
+            {
+                for (channel, output) in rewired {
+                    let _ = channel.input.connect_internal(&output);
+                }
+                let _ = self.session.remove_fx_chain(&chain);
+                self.wait();
+                self.staged_bus_fx.remove(&bus_id);
+                return Err(anyhow!("bus processor graph did not become active"));
+            }
+            let Some(output) = self
+                .ports
+                .get(&channel.output_port_id)
+                .and_then(|port| match &port.handle {
+                    NativePortHandle::Audio(output) => Some(output.clone()),
+                    NativePortHandle::Midi(_) => None,
+                })
+            else {
+                for (channel, output) in rewired {
+                    let _ = channel.input.connect_internal(&output);
+                }
+                let _ = self.session.remove_fx_chain(&chain);
+                self.wait();
+                self.staged_bus_fx.remove(&bus_id);
+                return Err(anyhow!("missing native bus output port"));
+            };
+            rewired.push((channel.clone(), output));
+        }
+        if !self.wait_for_graph().unwrap_or(false) {
+            for (channel, output) in rewired {
+                let _ = channel.input.connect_internal(&output);
+            }
+            let _ = self.session.remove_fx_chain(&chain);
+            self.wait();
+            self.staged_bus_fx.remove(&bus_id);
+            return Err(anyhow!("bus processor graph did not become active"));
+        }
+        self.staged_bus_fx.insert(
+            bus_id,
+            NativeFx {
+                processor_type: TrackProcessorTypeId::new(&fx_request.processor_type),
+                chain,
+                active: true,
+                last_confirmed_state,
+            },
+        );
+        Ok(())
+    }
+
+    fn rewire_bus_channel_for_fx(
+        &self,
+        chain: &FXChain,
+        channel: &NativeBusChannel,
+        index: usize,
+    ) -> Result<()> {
+        let input = chain
+            .get_audio_input_port(index as u32)
+            .ok_or_else(|| anyhow!("bus processor is missing audio input {index}"))?;
+        let output = chain
+            .get_audio_output_port(index as u32)
+            .ok_or_else(|| anyhow!("bus processor is missing audio output {index}"))?;
+        let driver_output = self
+            .ports
+            .get(&channel.output_port_id)
+            .and_then(|port| match &port.handle {
+                NativePortHandle::Audio(output) => Some(output.clone()),
+                NativePortHandle::Midi(_) => None,
+            })
+            .ok_or_else(|| anyhow!("missing native bus output port"))?;
+        self.session.detach_audio_ports(&[channel.input.clone()])?;
+        channel.input.connect_internal(&input)?;
+        output.connect_internal(&driver_output)?;
+        Ok(())
+    }
+
+    fn take_staged_bus_fx(&mut self, bus_id: BackendBusId) -> Result<NativeFx> {
+        self.staged_bus_fx
+            .remove(&bus_id)
+            .ok_or_else(|| anyhow!("missing staged bus processor"))
+    }
+
     fn create_bus(&mut self, request: BackendBusRequest) -> Result<BackendBusCreation> {
         let request = request.normalized()?;
         let channel_count = request.channel_count as usize;
@@ -868,6 +995,13 @@ impl NativeRuntime {
                 })
                 .collect(),
         };
+        if let Some(fx_request) = request.fx.clone() {
+            if let Err(error) = self.create_native_bus_fx(bus_id, &fx_request, &mut channels) {
+                self.staged_bus_fx.remove(&bus_id);
+                self.rollback_unpublished_bus_channels(channels);
+                return Err(error);
+            }
+        }
         self.buses.insert(
             bus_id,
             NativeBus {
@@ -877,15 +1011,23 @@ impl NativeRuntime {
                 gain_db: 0.0,
                 balance: 0.0,
                 muted: false,
+                fx: None,
             },
         );
+        if self.buses[&bus_id].fx.is_none() && request.fx.is_some() {
+            let fx = self.take_staged_bus_fx(bus_id)?;
+            self.buses
+                .get_mut(&bus_id)
+                .ok_or_else(|| anyhow!("missing native bus {bus_id:?}"))?
+                .fx = Some(fx);
+        }
         self.mixer_revision = self.mixer_revision.wrapping_add(1);
         Ok(creation)
     }
 
     fn restore_detached_bus_graph(
         &self,
-        bus: &NativeBus,
+        bus: &NativeBusSnapshot,
         outputs: &[AudioPort],
         affected_routes: &[BackendMixerLink],
     ) -> Result<()> {
@@ -915,11 +1057,10 @@ impl NativeRuntime {
     }
 
     fn remove_bus_internal(&mut self, bus_id: BackendBusId) -> Result<()> {
-        let bus = self
-            .buses
-            .get(&bus_id)
-            .cloned()
-            .ok_or_else(|| anyhow!("unknown native bus {bus_id:?}"))?;
+        if !self.buses.contains_key(&bus_id) {
+            return Err(anyhow!("unknown native bus {bus_id:?}"));
+        }
+        let bus = NativeBusSnapshot::of(self.buses.get(&bus_id).expect("bus present"));
         let channel_ids = bus
             .channels
             .iter()
@@ -1021,6 +1162,10 @@ impl NativeRuntime {
                 ));
             }
         }
+        if let Some(fx) = self.buses.get_mut(&bus_id).and_then(|bus| bus.fx.take()) {
+            let _ = self.session.remove_fx_chain(&fx.chain);
+            self.wait();
+        }
         self.buses.remove(&bus_id);
         for output_id in &output_ids {
             self.ports.remove(output_id);
@@ -1074,7 +1219,7 @@ impl NativeRuntime {
                         balance: bus.balance,
                         muted: bus.muted,
                         output_peaks_db,
-                        fx: None,
+                        fx: bus.fx.as_ref().map(native_bus_fx_state),
                     },
                 )
             })
@@ -1578,10 +1723,37 @@ impl NativeRuntime {
                 .map(|link| link.host_port_id.clone())
                 .collect(),
         }];
-        let buses = self
-            .buses
-            .values()
-            .map(|bus| BackendSessionBus {
+        let mut buses = Vec::with_capacity(self.buses.len());
+        for bus in self.buses.values_mut() {
+            let processor_state = bus
+                .fx
+                .as_mut()
+                .map(|fx| match fx.chain.try_get_state_str() {
+                    Ok(state) => {
+                        fx.last_confirmed_state = Some(state.clone());
+                        Ok(state)
+                    }
+                    Err(error) => fx.last_confirmed_state.clone().ok_or_else(|| {
+                        anyhow!(
+                            "bus processor state is unavailable and no checkpoint exists: {error}"
+                        )
+                    }),
+                })
+                .transpose()?;
+            let builtin_fx_midi_cc_assignments = bus
+                .fx
+                .as_ref()
+                .and_then(|fx| fx.chain.builtin_fx_midi_cc_assignments())
+                .into_iter()
+                .flat_map(|assignments| assignments.iter().collect::<Vec<_>>())
+                .map(|assignment| BuiltInFxMidiCcAssignment {
+                    parameter: app_builtin_fx_parameter(assignment.parameter),
+                    channel: assignment.channel,
+                    controller: assignment.controller,
+                })
+                .map(backend_builtin_fx_midi_cc_assignment)
+                .collect();
+            buses.push(BackendSessionBus {
                 source_id: bus.id.raw(),
                 name: bus.name.clone(),
                 channels: bus
@@ -1605,11 +1777,14 @@ impl NativeRuntime {
                 gain_db: bus.gain_db,
                 balance: bus.balance,
                 muted: bus.muted,
-                processor_type: None,
-                processor_state: None,
-                builtin_fx_midi_cc_assignments: Vec::new(),
-            })
-            .collect();
+                processor_type: bus
+                    .fx
+                    .as_ref()
+                    .map(|fx| fx.processor_type.as_str().to_owned()),
+                processor_state,
+                builtin_fx_midi_cc_assignments,
+            });
+        }
         let mixer_routes = self
             .mixer_routes
             .iter()
@@ -1652,11 +1827,23 @@ impl NativeRuntime {
             .insert(source_global.source_id, self.global_fx_port);
         self.remove_bus_internal(MASTER_BUS_ID)?;
         for source_bus in &data.buses {
+            validate_backend_bus_midi_cc_assignments(source_bus)?;
+            let fx = match source_bus.processor_type.as_deref() {
+                None => None,
+                Some(TrackProcessorTypeId::BUILTIN_FX) => Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: u32::try_from(source_bus.channels.len())
+                        .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
+                }),
+                Some(other) => {
+                    return Err(anyhow!("unsupported session bus processor {other}"));
+                }
+            };
             let request = BackendBusRequest {
                 name: source_bus.name.clone(),
                 channel_count: u32::try_from(source_bus.channels.len())
                     .map_err(|_| anyhow!("session bus channel count exceeds u32"))?,
-                fx: None,
+                fx,
             }
             .normalized()?;
             let expected_labels = default_bus_channel_labels(source_bus.channels.len())?;
@@ -1744,6 +1931,36 @@ impl NativeRuntime {
                 return Err(anyhow!("non-stereo session bus balance must be centered"));
             }
             self.apply_bus_control(created.bus_id, BackendBusControl::Mute(source_bus.muted))?;
+            match source_bus.processor_type.as_deref() {
+                None => {
+                    if source_bus.processor_state.is_some()
+                        || !source_bus.builtin_fx_midi_cc_assignments.is_empty()
+                    {
+                        return Err(anyhow!("unprocessed bus has processor state"));
+                    }
+                }
+                Some(TrackProcessorTypeId::BUILTIN_FX) => {
+                    let state = source_bus
+                        .processor_state
+                        .as_deref()
+                        .ok_or_else(|| anyhow!("processed bus has no saved processor state"))?;
+                    self.set_bus_fx_control(
+                        created.bus_id,
+                        BackendBusFxControl::RestoreState(state.to_owned()),
+                    )?;
+                    for assignment in &source_bus.builtin_fx_midi_cc_assignments {
+                        self.set_bus_fx_control(
+                            created.bus_id,
+                            BackendBusFxControl::BuiltInFx(BuiltInFxControl::AssignMidiCc(
+                                app_backend_builtin_fx_midi_cc_assignment(*assignment),
+                            )),
+                        )?;
+                    }
+                }
+                Some(other) => {
+                    return Err(anyhow!("unsupported session bus processor {other}"));
+                }
+            }
         }
         for external in &source_global.external_connections {
             if let Err(error) = self.set_port_connected(self.global_fx_port, external, true) {
@@ -3055,6 +3272,177 @@ impl NativeRuntime {
         }
     }
 
+    fn bus_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
+        let catalog = vec![super::bus_fx_descriptor()];
+        #[cfg(feature = "native-fx")]
+        let catalog = {
+            let mut catalog = catalog;
+            let carla_availability = shoop_engine::carla_native::carla_runtime_availability();
+            for (id, label, max_channels) in [
+                (TrackProcessorTypeId::CARLA_RACK, "Carla Rack", 2),
+                (TrackProcessorTypeId::CARLA_PATCHBAY, "Carla Patchbay", 2),
+                (
+                    TrackProcessorTypeId::CARLA_PATCHBAY_16X,
+                    "Carla Patchbay 16x",
+                    16,
+                ),
+            ] {
+                catalog.push(TrackProcessorDescriptor {
+                    id: TrackProcessorTypeId::new(id),
+                    label: label.to_owned(),
+                    available: carla_availability.is_ok(),
+                    unavailable_reason: carla_availability.as_ref().err().cloned(),
+                    constraints: TrackProcessorConstraints {
+                        min_dry_audio_channels: None,
+                        max_dry_audio_channels: Some(max_channels),
+                        min_wet_audio_channels: None,
+                        max_wet_audio_channels: Some(max_channels),
+                        matching_audio_channels: true,
+                        midi: TrackProcessorMidiPolicy::Unsupported,
+                    },
+                    features: TrackProcessorFeatures {
+                        state: true,
+                        external_ui: true,
+                        embedded_ui: false,
+                        recovery: true,
+                        logs: true,
+                    },
+                    editor: None,
+                });
+            }
+            catalog
+        };
+        Ok(catalog.into())
+    }
+
+    fn set_bus_fx_control(
+        &mut self,
+        bus_id: BackendBusId,
+        control: BackendBusFxControl,
+    ) -> Result<()> {
+        let processor_type = {
+            let bus = self
+                .buses
+                .get(&bus_id)
+                .ok_or_else(|| anyhow!("unknown native bus {bus_id:?}"))?;
+            let Some(fx) = bus.fx.as_ref() else {
+                return Err(anyhow!("bus has no processor"));
+            };
+            fx.processor_type.clone()
+        };
+        match control {
+            BackendBusFxControl::SetActive(active) => {
+                let fx = self
+                    .buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?;
+                fx.chain.set_active(active);
+                fx.active = active;
+            }
+            BackendBusFxControl::SetVisible(visible) => {
+                self.buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?
+                    .chain
+                    .set_visible(visible);
+            }
+            BackendBusFxControl::ToggleOrRecover => {
+                self.buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?
+                    .chain
+                    .toggle_or_recover()?;
+            }
+            BackendBusFxControl::RestoreState(state) => {
+                let fx = self
+                    .buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?;
+                fx.chain.try_restore_state(&state)?;
+                fx.last_confirmed_state = Some(state);
+            }
+            BackendBusFxControl::ClearLogs => {
+                self.buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?
+                    .chain
+                    .clear_logs();
+            }
+            BackendBusFxControl::BuiltInFx(control) => {
+                if processor_type.as_str() != TrackProcessorTypeId::BUILTIN_FX {
+                    return Err(anyhow!("bus is not a Built-in FX processor"));
+                }
+                let fx = self
+                    .buses
+                    .get_mut(&bus_id)
+                    .and_then(|bus| bus.fx.as_mut())
+                    .ok_or_else(|| anyhow!("bus has no processor"))?;
+                match control {
+                    BuiltInFxControl::SetStageEnabled(stage, enabled) => fx
+                        .chain
+                        .builtin_fx_set_stage_enabled(engine_builtin_fx_stage(stage), enabled)?,
+                    BuiltInFxControl::SetDriveType(drive_type) => fx
+                        .chain
+                        .builtin_fx_set_drive_type(engine_builtin_fx_drive_type(drive_type))?,
+                    BuiltInFxControl::SetModulationType(modulation_type) => {
+                        fx.chain.builtin_fx_set_modulation_type(
+                            engine_builtin_fx_modulation_type(modulation_type),
+                        )?
+                    }
+                    BuiltInFxControl::SetReverbType(reverb_type) => fx
+                        .chain
+                        .builtin_fx_set_reverb_type(engine_builtin_fx_reverb_type(reverb_type))?,
+                    BuiltInFxControl::SetParameter(parameter, value) => fx
+                        .chain
+                        .builtin_fx_set_parameter(engine_builtin_fx_parameter(parameter), value)?,
+                    BuiltInFxControl::AssignMidiCc(assignment) => fx
+                        .chain
+                        .builtin_fx_assign_midi_cc(engine_builtin_fx_midi_cc_assignment(
+                            assignment,
+                        ))?,
+                    BuiltInFxControl::RemoveMidiCc(parameter) => fx
+                        .chain
+                        .builtin_fx_remove_midi_cc(engine_builtin_fx_parameter(parameter))?,
+                    BuiltInFxControl::ClearMidiCcAssignments => {
+                        fx.chain.builtin_fx_clear_midi_cc_assignments()?
+                    }
+                    BuiltInFxControl::SetReverbEnabled(enabled) => {
+                        fx.chain.builtin_fx_set_reverb_enabled(enabled)?
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn bus_fx_state_string(&mut self, bus_id: BackendBusId) -> Result<Option<String>> {
+        let Some(fx) = self
+            .buses
+            .get_mut(&bus_id)
+            .ok_or_else(|| anyhow!("unknown native bus {bus_id:?}"))?
+            .fx
+            .as_mut()
+        else {
+            return Ok(None);
+        };
+        match fx.chain.try_get_state_str() {
+            Ok(state) => {
+                fx.last_confirmed_state = Some(state.clone());
+                Ok(Some(state))
+            }
+            Err(error) => fx
+                .last_confirmed_state
+                .clone()
+                .map(Some)
+                .ok_or_else(|| anyhow!("processor state unavailable: {error}")),
+        }
+    }
+
     fn apply_track_routing(&mut self, track_id: BackendTrackId) -> Result<()> {
         let (topology, loop_ids, monitoring) = {
             let track = self
@@ -4296,6 +4684,22 @@ impl Backend for NativeBackend {
         self.runtime_mut()?.apply_bus_control(bus_id, control)
     }
 
+    fn bus_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
+        self.runtime_mut()?.bus_processor_catalog()
+    }
+
+    fn set_bus_fx_control(
+        &mut self,
+        bus_id: BackendBusId,
+        control: BackendBusFxControl,
+    ) -> Result<()> {
+        self.runtime_mut()?.set_bus_fx_control(bus_id, control)
+    }
+
+    fn bus_fx_state_string(&mut self, bus_id: BackendBusId) -> Result<Option<String>> {
+        self.runtime_mut()?.bus_fx_state_string(bus_id)
+    }
+
     fn advance(&mut self, _elapsed: Duration) {}
 
     fn poll(&mut self) -> Result<BackendSnapshot> {
@@ -4758,6 +5162,49 @@ fn fx_lifecycle(lifecycle: shoop_engine::carla_processor::CarlaProcessorLifecycl
     }
 }
 
+fn native_bus_fx_title(bus_id: BackendBusId) -> String {
+    format!("bus_{}_fx", bus_id.raw())
+}
+
+fn native_bus_fx_state(fx: &NativeFx) -> TrackFxState {
+    let chain_state = fx.chain.get_state().unwrap_or_default();
+    let lifecycle = fx_lifecycle(fx.chain.lifecycle());
+    let deadline_misses = fx.chain.deadline_misses();
+    let stale_completions = fx.chain.stale_completions();
+    TrackFxState {
+        processor_type: fx.processor_type.clone(),
+        active: chain_state.active != 0,
+        visible: chain_state.visible != 0,
+        lifecycle,
+        generation: fx.chain.generation(),
+        deadline_misses,
+        stale_completions,
+        status_summary: fx_status_summary(lifecycle, deadline_misses, stale_completions),
+        crash_summary: fx.chain.crash_summary(),
+        logs: fx
+            .chain
+            .generation_logs()
+            .into_iter()
+            .map(|log| FxGenerationLogState {
+                generation: log.generation,
+                stdout: Arc::from(String::from_utf8_lossy(&log.stdout).into_owned()),
+                stderr: Arc::from(String::from_utf8_lossy(&log.stderr).into_owned()),
+                dropped_stdout_bytes: log.stdout_dropped_bytes,
+                dropped_stderr_bytes: log.stderr_dropped_bytes,
+            })
+            .collect::<Vec<_>>()
+            .into(),
+        editor: fx.chain.builtin_fx_state().map(|state| {
+            TrackProcessorEditorState::BuiltInFx(super::app_builtin_fx_state(
+                state,
+                fx.chain
+                    .builtin_fx_midi_cc_assignments()
+                    .unwrap_or_default(),
+            ))
+        }),
+    }
+}
+
 fn processor_chain_type(processor_type: &str) -> Option<FXChainType> {
     match processor_type {
         TrackProcessorTypeId::BUILTIN_FX => Some(FXChainType::BuiltInFx),
@@ -4861,6 +5308,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Surround".to_owned(),
                 channel_count: 4,
+                fx: None,
             })
             .unwrap();
         assert_eq!(created.channels.len(), 4);
@@ -4892,6 +5340,74 @@ mod tests {
             .application_ports
             .values()
             .all(|port| !matches!(port.owner, BackendPortOwner::Bus(_))));
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn native_dummy_bus_fx_builtin_round_trips_state_and_removes_cleanly() {
+        let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: 128,
+        }))
+        .unwrap();
+        let catalog = backend.bus_processor_catalog().unwrap();
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.id.as_str() == TrackProcessorTypeId::BUILTIN_FX));
+        assert!(catalog
+            .iter()
+            .all(|entry| entry.id.as_str() != TrackProcessorTypeId::OXISYNTH));
+        let created = backend
+            .create_bus(BackendBusRequest {
+                name: "FxBus".to_owned(),
+                channel_count: 2,
+                fx: Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 2,
+                }),
+            })
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        let snapshot = backend.poll().unwrap();
+        let fx = snapshot.mixer.buses[&created.bus_id]
+            .fx
+            .as_ref()
+            .expect("bus fx snapshot");
+        assert_eq!(fx.processor_type.as_str(), TrackProcessorTypeId::BUILTIN_FX);
+        assert!(fx
+            .editor
+            .as_ref()
+            .is_some_and(|editor| matches!(editor, TrackProcessorEditorState::BuiltInFx(_))));
+        let state = backend.bus_fx_state_string(created.bus_id).unwrap();
+        assert!(state.is_some());
+        let captured = backend.capture_session().unwrap();
+        let bus = captured
+            .buses
+            .iter()
+            .find(|bus| bus.name == "FxBus")
+            .expect("captured bus");
+        assert_eq!(
+            bus.processor_type.as_deref(),
+            Some(TrackProcessorTypeId::BUILTIN_FX)
+        );
+        assert!(bus.processor_state.is_some());
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::RestoreState(state.unwrap()),
+            )
+            .unwrap();
+        backend.remove_bus(created.bus_id).unwrap();
+        let snapshot = backend.poll().unwrap();
+        assert!(!snapshot.mixer.buses.contains_key(&created.bus_id));
+        assert!(backend.bus_fx_state_string(created.bus_id).is_err());
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -1079,6 +1079,7 @@ pub struct AppWidget {
     add_bus_open: bool,
     add_bus_name: String,
     add_bus_channels: u32,
+    add_bus_processor: Option<TrackProcessorTypeId>,
     next_add_bus_request_id: u64,
     pending_add_bus_request: Option<u64>,
     add_bus_error: Option<String>,
@@ -1177,6 +1178,7 @@ impl AppWidget {
             add_bus_open: false,
             add_bus_name: String::new(),
             add_bus_channels: 2,
+            add_bus_processor: None,
             next_add_bus_request_id: 1,
             pending_add_bus_request: None,
             add_bus_error: None,
@@ -1665,9 +1667,21 @@ impl AppWidget {
                             .filter(|link| output_ids.contains(&link.application_port_id))
                             .count();
                         let controls = self.bus_controls.entry(bus.id).or_default();
+                        let processor = bus.fx.as_ref().and_then(|fx| {
+                            state
+                                .bus_processors
+                                .iter()
+                                .find(|processor| processor.id == fx.processor_type)
+                        });
                         actions.extend(
                             controls
-                                .show(ui, bus, incoming_routes, outgoing_links)
+                                .show_with_processor(
+                                    ui,
+                                    bus,
+                                    incoming_routes,
+                                    outgoing_links,
+                                    processor,
+                                )
                                 .into_iter()
                                 .map(|action| AppAction::Bus {
                                     bus_id: bus.id,
@@ -1800,6 +1814,7 @@ impl AppWidget {
     fn open_add_bus_dialog(&mut self, bus_count: usize) {
         self.add_bus_name = format!("Bus {}", bus_count + 1);
         self.add_bus_channels = 2;
+        self.add_bus_processor = None;
         self.pending_add_bus_request = None;
         self.add_bus_error = None;
         self.add_bus_open = true;
@@ -1851,6 +1866,41 @@ impl AppWidget {
                                 .range(1..=crate::MAX_BUS_CHANNELS as u32),
                         );
                         ui.end_row();
+                        ui.label("Effect");
+                        let mut selected = self
+                            .add_bus_processor
+                            .as_ref()
+                            .map(|processor| processor.as_str().to_owned())
+                            .unwrap_or_else(|| "none".to_owned());
+                        egui::ComboBox::from_id_salt("add_bus_processor")
+                            .selected_text(
+                                selected
+                                    .as_str()
+                                    .eq("none")
+                                    .then_some("None")
+                                    .unwrap_or_else(|| {
+                                        state
+                                            .bus_processors
+                                            .iter()
+                                            .find(|processor| processor.id.as_str() == selected)
+                                            .map(|processor| processor.label.as_str())
+                                            .unwrap_or(&selected)
+                                    }),
+                            )
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(&mut selected, "none".to_owned(), "None");
+                                for processor in state.bus_processors.iter().filter(|p| p.available)
+                                {
+                                    ui.selectable_value(
+                                        &mut selected,
+                                        processor.id.as_str().to_owned(),
+                                        &processor.label,
+                                    );
+                                }
+                            });
+                        self.add_bus_processor =
+                            (selected != "none").then(|| TrackProcessorTypeId::new(selected));
+                        ui.end_row();
                     });
                 let trimmed = self.add_bus_name.trim();
                 let valid_name = !trimmed.is_empty()
@@ -1892,7 +1942,10 @@ impl AppWidget {
                 name: self.add_bus_name.trim().to_owned(),
                 channel_count: self.add_bus_channels,
                 creation_request_id: Some(request_id),
-                fx: None,
+                fx: self
+                    .add_bus_processor
+                    .clone()
+                    .map(|processor_type| crate::BusFxSpec { processor_type }),
             }));
         }
     }

--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -1892,6 +1892,7 @@ impl AppWidget {
                 name: self.add_bus_name.trim().to_owned(),
                 channel_count: self.add_bus_channels,
                 creation_request_id: Some(request_id),
+                fx: None,
             }));
         }
     }
@@ -3623,6 +3624,7 @@ mod tests {
                 name: "Surround".to_owned(),
                 channel_count: 6,
                 creation_request_id: Some(1),
+                fx: None,
             })]
         );
         assert_eq!(widget.pending_add_bus_request, Some(1));
@@ -4184,6 +4186,7 @@ mod tests {
             output_peaks_db: Arc::from([-20.0, -10.0]),
             control_pending: false,
             control_error: None,
+            fx: None,
         };
         let mut state = AppState {
             tracks: vec![TrackState {

--- a/src/rust/shoop_egui/src/builtin_fx_editor.rs
+++ b/src/rust/shoop_egui/src/builtin_fx_editor.rs
@@ -1,8 +1,8 @@
 use crate::{
     BuiltInFxControl, BuiltInFxDriveType, BuiltInFxMidiCcAssignment, BuiltInFxModulationType,
-    BuiltInFxParameter, BuiltInFxReverbType, BuiltInFxStage, BuiltInFxState, TrackAction,
-    TrackProcessorDescriptor, TrackProcessorEditorDescriptor, TrackProcessorEditorState,
-    TrackState,
+    BuiltInFxParameter, BuiltInFxReverbType, BuiltInFxStage, BuiltInFxState, BusAction, BusState,
+    TrackAction, TrackFxState, TrackProcessorDescriptor, TrackProcessorEditorDescriptor,
+    TrackProcessorEditorState, TrackState,
 };
 
 pub(crate) const FUNDSP_URL: &str = "https://github.com/SamiPerttu/fundsp";
@@ -62,7 +62,54 @@ impl BuiltInFxEditor {
         state: &TrackState,
         processor: Option<&TrackProcessorDescriptor>,
     ) -> Vec<TrackAction> {
-        let Some(fx) = &state.fx else {
+        let latest_cc = state
+            .controls
+            .latest_input_midi_message
+            .and_then(|message| message.midi_cc());
+        Self::show_for_fx(
+            self,
+            context,
+            &state.name,
+            state.id.raw(),
+            &state.fx,
+            processor,
+            latest_cc,
+            TrackAction::BuiltInFx,
+            TrackAction::FxVisibilityChanged(false),
+        )
+    }
+
+    pub(crate) fn show_for_bus(
+        &mut self,
+        context: &egui::Context,
+        state: &BusState,
+        processor: Option<&TrackProcessorDescriptor>,
+    ) -> Vec<BusAction> {
+        Self::show_for_fx(
+            self,
+            context,
+            &state.name,
+            state.id.raw(),
+            &state.fx,
+            processor,
+            None,
+            BusAction::BuiltInFx,
+            BusAction::FxVisibilityChanged(false),
+        )
+    }
+
+    fn show_for_fx<A>(
+        &mut self,
+        context: &egui::Context,
+        name: &str,
+        id: u64,
+        fx: &Option<TrackFxState>,
+        processor: Option<&TrackProcessorDescriptor>,
+        latest_cc: Option<(u8, u8, u8)>,
+        wrap: impl Fn(BuiltInFxControl) -> A,
+        hide: A,
+    ) -> Vec<A> {
+        let Some(fx) = fx else {
             return Vec::new();
         };
         let Some(TrackProcessorEditorState::BuiltInFx(editor)) = &fx.editor else {
@@ -86,8 +133,8 @@ impl BuiltInFxEditor {
         }
         let mut actions = Vec::new();
         let mut open = true;
-        let _shown = egui::Window::new(format!("{} — Built-in FX", state.name))
-            .id(egui::Id::new(("builtin_fx_editor", state.id)))
+        let _shown = egui::Window::new(format!("{name} — Built-in FX"))
+            .id(egui::Id::new(("builtin_fx_editor", id)))
             .open(&mut open)
             .resizable(true)
             .default_width(430.0)
@@ -116,9 +163,7 @@ impl BuiltInFxEditor {
                         #[cfg(test)]
                         self.stage_rects.push(($stage, response.rect));
                         if response.changed() {
-                            actions.push(TrackAction::BuiltInFx(
-                                BuiltInFxControl::SetStageEnabled($stage, value),
-                            ));
+                            actions.push(wrap(BuiltInFxControl::SetStageEnabled($stage, value)));
                         }
                     }};
                 }
@@ -139,9 +184,7 @@ impl BuiltInFxEditor {
                         #[cfg(test)]
                         self.parameter_rects.push(($parameter, response.rect));
                         if response.changed() {
-                            actions.push(TrackAction::BuiltInFx(BuiltInFxControl::SetParameter(
-                                $parameter, value,
-                            )));
+                            actions.push(wrap(BuiltInFxControl::SetParameter($parameter, value)));
                         }
                     }};
                 }
@@ -179,7 +222,7 @@ impl BuiltInFxEditor {
                             }
                         });
                     if let Some(control) = drive_type_control(editor.drive_type, drive_type) {
-                        actions.push(TrackAction::BuiltInFx(control));
+                        actions.push(wrap(control));
                     }
                     parameter_slider!(ui, BuiltInFxParameter::Drive, true);
                     parameter_slider!(ui, BuiltInFxParameter::DriveTone, true);
@@ -225,7 +268,7 @@ impl BuiltInFxEditor {
                     if let Some(control) =
                         modulation_type_control(editor.modulation_type, modulation_type)
                     {
-                        actions.push(TrackAction::BuiltInFx(control));
+                        actions.push(wrap(control));
                     }
                     parameter_slider!(ui, BuiltInFxParameter::ModulationRate, true);
                     parameter_slider!(ui, BuiltInFxParameter::ModulationDepth, true);
@@ -256,7 +299,7 @@ impl BuiltInFxEditor {
                             }
                         });
                     if let Some(control) = reverb_type_control(editor.reverb_type, reverb_type) {
-                        actions.push(TrackAction::BuiltInFx(control));
+                        actions.push(wrap(control));
                     }
                     parameter_slider!(ui, BuiltInFxParameter::ReverbAmount, true);
                     parameter_slider!(ui, BuiltInFxParameter::ReverbTone, true);
@@ -264,14 +307,10 @@ impl BuiltInFxEditor {
             });
 
         if self.midi_learn_open {
-            let latest_cc = state
-                .controls
-                .latest_input_midi_message
-                .and_then(|message| message.midi_cc());
             let mut learn_open = self.midi_learn_open;
             let mut selected_parameter = self.selected_midi_parameter;
-            egui::Window::new(format!("{} — MIDI Learn", state.name))
-                .id(egui::Id::new(("builtin_fx_midi_learn", state.id)))
+            egui::Window::new(format!("{name} — MIDI Learn"))
+                .id(egui::Id::new(("builtin_fx_midi_learn", id)))
                 .open(&mut learn_open)
                 .resizable(true)
                 .show(context, |ui| {
@@ -305,7 +344,7 @@ impl BuiltInFxEditor {
                         }
                         if assign.clicked() {
                             let (channel, controller, _) = latest_cc.expect("button is enabled");
-                            actions.push(TrackAction::BuiltInFx(BuiltInFxControl::AssignMidiCc(
+                            actions.push(wrap(BuiltInFxControl::AssignMidiCc(
                                 BuiltInFxMidiCcAssignment {
                                     parameter: selected_parameter,
                                     channel,
@@ -332,9 +371,9 @@ impl BuiltInFxEditor {
                             self.midi_remove_rects
                                 .push((assignment.parameter, remove.rect));
                             if remove.clicked() {
-                                actions.push(TrackAction::BuiltInFx(
-                                    BuiltInFxControl::RemoveMidiCc(assignment.parameter),
-                                ));
+                                actions.push(wrap(BuiltInFxControl::RemoveMidiCc(
+                                    assignment.parameter,
+                                )));
                             }
                         });
                     }
@@ -347,9 +386,7 @@ impl BuiltInFxEditor {
                         self.midi_remove_all_rect = Some(remove_all.rect);
                     }
                     if remove_all.clicked() {
-                        actions.push(TrackAction::BuiltInFx(
-                            BuiltInFxControl::ClearMidiCcAssignments,
-                        ));
+                        actions.push(wrap(BuiltInFxControl::ClearMidiCcAssignments));
                     }
                 });
             self.midi_learn_open = learn_open;
@@ -361,7 +398,7 @@ impl BuiltInFxEditor {
             self.window_rect = _shown.map(|response| response.response.rect);
         }
         if !open {
-            actions.push(TrackAction::FxVisibilityChanged(false));
+            actions.push(hide);
         }
         actions
     }

--- a/src/rust/shoop_egui/src/bus_controls.rs
+++ b/src/rust/shoop_egui/src/bus_controls.rs
@@ -417,6 +417,7 @@ mod tests {
             output_peaks_db: vec![-12.0; channels].into(),
             control_pending: false,
             control_error: None,
+            fx: None,
         }
     }
 

--- a/src/rust/shoop_egui/src/bus_controls.rs
+++ b/src/rust/shoop_egui/src/bus_controls.rs
@@ -1,6 +1,7 @@
 use crate::{
-    colors, dial::paint_dial, meter_ballistics::PeakMeterAnimation,
-    optimistic_value::OptimisticValue, BusAction, BusId, BusState, MAX_BUS_GAIN_DB,
+    builtin_fx_editor::BuiltInFxEditor, colors, dial::paint_dial,
+    meter_ballistics::PeakMeterAnimation, optimistic_value::OptimisticValue, BusAction, BusId,
+    BusState, FxLifecycle, TrackFxState, TrackProcessorDescriptor, MAX_BUS_GAIN_DB,
     MIN_BUS_GAIN_DB,
 };
 use egui_material_icons::icons::{
@@ -29,6 +30,8 @@ pub struct BusControls {
     balance_drag_start: Option<f32>,
     peaks: Vec<PeakMeterAnimation>,
     remove_confirmation_open: bool,
+    fx_logs_open: bool,
+    builtin_fx_editor: BuiltInFxEditor,
     #[cfg(test)]
     test_rects: TestBusControlRects,
 }
@@ -46,6 +49,7 @@ struct TestBusControlRects {
     mute: Option<egui::Rect>,
     gain: Option<egui::Rect>,
     balance: Option<egui::Rect>,
+    fx: Option<egui::Rect>,
 }
 
 impl BusControls {
@@ -55,6 +59,17 @@ impl BusControls {
         state: &BusState,
         incoming_routes: usize,
         outgoing_links: usize,
+    ) -> Vec<BusAction> {
+        self.show_with_processor(ui, state, incoming_routes, outgoing_links, None)
+    }
+
+    pub fn show_with_processor(
+        &mut self,
+        ui: &mut egui::Ui,
+        state: &BusState,
+        incoming_routes: usize,
+        outgoing_links: usize,
+        processor: Option<&TrackProcessorDescriptor>,
     ) -> Vec<BusAction> {
         #[cfg(test)]
         {
@@ -140,7 +155,7 @@ impl BusControls {
                             }
                         });
                     });
-                    self.show_control_row(ui, state, meter_width, &mut actions);
+                    self.show_control_row(ui, state, meter_width, processor, &mut actions);
                 });
             })
             .response;
@@ -148,6 +163,7 @@ impl BusControls {
         {
             self.test_rects.block = Some(_response.rect);
         }
+        self.show_fx_windows(ui.ctx(), state, processor, &mut actions);
         if self.remove_confirmation_open {
             let mut open = true;
             let mut remove = false;
@@ -185,6 +201,7 @@ impl BusControls {
         ui: &mut egui::Ui,
         state: &BusState,
         meter_width: f32,
+        processor: Option<&TrackProcessorDescriptor>,
         actions: &mut Vec<BusAction>,
     ) {
         let stereo = state.stereo();
@@ -330,8 +347,133 @@ impl BusControls {
                 actions.push(BusAction::MuteChanged(!state.muted));
             }
         });
+        self.show_fx_row(ui, state, processor, group_width, actions);
     }
 
+    fn show_fx_row(
+        &mut self,
+        ui: &mut egui::Ui,
+        state: &BusState,
+        processor: Option<&TrackProcessorDescriptor>,
+        group_width: f32,
+        actions: &mut Vec<BusAction>,
+    ) {
+        let Some(fx) = &state.fx else {
+            return;
+        };
+        let features = processor.map(|value| value.features).unwrap_or_default();
+        let color = bus_fx_color(fx);
+        let fx_button = ui
+            .add_sized(
+                [group_width, 22.0],
+                egui::Button::new(egui::RichText::new("FX").color(color)),
+            )
+            .on_hover_text(bus_fx_hover_text(fx));
+        #[cfg(test)]
+        {
+            self.test_rects.fx = Some(fx_button.rect);
+        }
+        if fx_button.clicked() {
+            actions.push(bus_fx_primary_action(fx));
+        }
+        fx_button.context_menu(|ui| {
+            if ui
+                .add_enabled(features.logs, egui::Button::new("Process logs..."))
+                .clicked()
+            {
+                self.fx_logs_open = true;
+                ui.close();
+            }
+        });
+    }
+
+    fn show_fx_windows(
+        &mut self,
+        context: &egui::Context,
+        state: &BusState,
+        processor: Option<&TrackProcessorDescriptor>,
+        actions: &mut Vec<BusAction>,
+    ) {
+        actions.extend(
+            self.builtin_fx_editor
+                .show_for_bus(context, state, processor),
+        );
+        if !self.fx_logs_open {
+            return;
+        }
+        let Some(fx) = &state.fx else {
+            self.fx_logs_open = false;
+            return;
+        };
+        let mut open = true;
+        egui::Window::new(format!("{} — Process logs", state.name))
+            .id(egui::Id::new(("bus_fx_logs", state.id.raw())))
+            .open(&mut open)
+            .resizable(true)
+            .show(context, |ui| {
+                ui.label(format!(
+                    "Lifecycle: {:?} · generation {}",
+                    fx.lifecycle, fx.generation
+                ));
+                if let Some(summary) = &fx.crash_summary {
+                    ui.colored_label(egui::Color32::LIGHT_RED, summary);
+                }
+                if fx.logs.is_empty() {
+                    ui.weak("No process logs");
+                }
+                for log in fx.logs.iter() {
+                    ui.label(format!(
+                        "generation {}\nstdout:\n{}\nstderr:\n{}",
+                        log.generation, log.stdout, log.stderr
+                    ));
+                }
+                if ui.button("Clear").clicked() {
+                    actions.push(BusAction::FxClearLogs);
+                }
+            });
+        if !open {
+            self.fx_logs_open = false;
+        }
+    }
+}
+
+fn bus_fx_color(fx: &TrackFxState) -> egui::Color32 {
+    match fx.lifecycle {
+        FxLifecycle::Running if fx.active => egui::Color32::LIGHT_GREEN,
+        FxLifecycle::Running => egui::Color32::GRAY,
+        FxLifecycle::Starting | FxLifecycle::Degraded | FxLifecycle::Restarting => {
+            egui::Color32::YELLOW
+        }
+        FxLifecycle::Crashed | FxLifecycle::Unavailable => egui::Color32::LIGHT_RED,
+        FxLifecycle::Stopped => egui::Color32::GRAY,
+    }
+}
+
+fn bus_fx_hover_text(fx: &TrackFxState) -> String {
+    format!(
+        "{}: {:?}{}",
+        fx.processor_type,
+        fx.lifecycle,
+        fx.status_summary
+            .as_deref()
+            .or(fx.crash_summary.as_deref())
+            .map(|summary| format!(" — {summary}"))
+            .unwrap_or_default()
+    )
+}
+
+fn bus_fx_primary_action(fx: &TrackFxState) -> BusAction {
+    if matches!(
+        fx.lifecycle,
+        FxLifecycle::Crashed | FxLifecycle::Unavailable
+    ) {
+        BusAction::FxToggleOrRecover
+    } else {
+        BusAction::FxVisibilityChanged(!fx.visible)
+    }
+}
+
+impl BusControls {
     #[cfg(test)]
     pub(crate) fn block_rect(&self) -> Option<egui::Rect> {
         self.test_rects.block
@@ -390,12 +532,23 @@ impl BusControls {
                 .request_repaint_after(std::time::Duration::from_millis(16));
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn fx_rect(&self) -> Option<egui::Rect> {
+        self.test_rects.fx
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::{BusChannelId, BusChannelState, BusId, PortId};
+    use crate::{
+        BuiltInFxState, BusChannelId, BusChannelState, BusId, PortId, TrackProcessorConstraints,
+        TrackProcessorEditorDescriptor, TrackProcessorEditorState, TrackProcessorFeatures,
+        TrackProcessorMidiPolicy, TrackProcessorTypeId,
+    };
 
     fn state(channels: usize) -> BusState {
         BusState {
@@ -427,17 +580,27 @@ mod tests {
         state: &BusState,
         events: Vec<egui::Event>,
     ) -> Vec<BusAction> {
+        frame_with_processor(context, controls, state, None, events)
+    }
+
+    fn frame_with_processor(
+        context: &egui::Context,
+        controls: &mut BusControls,
+        state: &BusState,
+        processor: Option<&TrackProcessorDescriptor>,
+        events: Vec<egui::Event>,
+    ) -> Vec<BusAction> {
         let mut actions = Vec::new();
         let mut output = context.run_ui(
             egui::RawInput {
                 screen_rect: Some(egui::Rect::from_min_size(
                     egui::Pos2::ZERO,
-                    egui::vec2(240.0, 220.0),
+                    egui::vec2(240.0, 420.0),
                 )),
                 events,
                 ..Default::default()
             },
-            |ui| actions = controls.show(ui, state, 0, 0),
+            |ui| actions = controls.show_with_processor(ui, state, 0, 0, processor),
         );
         output.textures_delta.clear();
         actions
@@ -785,5 +948,119 @@ mod tests {
             ],
         );
         assert_eq!(actions, [BusAction::Remove]);
+    }
+
+    fn fx_fixture() -> (BusState, TrackProcessorDescriptor) {
+        let processor = TrackProcessorDescriptor {
+            id: TrackProcessorTypeId::new(TrackProcessorTypeId::BUILTIN_FX),
+            label: "Built-in FX".to_owned(),
+            available: true,
+            unavailable_reason: None,
+            constraints: TrackProcessorConstraints {
+                min_dry_audio_channels: Some(1),
+                max_dry_audio_channels: None,
+                min_wet_audio_channels: Some(1),
+                max_wet_audio_channels: None,
+                matching_audio_channels: true,
+                midi: TrackProcessorMidiPolicy::Unsupported,
+            },
+            features: TrackProcessorFeatures {
+                state: true,
+                embedded_ui: true,
+                logs: true,
+                recovery: true,
+                ..TrackProcessorFeatures::default()
+            },
+            editor: Some(TrackProcessorEditorDescriptor::BuiltInFx),
+        };
+        let mut state = state(2);
+        state.fx = Some(TrackFxState {
+            processor_type: processor.id.clone(),
+            active: true,
+            visible: false,
+            lifecycle: FxLifecycle::Running,
+            generation: 1,
+            deadline_misses: 0,
+            stale_completions: 0,
+            status_summary: None,
+            crash_summary: None,
+            logs: Arc::from([]),
+            editor: Some(TrackProcessorEditorState::BuiltInFx(
+                BuiltInFxState::default(),
+            )),
+        });
+        (state, processor)
+    }
+
+    fn click(
+        context: &egui::Context,
+        controls: &mut BusControls,
+        state: &BusState,
+        processor: &TrackProcessorDescriptor,
+        position: egui::Pos2,
+    ) -> Vec<BusAction> {
+        frame_with_processor(
+            context,
+            controls,
+            state,
+            Some(processor),
+            vec![
+                egui::Event::PointerMoved(position),
+                egui::Event::PointerButton {
+                    pos: position,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        );
+        frame_with_processor(
+            context,
+            controls,
+            state,
+            Some(processor),
+            vec![
+                egui::Event::PointerMoved(position),
+                egui::Event::PointerButton {
+                    pos: position,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::NONE,
+                },
+            ],
+        )
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn fx_button_toggles_visibility_without_midi_ports() {
+        let context = egui::Context::default();
+        crate::initialize(&context);
+        let mut controls = BusControls::default();
+        let (state, processor) = fx_fixture();
+        frame_with_processor(
+            &context,
+            &mut controls,
+            &state,
+            Some(&processor),
+            Vec::new(),
+        );
+        assert!(controls.fx_rect().is_some());
+        let position = controls.fx_rect().unwrap().center();
+        let actions = click(&context, &mut controls, &state, &processor, position);
+        assert_eq!(actions, [BusAction::FxVisibilityChanged(true)]);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn fx_picker_hides_synth_processors() {
+        let catalog = [
+            TrackProcessorTypeId::new(TrackProcessorTypeId::BUILTIN_FX),
+            TrackProcessorTypeId::new(TrackProcessorTypeId::OXISYNTH),
+        ];
+        let bus_catalog = catalog
+            .iter()
+            .filter(|id| id.as_str() != TrackProcessorTypeId::OXISYNTH)
+            .collect::<Vec<_>>();
+        assert_eq!(bus_catalog.len(), 1);
+        assert_eq!(bus_catalog[0].as_str(), TrackProcessorTypeId::BUILTIN_FX);
     }
 }

--- a/src/rust/shoop_egui/src/connection_dialog.rs
+++ b/src/rust/shoop_egui/src/connection_dialog.rs
@@ -1779,6 +1779,7 @@ mod tests {
             output_peaks_db: Arc::from([-200.0]),
             control_pending: false,
             control_error: None,
+            fx: None,
         }]);
         let connections = Arc::make_mut(&mut state.connections);
         let mut ports = connections.application_ports.to_vec();

--- a/src/rust/shoop_egui/src/track_widget.rs
+++ b/src/rust/shoop_egui/src/track_widget.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::{
     colors, composite_loop_widget::LoopDragPayload, AppIntent, DefaultPlaybackMode, FxLifecycle,
     GlobalControlState, LoopId, LoopWidget, LoopWidgetAction, ProcessorLatencyAdjustmentState,
-    RecordingOffsetAdjustmentState, TrackControls, TrackProcessorDescriptor, TrackState,
-    TrackWidgetAction,
+    RecordingOffsetAdjustmentState, TrackControls, TrackFxState, TrackProcessorDescriptor,
+    TrackState, TrackWidgetAction,
 };
 use egui_material_icons::icons::{ICON_ADD, ICON_DRAG_INDICATOR, ICON_MORE_VERT};
 
@@ -202,7 +202,7 @@ fn track_background(state: &crate::TrackControlState) -> egui::Color32 {
     }
 }
 
-fn fx_color(fx: &crate::TrackFxState) -> egui::Color32 {
+fn fx_color(fx: &TrackFxState) -> egui::Color32 {
     match fx.lifecycle {
         FxLifecycle::Running if fx.active => egui::Color32::LIGHT_GREEN,
         FxLifecycle::Running => egui::Color32::GRAY,
@@ -214,7 +214,7 @@ fn fx_color(fx: &crate::TrackFxState) -> egui::Color32 {
     }
 }
 
-fn fx_hover_text(fx: &crate::TrackFxState) -> String {
+fn fx_hover_text(fx: &TrackFxState) -> String {
     format!(
         "{}: {:?}{}",
         fx.processor_type,
@@ -227,7 +227,7 @@ fn fx_hover_text(fx: &crate::TrackFxState) -> String {
     )
 }
 
-fn fx_primary_action(fx: &crate::TrackFxState) -> TrackWidgetAction {
+fn fx_primary_action(fx: &TrackFxState) -> TrackWidgetAction {
     if matches!(
         fx.lifecycle,
         FxLifecycle::Crashed | FxLifecycle::Unavailable

--- a/src/rust/shoop_engine/src/session.rs
+++ b/src/rust/shoop_engine/src/session.rs
@@ -1684,7 +1684,7 @@ impl Session {
         if let ProcessorBackend::BuiltInFx(processor) = &route.backend {
             if audio_inputs.len() != processor.audio_channels()
                 || audio_outputs.len() != processor.audio_channels()
-                || midi_inputs.len() != 1
+                || midi_inputs.len() > 1
             {
                 return Err(SessionError::InvalidProcessorPorts);
             }
@@ -2533,22 +2533,20 @@ impl Session {
         }
 
         route.global_current.clear();
-        if !route.midi_inputs.is_empty() {
-            if let Some(port) = self
-                .global_fx_midi_input
-                .and_then(|port| self.ports.get(port))
-            {
-                for event in port.midi_events() {
-                    if PendingMidiControlState::supports(event.data()) {
-                        if route.global_current.len() < MAX_MIDI_EVENTS_PER_BLOCK {
-                            route.global_current.push(*event);
-                        } else {
-                            route.global_capacity_deferrals =
-                                route.global_capacity_deferrals.saturating_add(1);
-                        }
+        if let Some(port) = self
+            .global_fx_midi_input
+            .and_then(|port| self.ports.get(port))
+        {
+            for event in port.midi_events() {
+                if PendingMidiControlState::supports(event.data()) {
+                    if route.global_current.len() < MAX_MIDI_EVENTS_PER_BLOCK {
+                        route.global_current.push(*event);
                     } else {
-                        route.global_rejected = route.global_rejected.saturating_add(1);
+                        route.global_capacity_deferrals =
+                            route.global_capacity_deferrals.saturating_add(1);
                     }
+                } else {
+                    route.global_rejected = route.global_rejected.saturating_add(1);
                 }
             }
         }
@@ -4050,7 +4048,7 @@ mod tests {
     }
 
     #[shoop_wasm_test_support::shoop_test]
-    fn builtin_fx_routes_matching_mono_stereo_and_n_channels_with_required_midi() {
+    fn builtin_fx_routes_matching_mono_stereo_and_n_channels_with_optional_midi() {
         use crate::builtin_fx::{BuiltInFxProcessor, BuiltInFxStage, BuiltInFxState};
 
         let frames = 4;
@@ -4115,15 +4113,6 @@ mod tests {
                     processor_inputs[..channels - 1].to_vec(),
                     processor_outputs.clone(),
                     vec![midi],
-                ),
-                Err(SessionError::InvalidProcessorPorts)
-            );
-            assert_eq!(
-                session.set_processor_ports(
-                    "builtin",
-                    processor_inputs.clone(),
-                    processor_outputs.clone(),
-                    vec![],
                 ),
                 Err(SessionError::InvalidProcessorPorts)
             );
@@ -4221,6 +4210,96 @@ mod tests {
                 2
             );
         }
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn builtin_fx_processes_audio_without_midi_ports() {
+        use crate::builtin_fx::{BuiltInFxProcessor, BuiltInFxStage, BuiltInFxState};
+
+        let frames = 64;
+        let channels = 2;
+        let mut session = Session::default();
+        session.set_sample_rate(48_000);
+        session.set_buffer_size(frames as u32);
+        let mut inputs = Vec::new();
+        let mut sends = Vec::new();
+        let mut returns = Vec::new();
+        let mut outputs = Vec::new();
+        for channel in 0..channels {
+            let input = session.add_port(dummy_with_frames(
+                600 + channel as u64,
+                &format!("input-{channel}"),
+                PortDirection::Input,
+                frames,
+            ));
+            let send = session.add_port(internal(&format!("builtin:audio_in_{channel}"), frames));
+            let return_ =
+                session.add_port(internal(&format!("builtin:audio_out_{channel}"), frames));
+            let output = session.add_port(dummy_with_frames(
+                700 + channel as u64,
+                &format!("output-{channel}"),
+                PortDirection::Output,
+                frames,
+            ));
+            session.connect_ports_internal(input, send).unwrap();
+            session.connect_ports_internal(return_, output).unwrap();
+            inputs.push(input);
+            sends.push(send);
+            returns.push(return_);
+            outputs.push(output);
+        }
+        session.set_builtin_fx_processor(
+            "builtin",
+            BuiltInFxProcessor::new(
+                48_000.0,
+                frames / 2,
+                BuiltInFxState {
+                    reverb_enabled: false,
+                    ..BuiltInFxState::default()
+                },
+            ),
+        );
+        session.set_builtin_fx_active("builtin", true);
+        session
+            .set_processor_ports("builtin", sends, returns, vec![])
+            .unwrap();
+        session.apply_graph_changes().unwrap();
+
+        for &input in &inputs {
+            session
+                .port_mut(input)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .queue_data(&vec![0.25; frames]);
+        }
+        for &output in &outputs {
+            session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .request_data(frames);
+        }
+        session.process(frames);
+        for (channel, &output) in outputs.iter().enumerate() {
+            let actual = session
+                .port_mut(output)
+                .unwrap()
+                .as_dummy_mut()
+                .unwrap()
+                .dequeue_data(frames)
+                .unwrap();
+            assert!(actual.iter().all(|sample| sample.is_finite()));
+            assert!(actual[0] > 0.1, "channel {channel} produced {actual:?}");
+        }
+        assert_eq!(
+            session
+                .builtin_fx_processor_mut("builtin")
+                .unwrap()
+                .stage_process_calls(BuiltInFxStage::Reverb),
+            0
+        );
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_session/src/archive.rs
+++ b/src/rust/shoop_session/src/archive.rs
@@ -1,10 +1,11 @@
 use crate::document::{
     AudioPayload, ChannelDocument, ChannelModeDocument, CompositeKindDocument,
     ConnectabilityDocument, DataTypeDocument, DefaultPlaybackModeDocument, FormatVersion,
-    FxChainTypeDocument, MediaPayload, PortDirectionDocument, PortDocument, PortRoleDocument,
-    ProcessorLatencyAdjustmentDocument, RecordingOffsetAdjustmentDocument, SessionBundle,
-    SessionDocument, TrackDocument, TrackTopologyDocument, AUDIO_FORMAT, DOCUMENT_VERSION,
-    FORMAT_MAJOR, FORMAT_MINOR, MIDI_FORMAT, SESSION_DOCUMENT_VERSION, SESSION_FORMAT,
+    FxChainDocument, FxChainTypeDocument, MediaPayload, PortDirectionDocument, PortDocument,
+    PortRoleDocument, ProcessorLatencyAdjustmentDocument, RecordingOffsetAdjustmentDocument,
+    SessionBundle, SessionDocument, TrackDocument, TrackTopologyDocument, AUDIO_FORMAT,
+    DOCUMENT_VERSION, FORMAT_MAJOR, FORMAT_MINOR, MIDI_FORMAT, SESSION_DOCUMENT_VERSION,
+    SESSION_FORMAT,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1372,6 +1373,7 @@ pub fn validate_bundle(bundle: &SessionBundle) -> Result<(), SessionError> {
                 )));
             }
         }
+        validate_bus_fx_shape(bus)?;
     }
     let display_order = bundle
         .document
@@ -1578,52 +1580,90 @@ fn is_canonical_builtin_fx_state(state: &str) -> bool {
     })
 }
 
+fn validate_fx_chain_assignments(chain: &FxChainDocument) -> Result<(), SessionError> {
+    if chain.chain_type != FxChainTypeDocument::BuiltInFx
+        && !chain.builtin_fx_midi_cc_assignments.is_empty()
+    {
+        return Err(SessionError::Validation(format!(
+            "non-Built-in FX chain {} contains Built-in FX MIDI CC assignments",
+            chain.id
+        )));
+    }
+    let mut builtin_parameters = BTreeSet::new();
+    let mut builtin_sources = BTreeSet::new();
+    for assignment in &chain.builtin_fx_midi_cc_assignments {
+        if assignment.channel > 15
+            || assignment.controller > 127
+            || !builtin_parameters.insert(assignment.parameter)
+            || !builtin_sources.insert((assignment.channel, assignment.controller))
+        {
+            return Err(SessionError::Validation(format!(
+                "FX chain {} contains invalid or duplicate Built-in FX MIDI CC assignments",
+                chain.id
+            )));
+        }
+    }
+    if chain.chain_type != FxChainTypeDocument::OxiSynth && !chain.midi_cc_assignments.is_empty() {
+        return Err(SessionError::Validation(format!(
+            "non-OxiSynth FX chain {} contains MIDI CC assignments",
+            chain.id
+        )));
+    }
+    let mut parameters = BTreeSet::new();
+    let mut sources = BTreeSet::new();
+    for assignment in &chain.midi_cc_assignments {
+        if assignment.channel > 15
+            || assignment.controller > 127
+            || !parameters.insert(assignment.parameter)
+            || !sources.insert((assignment.channel, assignment.controller))
+        {
+            return Err(SessionError::Validation(format!(
+                "FX chain {} contains invalid or duplicate MIDI CC assignments",
+                chain.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_bus_fx_shape(bus: &crate::document::BusDocument) -> Result<(), SessionError> {
+    let Some(chain) = &bus.fx_chain else {
+        return Ok(());
+    };
+    validate_fx_chain_assignments(chain)?;
+    match chain.chain_type {
+        FxChainTypeDocument::CarlaRack
+        | FxChainTypeDocument::CarlaPatchbay
+        | FxChainTypeDocument::CarlaPatchbay16x
+        | FxChainTypeDocument::BuiltInFx
+        | FxChainTypeDocument::Test => {}
+        FxChainTypeDocument::OxiSynth => {
+            return Err(SessionError::Validation(format!(
+                "bus {} FX chain type is unsupported",
+                bus.id
+            )));
+        }
+    }
+    if chain.chain_type == FxChainTypeDocument::BuiltInFx
+        && !is_canonical_builtin_fx_state(&chain.internal_state)
+    {
+        return Err(SessionError::Validation(format!(
+            "bus {} contains invalid Built-in FX processor state",
+            bus.id
+        )));
+    }
+    if !chain.midi_cc_assignments.is_empty() {
+        return Err(SessionError::Validation(format!(
+            "bus {} FX chain must not contain MIDI CC assignments",
+            bus.id
+        )));
+    }
+    Ok(())
+}
+
 fn validate_track_fx_shape(track: &TrackDocument) -> Result<(), SessionError> {
     if let Some(chain) = &track.fx_chain {
-        if chain.chain_type != FxChainTypeDocument::BuiltInFx
-            && !chain.builtin_fx_midi_cc_assignments.is_empty()
-        {
-            return Err(SessionError::Validation(format!(
-                "non-Built-in FX chain {} contains Built-in FX MIDI CC assignments",
-                chain.id
-            )));
-        }
-        let mut builtin_parameters = BTreeSet::new();
-        let mut builtin_sources = BTreeSet::new();
-        for assignment in &chain.builtin_fx_midi_cc_assignments {
-            if assignment.channel > 15
-                || assignment.controller > 127
-                || !builtin_parameters.insert(assignment.parameter)
-                || !builtin_sources.insert((assignment.channel, assignment.controller))
-            {
-                return Err(SessionError::Validation(format!(
-                    "FX chain {} contains invalid or duplicate Built-in FX MIDI CC assignments",
-                    chain.id
-                )));
-            }
-        }
-        if chain.chain_type != FxChainTypeDocument::OxiSynth
-            && !chain.midi_cc_assignments.is_empty()
-        {
-            return Err(SessionError::Validation(format!(
-                "non-OxiSynth FX chain {} contains MIDI CC assignments",
-                chain.id
-            )));
-        }
-        let mut parameters = BTreeSet::new();
-        let mut sources = BTreeSet::new();
-        for assignment in &chain.midi_cc_assignments {
-            if assignment.channel > 15
-                || assignment.controller > 127
-                || !parameters.insert(assignment.parameter)
-                || !sources.insert((assignment.channel, assignment.controller))
-            {
-                return Err(SessionError::Validation(format!(
-                    "FX chain {} contains invalid or duplicate MIDI CC assignments",
-                    chain.id
-                )));
-            }
-        }
+        validate_fx_chain_assignments(chain)?;
     }
     match (&track.topology, &track.fx_chain) {
         (TrackTopologyDocument::DryWetExternal { .. }, Some(_)) => {

--- a/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
+++ b/src/rust/shoop_wasm_runtime_tests/tests/remote_application.rs
@@ -547,6 +547,7 @@ async fn remote_session_round_trips_track_controls_and_dynamic_buses() {
         name: "Surround".to_owned(),
         channel_count: 6,
         creation_request_id: Some(99),
+        fx: None,
     }));
     harness
         .drive_until("created multichannel bus", |snapshot| {

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -28,31 +28,32 @@ use shoop_audio_protocol::{
     decode_binary, encode_binary, Command, Event, MidiDataChunk, WaveformChunk,
     WireApplicationPortOwner, WireBuiltInFxDriveType, WireBuiltInFxMidiCcAssignment,
     WireBuiltInFxModulationType, WireBuiltInFxParameter, WireBuiltInFxReverbType,
-    WireBuiltInFxStage, WireBusControl, WireChannelMode, WireCompositeConfig, WireCompositeEntry,
-    WireCompositeKind, WireCompositeTarget, WireDefaultPlaybackMode, WireGrabRequest, WireHostPort,
-    WireLoopMode, WireMidiEvent, WireOxiSynthMidiCcAssignment, WireOxiSynthParameter,
-    WirePortDataType, WirePortDirection, WirePortRole, WireProcessorLatencyAdjustment,
-    WireRecordingOffsetAdjustment, WireSnapshot, WireTrackControl, WireTrackFxControl,
-    WireTrackTopology, COMMAND_CAPACITY, MIDI_BATCH_CAPACITY, MIDI_DETAIL_CHUNK_EVENTS,
-    SESSION_TRANSFER_CHUNK_BYTES, SESSION_TRANSFER_MAX_BYTES, STATUS_INTERVAL_MS,
-    WAVEFORM_CHUNK_SAMPLES,
+    WireBuiltInFxStage, WireBusControl, WireBusFxRequest, WireChannelMode, WireCompositeConfig,
+    WireCompositeEntry, WireCompositeKind, WireCompositeTarget, WireDefaultPlaybackMode,
+    WireGrabRequest, WireHostPort, WireLoopMode, WireMidiEvent, WireOxiSynthMidiCcAssignment,
+    WireOxiSynthParameter, WirePortDataType, WirePortDirection, WirePortRole,
+    WireProcessorLatencyAdjustment, WireRecordingOffsetAdjustment, WireSnapshot, WireTrackControl,
+    WireTrackFxControl, WireTrackTopology, COMMAND_CAPACITY, MIDI_BATCH_CAPACITY,
+    MIDI_DETAIL_CHUNK_EVENTS, SESSION_TRANSFER_CHUNK_BYTES, SESSION_TRANSFER_MAX_BYTES,
+    STATUS_INTERVAL_MS, WAVEFORM_CHUNK_SAMPLES,
 };
 use shoop_backend::{
-    builtin_fx_descriptor, default_bus_channel_labels, encode_builtin_fx_state,
-    encode_oxisynth_state, oxisynth_descriptor, Backend, BackendActiveCompositeChild,
-    BackendAsyncResult, BackendAudioChannelData, BackendAudioData, BackendBusChannelId,
-    BackendBusChannelState, BackendBusControl, BackendBusCreation, BackendBusId, BackendBusRequest,
-    BackendBusState, BackendChannelMode, BackendCompositeConfig, BackendCompositeId,
-    BackendCompositeKind, BackendCompositeState, BackendCompositeTarget, BackendConfirmedLink,
-    BackendConnectionFailure, BackendDefaultPlaybackMode, BackendDriverState, BackendGrabRequest,
-    BackendHostPortDescriptor, BackendLoopContentUpdate, BackendLoopId, BackendLoopMode,
-    BackendLoopState, BackendMidiChannelData, BackendMidiData, BackendMidiEvent,
-    BackendMixerFailure, BackendMixerLink, BackendMutationDetail, BackendMutationFailure,
-    BackendMutationKind, BackendOperationKind, BackendOperationProgress, BackendPortDataType,
-    BackendPortDescriptor, BackendPortDirection, BackendPortId, BackendPortOwner, BackendPortRole,
-    BackendSessionData, BackendSessionReplacement, BackendSnapshot, BackendStatus,
-    BackendTrackControl, BackendTrackCreation, BackendTrackFxControl, BackendTrackId,
-    BackendTrackState, BackendTrackTopology, BuiltInFxControl, DirectTrackRequest, OxiSynthControl,
+    builtin_fx_descriptor, bus_fx_descriptor_for_catalog, default_bus_channel_labels,
+    encode_builtin_fx_state, encode_oxisynth_state, oxisynth_descriptor, Backend,
+    BackendActiveCompositeChild, BackendAsyncResult, BackendAudioChannelData, BackendAudioData,
+    BackendBusChannelId, BackendBusChannelState, BackendBusControl, BackendBusCreation,
+    BackendBusFxControl, BackendBusId, BackendBusRequest, BackendBusState, BackendChannelMode,
+    BackendCompositeConfig, BackendCompositeId, BackendCompositeKind, BackendCompositeState,
+    BackendCompositeTarget, BackendConfirmedLink, BackendConnectionFailure,
+    BackendDefaultPlaybackMode, BackendDriverState, BackendGrabRequest, BackendHostPortDescriptor,
+    BackendLoopContentUpdate, BackendLoopId, BackendLoopMode, BackendLoopState,
+    BackendMidiChannelData, BackendMidiData, BackendMidiEvent, BackendMixerFailure,
+    BackendMixerLink, BackendMutationDetail, BackendMutationFailure, BackendMutationKind,
+    BackendOperationKind, BackendOperationProgress, BackendPortDataType, BackendPortDescriptor,
+    BackendPortDirection, BackendPortId, BackendPortOwner, BackendPortRole, BackendSessionData,
+    BackendSessionReplacement, BackendSnapshot, BackendStatus, BackendTrackControl,
+    BackendTrackCreation, BackendTrackFxControl, BackendTrackId, BackendTrackState,
+    BackendTrackTopology, BuiltInFxControl, DirectTrackRequest, OxiSynthControl,
     TrackProcessorTypeId, TrackRequest, GLOBAL_FX_PORT_ID, MASTER_BUS_CHANNEL_IDS,
     MASTER_BUS_CHANNEL_LABELS, MASTER_BUS_ID, MASTER_BUS_OUTPUT_PORT_IDS, MAX_BUSES,
     MAX_TOTAL_BUS_CHANNELS,
@@ -1071,7 +1072,26 @@ impl RemoteWorkletBackend {
                         balance: bus.balance,
                         muted: bus.muted,
                         output_peaks_db: bus.output_peaks_db,
-                        fx: None,
+                        fx: bus.fx.map(|fx| {
+                            let builtin_fx = fx.builtin_fx.map(|builtin_fx| {
+                                TrackProcessorEditorState::BuiltInFx(from_wire_builtin_fx_state(
+                                    builtin_fx,
+                                ))
+                            });
+                            TrackFxState {
+                                processor_type: TrackProcessorTypeId::new(fx.processor_type),
+                                active: fx.active,
+                                visible: fx.visible,
+                                lifecycle: FxLifecycle::Running,
+                                generation: 0,
+                                deadline_misses: 0,
+                                stale_completions: 0,
+                                status_summary: None,
+                                crash_summary: None,
+                                logs: Arc::from([]),
+                                editor: builtin_fx,
+                            }
+                        }),
                     },
                 )
             })
@@ -1603,6 +1623,9 @@ fn command_mutation_identity(command: &Command) -> Option<(BackendMutationKind, 
         } => (BackendMutationKind::BusStructure, Some(*expected_bus_id)),
         Command::RemoveBus { bus_id } => (BackendMutationKind::BusStructure, Some(*bus_id)),
         Command::SetBusControl { bus_id, .. } => (BackendMutationKind::BusControl, Some(*bus_id)),
+        Command::SetBusFxControl { bus_id, .. } => {
+            (BackendMutationKind::BusFxControl, Some(*bus_id))
+        }
         Command::SetTrackFxControl { track_id, .. } => {
             (BackendMutationKind::TrackFxControl, Some(*track_id))
         }
@@ -1773,6 +1796,9 @@ fn mutation_detail(command: &Command) -> Option<BackendMutationDetail> {
         Command::SetTrackFxControl { control, .. } => Some(BackendMutationDetail::TrackFxControl(
             from_wire_track_fx_control(control),
         )),
+        Command::SetBusFxControl { control, .. } => Some(BackendMutationDetail::BusFxControl(
+            from_wire_bus_fx_control(control),
+        )),
         Command::SetLoopGain { gain, .. } => Some(BackendMutationDetail::LoopGain(*gain)),
         Command::SetLoopBalance { balance, .. } => {
             Some(BackendMutationDetail::LoopBalance(*balance))
@@ -1826,6 +1852,10 @@ impl Backend for RemoteWorkletBackend {
 
     fn track_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
         Ok(vec![builtin_fx_descriptor(), oxisynth_descriptor()].into())
+    }
+
+    fn bus_processor_catalog(&mut self) -> Result<Arc<[TrackProcessorDescriptor]>> {
+        Ok(vec![bus_fx_descriptor_for_catalog()].into())
     }
 
     fn create_track(&mut self, request: TrackRequest) -> Result<BackendTrackCreation> {
@@ -2909,6 +2939,10 @@ impl Backend for RemoteWorkletBackend {
                 .collect(),
             name: request.name,
             channel_count: request.channel_count,
+            fx: request.fx.map(|request| WireBusFxRequest {
+                processor_type: request.processor_type,
+                audio_channels: request.audio_channels,
+            }),
         })?;
         self.next_bus_id = next_bus_id;
         self.next_bus_channel_id = next_channel_id;
@@ -2965,6 +2999,74 @@ impl Backend for RemoteWorkletBackend {
             bus_id: bus_id.raw(),
             control: to_wire_bus_control(control),
         })
+    }
+
+    fn set_bus_fx_control(
+        &mut self,
+        bus_id: BackendBusId,
+        control: BackendBusFxControl,
+    ) -> Result<()> {
+        let fx = self
+            .snapshot
+            .mixer
+            .buses
+            .get(&bus_id)
+            .ok_or_else(|| anyhow!("unknown browser bus {bus_id:?}"))?
+            .fx
+            .as_ref()
+            .ok_or_else(|| anyhow!("bus has no processor"))?;
+        if let BackendBusFxControl::BuiltInFx(builtin_fx) = &control {
+            if !matches!(
+                fx.editor.as_ref(),
+                Some(TrackProcessorEditorState::BuiltInFx(_))
+            ) {
+                return Err(anyhow!("bus has no Built-in FX editor state"));
+            }
+            match builtin_fx {
+                BuiltInFxControl::SetParameter(parameter, value) if !parameter.is_valid(*value) => {
+                    return Err(anyhow!("invalid Built-in FX parameter value"));
+                }
+                BuiltInFxControl::AssignMidiCc(assignment)
+                    if assignment.channel > 15 || assignment.controller > 127 =>
+                {
+                    return Err(anyhow!("invalid Built-in FX MIDI CC assignment"));
+                }
+                _ => {}
+            }
+        }
+        let command = Command::SetBusFxControl {
+            bus_id: bus_id.raw(),
+            control: to_wire_bus_fx_control(control.clone())?,
+        };
+        if matches!(
+            &control,
+            BackendBusFxControl::ToggleOrRecover | BackendBusFxControl::ClearLogs
+        ) {
+            self.submit_ephemeral(command)
+        } else {
+            self.submit(command)
+        }
+    }
+
+    fn bus_fx_state_string(&mut self, bus_id: BackendBusId) -> Result<Option<String>> {
+        let bus = self
+            .snapshot
+            .mixer
+            .buses
+            .get(&bus_id)
+            .ok_or_else(|| anyhow!("unknown browser bus {bus_id:?}"))?;
+        let Some(fx) = &bus.fx else {
+            return Ok(None);
+        };
+        match &fx.editor {
+            Some(TrackProcessorEditorState::BuiltInFx(editor)) => {
+                Ok(Some(encode_builtin_fx_state(editor)))
+            }
+            None => Ok(None),
+            Some(TrackProcessorEditorState::OxiSynth(_)) => {
+                Err(anyhow!("bus has unsupported processor editor state"))
+            }
+        }
     }
 
     fn advance(&mut self, elapsed: Duration) {
@@ -3602,6 +3704,69 @@ fn to_wire_oxisynth_parameter(parameter: OxiSynthParameter) -> WireOxiSynthParam
     match parameter {
         OxiSynthParameter::ReverbSend => WireOxiSynthParameter::ReverbSend,
         OxiSynthParameter::ChorusSend => WireOxiSynthParameter::ChorusSend,
+    }
+}
+
+fn to_wire_bus_fx_control(control: BackendBusFxControl) -> Result<WireTrackFxControl> {
+    match control {
+        BackendBusFxControl::SetActive(value) => Ok(WireTrackFxControl::SetActive(value)),
+        BackendBusFxControl::SetVisible(value) => Ok(WireTrackFxControl::SetVisible(value)),
+        BackendBusFxControl::ToggleOrRecover => Ok(WireTrackFxControl::ToggleOrRecover),
+        BackendBusFxControl::RestoreState(value) => Ok(WireTrackFxControl::RestoreState(value)),
+        BackendBusFxControl::ClearLogs => Ok(WireTrackFxControl::ClearLogs),
+        BackendBusFxControl::BuiltInFx(control) => {
+            to_wire_track_fx_control(BackendTrackFxControl::BuiltInFx(control))
+        }
+    }
+}
+
+fn from_wire_bus_fx_control(control: &WireTrackFxControl) -> BackendBusFxControl {
+    match control {
+        WireTrackFxControl::SetActive(value) => BackendBusFxControl::SetActive(*value),
+        WireTrackFxControl::SetVisible(value) => BackendBusFxControl::SetVisible(*value),
+        WireTrackFxControl::ToggleOrRecover => BackendBusFxControl::ToggleOrRecover,
+        WireTrackFxControl::RestoreState(value) => BackendBusFxControl::RestoreState(value.clone()),
+        WireTrackFxControl::ClearLogs => BackendBusFxControl::ClearLogs,
+        WireTrackFxControl::BuiltInSetStageEnabled(stage, enabled) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                from_wire_builtin_fx_stage(*stage),
+                *enabled,
+            ))
+        }
+        WireTrackFxControl::BuiltInSetDriveType(drive_type) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::SetDriveType(from_wire_builtin_fx_drive_type(*drive_type)),
+        ),
+        WireTrackFxControl::BuiltInSetModulationType(modulation_type) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetModulationType(
+                from_wire_builtin_fx_modulation_type(*modulation_type),
+            ))
+        }
+        WireTrackFxControl::BuiltInSetReverbType(reverb_type) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::SetReverbType(from_wire_builtin_fx_reverb_type(*reverb_type)),
+        ),
+        WireTrackFxControl::BuiltInSetParameter(parameter, value) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetParameter(
+                from_wire_builtin_fx_parameter(*parameter),
+                *value,
+            ))
+        }
+        WireTrackFxControl::BuiltInAssignMidiCc(assignment) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::AssignMidiCc(BuiltInFxMidiCcAssignment {
+                parameter: from_wire_builtin_fx_parameter(assignment.parameter),
+                channel: assignment.channel,
+                controller: assignment.controller,
+            }),
+        ),
+        WireTrackFxControl::BuiltInRemoveMidiCc(parameter) => BackendBusFxControl::BuiltInFx(
+            BuiltInFxControl::RemoveMidiCc(from_wire_builtin_fx_parameter(*parameter)),
+        ),
+        WireTrackFxControl::BuiltInClearMidiCcAssignments => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::ClearMidiCcAssignments)
+        }
+        WireTrackFxControl::BuiltInSetReverbEnabled(value) => {
+            BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetReverbEnabled(*value))
+        }
+        control => panic!("unsupported bus FX control: {control:?}"),
     }
 }
 
@@ -4464,6 +4629,7 @@ mod tests {
                     balance: 0.0,
                     muted: false,
                     output_peaks_db: vec![-12.0],
+                    fx: None,
                 }],
                 confirmed_mixer_links: vec![shoop_audio_protocol::WireMixerLink {
                     source_port_id: 2,
@@ -4833,6 +4999,7 @@ mod tests {
                     balance: 0.0,
                     muted: false,
                     output_peaks_db: vec![-200.0; 2],
+                    fx: None,
                 }],
                 ..Default::default()
             }),
@@ -5637,6 +5804,7 @@ mod tests {
                 expected_output_port_ids: vec![1, 2, 3, 4],
                 name: "Surround".to_owned(),
                 channel_count: 4,
+                fx: None,
             }));
         backend.remove_bus(created.bus_id).unwrap();
         assert!(!backend.bus_resources.contains_key(&created.bus_id));

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -248,6 +248,7 @@ impl RemoteWorkletBackend {
                 gain_db: 0.0,
                 balance: 0.0,
                 muted: false,
+                fx: None,
             },
         );
         (
@@ -884,6 +885,7 @@ impl RemoteWorkletBackend {
                     gain_db: source_bus.gain_db,
                     balance: source_bus.balance,
                     muted: source_bus.muted,
+                    fx: None,
                 },
             );
         }
@@ -1069,6 +1071,7 @@ impl RemoteWorkletBackend {
                         balance: bus.balance,
                         muted: bus.muted,
                         output_peaks_db: bus.output_peaks_db,
+                        fx: None,
                     },
                 )
             })

--- a/src/rust/shoop_worklet_client/src/lib.rs
+++ b/src/rust/shoop_worklet_client/src/lib.rs
@@ -4702,6 +4702,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Rejected".to_owned(),
                 channel_count: 1,
+                fx: None,
             })
             .unwrap();
         control
@@ -4749,6 +4750,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Retained".to_owned(),
                 channel_count: 2,
+                fx: None,
             })
             .unwrap();
         deliver(&control, 1, 4, Event::Ack);
@@ -5405,6 +5407,9 @@ mod tests {
             buses: vec![shoop_backend::BackendSessionBus {
                 source_id: 1,
                 name: "Master".to_owned(),
+                processor_type: None,
+                processor_state: None,
+                builtin_fx_midi_cc_assignments: Vec::new(),
                 channels: vec![
                     shoop_backend::BackendSessionBusChannel {
                         source_id: 42,
@@ -5468,6 +5473,9 @@ mod tests {
         dynamic.buses.push(shoop_backend::BackendSessionBus {
             source_id: 50,
             name: "Mono".to_owned(),
+            processor_type: None,
+            processor_state: None,
+            builtin_fx_midi_cc_assignments: Vec::new(),
             channels: vec![shoop_backend::BackendSessionBusChannel {
                 source_id: 51,
                 label: "Mono".to_owned(),
@@ -5580,6 +5588,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "After zero".to_owned(),
                 channel_count: 1,
+                fx: None,
             })
             .unwrap();
         assert_eq!(created.bus_id, BackendBusId::from_raw(2));
@@ -5598,6 +5607,7 @@ mod tests {
             .create_bus(BackendBusRequest {
                 name: "Surround".to_owned(),
                 channel_count: 4,
+                fx: None,
             })
             .unwrap();
         assert_eq!(created.bus_id, BackendBusId::from_raw(2));

--- a/src/rust/shoop_worklet_client/src/transport.rs
+++ b/src/rust/shoop_worklet_client/src/transport.rs
@@ -264,7 +264,10 @@ impl TransportCore {
                 Command::SetBusControl {
                     bus_id: existing, ..
                 }
-                | Command::RemoveBus { bus_id: existing } => *existing == bus_id,
+                | Command::RemoveBus { bus_id: existing }
+                | Command::SetBusFxControl {
+                    bus_id: existing, ..
+                } => *existing == bus_id,
                 Command::SetMixerRoute {
                     destination_channel_id,
                     ..
@@ -932,6 +935,7 @@ mod tests {
                     expected_output_port_ids: vec![4],
                     name: "Mono".to_owned(),
                     channel_count: 1,
+                    fx: None,
                 },
                 Command::SetBusControl {
                     bus_id: 2,

--- a/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
+++ b/src/rust/shoopdaloop/raw_wasm_host_contract.mjs
@@ -7,7 +7,7 @@ const module = await WebAssembly.compile(bytes);
 if (WebAssembly.Module.imports(module).length !== 0) {
   throw new Error('raw host contract requires an import-free Wasm artifact');
 }
-const protocolVersion = 25;
+const protocolVersion = 26;
 const host = new ShoopRawWasmHost(module, 48000, 2048, 262144);
 const poll = JSON.stringify({ version: protocolVersion, sequence: 1, command: { kind: 'poll' } });
 const first = JSON.parse(host.command(poll));


### PR DESCRIPTION
Implements BUS_FX.md stages 0-7: MIDI-less bus insert FX reusing per-track concepts.

- Engine: MIDI-less Built-in FX processing (0 or 1 MIDI ports).
- Backend API: BackendBusFxRequest/BackendBusFxControl, fx on BackendBusState/session, bus_processor_catalog (Built-in FX Unsupported MIDI, no synth).
- EngineBackend dummy/web: insert wiring input->send->processor->receive->output, controls/state/snapshot/session replace, remove cleanup.
- NativeBackend: stereo insert via processor_chain_type dispatch (Built-in FX + Carla, dry_midi=false), stable bus_<id>_fx titles, catalog/controls/state/session.
- App: BusState.fx, BusAction::Fx*, desired_bus_fx_controls optimistic sync, bus FX creation validation, session save/load FxChainDocument round-trip.
- Session validation: bus chains allow Carla/Built-in/Test fixture compat, reject OxiSynth + MIDI CC assignments.
- UI: bus strip FX button + logs + Built-in FX editor reuse, add-bus FX picker from bus catalog (no synth).
- Tests: audible stereo/mono Drive vs dry, mixer-route matrix, wide channels 1/2/3/6/64, app FX intents, session round-trips, old fixtures unchanged.

Acceptance: stereo+mono audible Drive, bypass/disable restores dry, no MIDI ports on bus path, no synth offered, session round-trips FX state + CC, routes survive, remove cleans up, suites green.