### PR TITLE
Center empty-track welcome message

### DIFF
--- a/src/rust/shoop_egui/src/app_widget.rs
+++ b/src/rust/shoop_egui/src/app_widget.rs
@@ -1133,6 +1133,8 @@ pub struct AppWidget {
     reset_xruns_rect: Option<egui::Rect>,
     #[cfg(test)]
     bus_area_rect: Option<egui::Rect>,
+    #[cfg(test)]
+    empty_tracks_welcome_rect: Option<egui::Rect>,
 }
 
 impl Default for AppWidget {
@@ -1232,6 +1234,8 @@ impl AppWidget {
             reset_xruns_rect: None,
             #[cfg(test)]
             bus_area_rect: None,
+            #[cfg(test)]
+            empty_tracks_welcome_rect: None,
         }
     }
 
@@ -1532,6 +1536,23 @@ impl AppWidget {
                     &state.track_processors,
                     &state.global_controls,
                 );
+                #[cfg(test)]
+                {
+                    self.empty_tracks_welcome_rect = None;
+                }
+                if main_tracks.is_empty() {
+                    let _welcome_rect = ui.painter().text(
+                        ui.ctx().content_rect().center(),
+                        egui::Align2::CENTER_CENTER,
+                        "Welcome to ShoopDaLoop!\nTo add your first recording track, click \"+\".",
+                        egui::TextStyle::Body.resolve(ui.style()),
+                        ui.visuals().text_color(),
+                    );
+                    #[cfg(test)]
+                    {
+                        self.empty_tracks_welcome_rect = Some(_welcome_rect);
+                    }
+                }
                 if response.add_track_requested {
                     let defaults = self.effective_track_defaults(settings_state);
                     self.open_add_track_dialog(main_tracks.len(), &defaults);
@@ -3500,6 +3521,32 @@ mod tests {
             recovery_required: false,
             persistence: SettingsPersistenceState::Idle,
         }
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn empty_tracks_welcome_is_window_centered_and_ignores_sync_track() {
+        let context = egui::Context::default();
+        crate::initialize(&context);
+        let mut widget = AppWidget::default();
+        let mut state = AppState {
+            tracks: vec![TrackState {
+                id: crate::TrackId::from_raw(1),
+                is_sync: true,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        frame(&context, &mut widget, &state, Vec::new());
+        let welcome = widget.empty_tracks_welcome_rect.unwrap();
+        assert_eq!(welcome.center(), egui::pos2(450.0, 300.0));
+
+        state.tracks.push(TrackState {
+            id: crate::TrackId::from_raw(2),
+            ..Default::default()
+        });
+        frame(&context, &mut widget, &state, Vec::new());
+        assert!(widget.empty_tracks_welcome_rect.is_none());
     }
 
     fn frame(

--- a/src/rust/shoop_egui/src/tracks_widget.rs
+++ b/src/rust/shoop_egui/src/tracks_widget.rs
@@ -22,8 +22,6 @@ pub struct TracksWidget {
     track_widgets: BTreeMap<TrackId, TrackWidget>,
     track_centers: BTreeMap<TrackId, f32>,
     #[cfg(test)]
-    test_empty_prompt_shown: bool,
-    #[cfg(test)]
     test_track_insert_rects: Vec<(Option<TrackId>, egui::Rect)>,
     #[cfg(test)]
     test_highlighted_track_insert: Option<Option<TrackId>>,
@@ -62,7 +60,6 @@ impl TracksWidget {
         let mut result = TracksWidgetResponse::default();
         #[cfg(test)]
         {
-            self.test_empty_prompt_shown = tracks.is_empty();
             self.test_track_insert_rects.clear();
             self.test_highlighted_track_insert = None;
         }
@@ -116,14 +113,7 @@ impl TracksWidget {
                                         track_response.response.rect.center().x,
                                     );
                                 }
-                                if tracks.is_empty() {
-                                    ui.add_sized(
-                                        [190.0, 40.0],
-                                        egui::Label::new(
-                                            "No tracks yet — use + to add your first track",
-                                        ),
-                                    );
-                                } else {
+                                if !tracks.is_empty() {
                                     self.show_track_insert_zone(
                                         ui,
                                         &track_ids,
@@ -293,39 +283,6 @@ mod tests {
         );
         ignored_output_0.textures_delta.clear();
         response
-    }
-
-    #[shoop_wasm_test_support::shoop_test]
-    fn empty_main_tracks_show_first_track_instruction_only() {
-        let context = egui::Context::default();
-        crate::initialize(&context);
-        let mut widget = TracksWidget::default();
-        for (tracks, expected) in [
-            (Vec::<TrackState>::new(), true),
-            (
-                vec![TrackState {
-                    id: TrackId::from_raw(1),
-                    name: "Track".to_owned(),
-                    ..Default::default()
-                }],
-                false,
-            ),
-        ] {
-            let mut ignored_output_1 = context.run_ui(
-                egui::RawInput {
-                    screen_rect: Some(egui::Rect::from_min_size(
-                        egui::Pos2::ZERO,
-                        egui::vec2(600.0, 400.0),
-                    )),
-                    ..Default::default()
-                },
-                |ui| {
-                    widget.show(ui, &tracks, &[]);
-                },
-            );
-            ignored_output_1.textures_delta.clear();
-            assert_eq!(widget.test_empty_prompt_shown, expected);
-        }
     }
 
     #[shoop_wasm_test_support::shoop_test]


### PR DESCRIPTION
### Motivation
- Replace the small top-left empty-track hint with a single "+" button in the track row and surface a full-window welcome message when there are no recording tracks (sync tracks excluded), matching the requested UX.

### Description
- Removed the inline label from the tracks row so only the add-track button remains in `TracksWidget` (remove one-off empty hint). 
- Added a centered welcome message painted in the central panel when the list of main (non-sync) tracks is empty and recorded its paint rect for tests via `empty_tracks_welcome_rect` in `AppWidget`.
- Added a UI test `empty_tracks_welcome_is_window_centered_and_ignores_sync_track` that verifies a sync-only session shows the centered message and that adding a recording track clears it.
- Tidied test-only fields in `TracksWidget` by removing the previous `test_empty_prompt_shown` mechanism.

### Testing
- `cargo test -p shoop_egui empty_tracks_welcome_is_window_centered_and_ignores_sync_track` — passed.
- `cargo test -p shoop_egui` — full package tests passed.
- `RUSTFLAGS="-D warnings" cargo build -p shoop_egui` — built successfully for the package.
- `cargo fmt --all -- --check` and `python3 scripts/check_shoop_test_usage.py` — checks passed.
- Note: a workspace-wide warning-denying build (`RUSTFLAGS="-D warnings" cargo build --workspace`) was attempted but cannot complete in this environment due to missing system ALSA pkg-config / development package required by `alsa-sys` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ea706b9cc8328a512879bf68e5fac)