### PR TITLE
Fix live native bus FX switching

### DIFF
--- a/bus-fx-switch-fix-plan.md
+++ b/bus-fx-switch-fix-plan.md
@@ -1,0 +1,118 @@
+# Native Bus FX Switching Fix Plan
+
+## Goals
+
+- Fix sustained bus-output silence when an existing native bus is switched from no processor to Built-in FX or Carla during playback.
+- Keep existing mixer sources connected to the bus throughout processor insertion, replacement, and removal.
+- Make the engine processor activation state agree with the backend/application state published after processor selection.
+- Add regression coverage that proves audio, not only metadata, survives the switch.
+
+## Scope
+
+### In scope
+
+- Native backend bus-FX creation, graph rewiring, rollback, replacement, and removal paths in `src/rust/shoop_backend/src/native.rs`.
+- Native dummy-backend regression tests for live mixer routing and processor activation.
+- End-to-end validation of Built-in FX and, where the Carla runtime is available, Carla bus-FX selection.
+
+### Out of scope
+
+- Changes to plugin DSP, Carla bridge scheduling, the generic/WebAssembly backend, mixer UI behavior, or unrelated graph APIs.
+- Redefining explicit `SetActive(false)` semantics or adding click-free transition/crossfade behavior.
+- Broad refactoring of `detach_audio_ports`; live bus rewiring should stop using that destructive operation instead.
+
+## Immutable acceptance criteria
+
+1. With a non-silent source routed into an existing native bus, switching from no FX to Built-in FX preserves the actual engine mixer connection and produces non-silent bus output.
+2. A newly selected bus processor is activated before the backend reports `active: true`; Built-in FX demonstrably processes audio rather than only preserving a dry route.
+3. The shared creation path activates Carla bus processors as well as Built-in FX; on a Carla-capable runtime, no-FX-to-Carla switching keeps the bus audible and the Carla lifecycle healthy.
+4. Removing or replacing bus FX restores the direct bus-input-to-output path without losing any source-to-bus mixer route.
+5. If processor creation, rewiring, activation, or graph publication fails, the prior direct route and mixer inputs remain usable, and no staged/orphan FX chain is published.
+6. Regression tests fail against the diagnosed implementation and pass after the fix; formatting, warning-denying build, required test-policy check, and the complete Rust suite pass.
+
+## Design rules and constraints
+
+- Disconnect only the exact direct edge `bus input -> driver output`; never detach/remove a live bus input merely to insert FX.
+- Preserve source-to-bus edges and keep `mixer_routes` consistent with the engine graph.
+- Treat insertion as a transaction: queue exact route changes and activation, wait for graph/control application, then publish `NativeFx`; on failure, remove the candidate chain, restore the direct edge, and verify rollback.
+- Use the common `FXChain` activation API after chain creation so all supported bus processor types follow the same activation contract.
+- Keep `NativeFx.active` truthful; do not set it to `true` unless the corresponding activation command was accepted.
+- Preserve channel ordering and require one FX input/output pair per bus channel.
+- Keep control-thread work out of the real-time callback and retain existing bounded graph-wait behavior.
+- Avoid unrelated formatting, comments, and refactors.
+
+## Staged implementation
+
+### Stage 1 — Establish the regression and transaction shape
+
+- [x] Use the dedicated `fix-bus` branch from the current target branch; the only pre-existing worktree item was this task plan.
+- [x] Extend the native dummy test setup with a small helper that renders a routed source through a selected bus output under controlled dummy-driver frames.
+- [x] Add/extend a regression scenario covering `no FX -> Built-in FX -> no FX`, asserting both non-zero samples and retained mixer-link metadata at each step.
+- [x] Configure a non-default Built-in FX stage/parameter and assert processed output differs from the dry baseline, so the test detects a processor that remains inactive.
+- [x] Confirm the new audio assertions fail on the current implementation for the diagnosed reasons.
+
+Verification:
+
+- [x] Run the targeted native bus-FX tests in the Nix development environment: `nix develop --command cargo nextest run -p shoop_backend --features native-drivers,shoop_engine/app_backend -E 'test(native_dummy_bus_fx)'` (the original example omitted the feature that compiles `native.rs`).
+- [x] Record which assertion exposes route destruction and which exposes missing activation before changing production code.
+
+### Stage 2 — Make bus-FX insertion non-destructive and active
+
+Depends on Stage 1.
+
+- [x] Change bus-channel rewiring to disconnect only `channel.input -> driver_output`, then connect `channel.input -> FX input` and `FX output -> driver_output`.
+- [x] Activate the newly created `FXChain` through `set_active(true)` before publishing it as an active `NativeFx`.
+- [x] Adjust partial-failure and graph-timeout cleanup so it removes the candidate chain, reconnects the exact direct edge, waits for the restored graph, and leaves incoming mixer routes untouched.
+- [x] Review replacement/removal ordering to ensure the direct edge is restored while old FX edges disappear with the removed chain, without using destructive port detachment.
+- [x] Keep the shared activation and routing path processor-type-neutral so Built-in FX and Carla receive the same fix.
+- [x] Run the regression repeatedly to catch queued-command or graph-publication races.
+- [ ] Commit the production fix and its focused regression tests as one green milestone.
+
+Verification:
+
+- [x] The targeted native tests prove dry audio before insertion, processed/non-zero audio after insertion, and restored audio after removal.
+- [x] `poll()` still reports the expected processor and mixer links, matching the rendered graph behavior.
+- [x] Invalid processor/channel requests continue to fail without changing the audible route; the native regression includes an audio assertion after rejection.
+
+### Stage 3 — Focused compatibility checks
+
+Depends on Stage 2.
+
+- [x] Run existing native bus creation, session round-trip, processor replacement, bus removal, and mixer-route tests.
+- [x] Run relevant engine FX-chain activation tests, including Carla fake-processor tests, to verify the common activation contract.
+- [x] Probe Carla locally and cover the shared bus path conditionally; the library is present but application-host instantiation is unavailable in this environment, so the test verifies failed insertion preserves direct audio and mixer routing.
+- [x] Review the diff for changes outside native bus-FX routing/tests and remove any unnecessary edits.
+- [x] Keep the Carla conditional/failure-path coverage in the focused green milestone; no separate hardening commit is needed.
+
+Verification:
+
+- [x] `python3 scripts/check_shoop_test_usage.py` passes because Rust tests changed.
+- [x] All focused test filters pass repeatedly in the repository Nix environment.
+
+### Stage 4 — Final end-to-end and repository validation
+
+Depends on Stages 1–3.
+
+- [x] Run `nix develop --command cargo fmt --all -- --check`.
+- [x] Run `nix develop --command env RUSTFLAGS='-D warnings' cargo build --workspace --features shoop_engine/app_backend,shoop_backend/native-fx` so the warning-denying build covers the changed native code.
+- [ ] Run `nix develop --command env SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
+- [ ] Run `nix develop --command python3 scripts/check_tracing_coverage.py --require-closed`.
+- [ ] Reproduce the original playback workflow on the master bus: no FX to Built-in FX, back to no FX, then Carla when available; confirm the master remains audible and its meter remains non-zero while upstream tracks continue.
+- [ ] Optionally capture a short replacement Perfetto trace and confirm the inserted processor performs normal DSP work, graph generations settle, callbacks continue, and bridge fallback/crash counters remain zero.
+- [ ] Commit any final validation-driven correction, then ensure the branch is clean and all acceptance criteria have explicit evidence.
+
+## Delivery
+
+- [ ] Push the branch to `origin` and open a PR summarizing the two root causes, transactional routing fix, activation fix, and audio-level regression coverage.
+- [ ] Link the validation commands/results and, if captured, the before/after trace evidence in the PR.
+- [ ] Monitor CI until every required job is green; inspect failed job logs before making targeted corrections and rerun local affected checks.
+- [ ] Check the PR for automated review feedback. If automated review appears, address justified findings, push updates, rerun affected/full validation, and repeat until the reviewer approves.
+- [ ] Ensure the final PR diff remains within scope and the acceptance criteria are unchanged.
+
+## Execution contract
+
+- Keep this plan updated as work progresses and check off completed items.
+- Commit each completed stage or meaningful milestone.
+- Implementation steps may be revised when new evidence warrants it.
+- Design rules may be revised only for a documented, well-supported reason.
+- Goals and acceptance criteria must not be changed without explicit user approval.

--- a/bus-fx-switch-fix-plan.md
+++ b/bus-fx-switch-fix-plan.md
@@ -80,9 +80,9 @@ Depends on Stage 2.
 
 - [x] Run existing native bus creation, session round-trip, processor replacement, bus removal, and mixer-route tests.
 - [x] Run relevant engine FX-chain activation tests, including Carla fake-processor tests, to verify the common activation contract.
-- [x] Probe Carla locally and cover the shared bus path conditionally; the library is present but application-host instantiation is unavailable in this environment, so the test verifies failed insertion preserves direct audio and mixer routing.
+- [x] Probe Carla locally and cover the shared bus path conditionally; with a main-thread UI dispatcher configured, the Carla Rack master-bus workflow produces non-silent output with stable lifecycle counters, while the forced-unavailable test verifies failed insertion leaves no published FX.
 - [x] Review the diff for changes outside native bus-FX routing/tests and remove any unnecessary edits.
-- [x] Keep the Carla conditional/failure-path coverage in the focused green milestone; no separate hardening commit is needed.
+- [x] Commit the master-bus/Carla and CI-hardening follow-ups as separate milestones.
 
 Verification:
 
@@ -110,11 +110,11 @@ Validation evidence:
 
 ## Delivery
 
-- [ ] Push the branch to `origin` and open a PR summarizing the two root causes, transactional routing fix, activation fix, and audio-level regression coverage.
-- [ ] Link the validation commands/results and, if captured, the before/after trace evidence in the PR.
-- [ ] Monitor CI until every required job is green; inspect failed job logs before making targeted corrections and rerun local affected checks.
-- [ ] Check the PR for automated review feedback. If automated review appears, address justified findings, push updates, rerun affected/full validation, and repeat until the reviewer approves.
-- [ ] Ensure the final PR diff remains within scope and the acceptance criteria are unchanged.
+- [x] Push the branch to `origin` and open PR [#873](https://github.com/SanderVocke/shoopdaloop/pull/873) summarizing the two root causes, transactional routing fix, activation fix, and audio-level regression coverage.
+- [x] Link the validation commands/results and the deterministic graph/lifecycle evidence in the PR.
+- [x] Monitor CI and inspect failed logs before targeted corrections. All native platform builds, Rust coverage, CodeQL, docs, and Codecov checks pass; branch protection reports no required checks. The non-required WebAssembly release job repeatedly exposes a pre-existing Firefox smoke UI-publication race outside this plan's scope, while the WebAssembly debug job and all artifact/build checks pass.
+- [x] Check the PR for automated feedback. Codecov's justified patch-coverage finding was addressed (80.27% now passes); no code-review findings appeared.
+- [x] Ensure the final PR diff remains within scope and the acceptance criteria are unchanged.
 
 ## Execution contract
 

--- a/bus-fx-switch-fix-plan.md
+++ b/bus-fx-switch-fix-plan.md
@@ -66,7 +66,7 @@ Depends on Stage 1.
 - [x] Review replacement/removal ordering to ensure the direct edge is restored while old FX edges disappear with the removed chain, without using destructive port detachment.
 - [x] Keep the shared activation and routing path processor-type-neutral so Built-in FX and Carla receive the same fix.
 - [x] Run the regression repeatedly to catch queued-command or graph-publication races.
-- [ ] Commit the production fix and its focused regression tests as one green milestone.
+- [x] Commit the production fix and its focused regression tests as green milestone `2c6b8a0f`.
 
 Verification:
 
@@ -95,11 +95,18 @@ Depends on Stages 1–3.
 
 - [x] Run `nix develop --command cargo fmt --all -- --check`.
 - [x] Run `nix develop --command env RUSTFLAGS='-D warnings' cargo build --workspace --features shoop_engine/app_backend,shoop_backend/native-fx` so the warning-denying build covers the changed native code.
-- [ ] Run `nix develop --command env SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend --profile ci`.
-- [ ] Run `nix develop --command python3 scripts/check_tracing_coverage.py --require-closed`.
-- [ ] Reproduce the original playback workflow on the master bus: no FX to Built-in FX, back to no FX, then Carla when available; confirm the master remains audible and its meter remains non-zero while upstream tracks continue.
-- [ ] Optionally capture a short replacement Perfetto trace and confirm the inserted processor performs normal DSP work, graph generations settle, callbacks continue, and bridge fallback/crash counters remain zero.
-- [ ] Commit any final validation-driven correction, then ensure the branch is clean and all acceptance criteria have explicit evidence.
+- [x] Run `nix develop --command env SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend,shoop_backend/native-fx --profile ci` so the complete suite includes the native backend and Carla path.
+- [x] Run `nix develop --command python3 scripts/check_tracing_coverage.py --require-closed`.
+- [x] Reproduce the original playback workflow on the master bus: no FX to Built-in FX, back to no FX, then Carla when available; the controlled native dummy test confirms non-silent output and retained upstream routing throughout.
+- [x] Use deterministic graph generations and Carla deadline/stale/crash counters in the regression instead of an optional Perfetto trace; the counters remain zero and the generation remains stable.
+- [x] Commit the final master-bus/Carla validation hardening, then ensure the branch is clean and all acceptance criteria have explicit evidence.
+
+Validation evidence:
+
+- Before the production fix, the corrected native filter ran three tests: `native_dummy_bus_fx_new_processor_is_engine_active` failed with engine `active == 0`, and `native_dummy_bus_fx_processor_switch_preserves_routed_audio` failed because processed output was silent.
+- After the fix, the native bus-FX filter passed repeatedly, including actual Built-in FX DSP output, replacement/removal, rejected insertion rollback, and the Carla-capable master-bus workflow.
+- The complete native-featured Rust run passed 1,800 tests with 4 environment skips.
+- Formatting, warning-denying workspace build, Rust test-policy check, tracing coverage, the complete `shoop_backend` suite, and focused engine FX/Carla tests all pass.
 
 ## Delivery
 

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -5716,7 +5716,7 @@ mod tests {
         configure_carla_ui_dispatcher(Some(carla_ui_dispatcher));
         let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
             sample_rate: 48_000,
-            buffer_size: 128,
+            buffer_size: 2_048,
         }))
         .unwrap();
         let source = backend
@@ -5793,29 +5793,15 @@ mod tests {
             configure_carla_ui_dispatcher(None);
             return;
         }
-        if let Err(error) = backend.set_bus_fx_control(
-            MASTER_BUS_ID,
-            BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
-                processor_type: TrackProcessorTypeId::CARLA_RACK.to_owned(),
-                audio_channels: 2,
-            })),
-        ) {
-            assert!(error.to_string().contains("bus processor is unavailable"));
-            eprintln!(
-                "skipping native bus Carla audio assertion; Carla could not instantiate: {error:#}"
-            );
-            assert!(
-                render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input)
-                    .iter()
-                    .any(|sample| sample.abs() > 0.1)
-            );
-            assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
-            assert!(backend.poll().unwrap().mixer.buses[&MASTER_BUS_ID]
-                .fx
-                .is_none());
-            configure_carla_ui_dispatcher(None);
-            return;
-        }
+        backend
+            .set_bus_fx_control(
+                MASTER_BUS_ID,
+                BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::CARLA_RACK.to_owned(),
+                    audio_channels: 2,
+                })),
+            )
+            .unwrap();
         let initial_generation = backend.poll().unwrap().mixer.buses[&MASTER_BUS_ID]
             .fx
             .as_ref()
@@ -7794,6 +7780,17 @@ mod tests {
                 .all(|descriptor| {
                     !descriptor.available && descriptor.unavailable_reason.is_some()
                 }));
+            let error = backend
+                .set_bus_fx_control(
+                    MASTER_BUS_ID,
+                    BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
+                        processor_type: TrackProcessorTypeId::CARLA_RACK.to_owned(),
+                        audio_channels: 2,
+                    })),
+                )
+                .unwrap_err();
+            assert!(error.to_string().contains("bus processor is unavailable"));
+            assert!(backend.poll()?.mixer.buses[&MASTER_BUS_ID].fx.is_none());
             Ok::<_, anyhow::Error>(())
         })();
         unsafe {

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -761,47 +761,71 @@ impl NativeRuntime {
                     .create_builtin_fx_chain_with_audio_channels(&title, ring, channel_count)?,
                 _ => self.session.create_fx_chain(chain_type, &title, ring)?,
             };
-        let last_confirmed_state = chain.try_get_state_str().ok();
-        let mut rewired: Vec<(NativeBusChannel, AudioPort)> = Vec::with_capacity(channel_count);
-        for (index, channel) in channels.iter().enumerate() {
-            if self
-                .rewire_bus_channel_for_fx(&chain, channel, index)
-                .is_err()
-            {
-                for (channel, output) in rewired {
-                    let _ = channel.input.connect_internal(&output);
-                }
+        let last_confirmed_state = match chain.try_get_state_str() {
+            Ok(state) => Some(state),
+            Err(error) if !chain.available() => {
                 let _ = self.session.remove_fx_chain(&chain);
-                self.wait();
-                self.staged_bus_fx.remove(&bus_id);
-                return Err(anyhow!("bus processor graph did not become active"));
+                let _ = self.wait_for_graph();
+                return Err(anyhow!("bus processor is unavailable: {error}"));
             }
-            let Some(output) = self
-                .ports
-                .get(&channel.output_port_id)
-                .and_then(|port| match &port.handle {
-                    NativePortHandle::Audio(output) => Some(output.clone()),
-                    NativePortHandle::Midi(_) => None,
-                })
-            else {
-                for (channel, output) in rewired {
-                    let _ = channel.input.connect_internal(&output);
-                }
+            Err(_) => None,
+        };
+        let routes = channels
+            .iter()
+            .enumerate()
+            .map(|(index, channel)| {
+                let input = chain
+                    .get_audio_input_port(index as u32)
+                    .ok_or_else(|| anyhow!("bus processor is missing audio input {index}"))?;
+                let output = chain
+                    .get_audio_output_port(index as u32)
+                    .ok_or_else(|| anyhow!("bus processor is missing audio output {index}"))?;
+                let driver_output = self
+                    .ports
+                    .get(&channel.output_port_id)
+                    .and_then(|port| match &port.handle {
+                        NativePortHandle::Audio(output) => Some(output.clone()),
+                        NativePortHandle::Midi(_) => None,
+                    })
+                    .ok_or_else(|| anyhow!("missing native bus output port"))?;
+                Ok((channel.clone(), input, output, driver_output))
+            })
+            .collect::<Result<Vec<_>>>();
+        let routes = match routes {
+            Ok(routes) => routes,
+            Err(error) => {
                 let _ = self.session.remove_fx_chain(&chain);
-                self.wait();
-                self.staged_bus_fx.remove(&bus_id);
-                return Err(anyhow!("missing native bus output port"));
+                let _ = self.wait_for_graph();
+                return Err(error);
+            }
+        };
+        let activation = (|| {
+            for (channel, input, output, driver_output) in &routes {
+                channel.input.disconnect_internal(driver_output)?;
+                channel.input.connect_internal(input)?;
+                output.connect_internal(driver_output)?;
+            }
+            if !chain.set_active(true) {
+                return Err(anyhow!("bus processor activation could not be queued"));
+            }
+            match self.wait_for_graph()? {
+                true => Ok(()),
+                false => Err(anyhow!("bus processor graph did not become active")),
+            }
+        })();
+        if let Err(error) = activation {
+            let rollback = self.rollback_native_bus_fx(
+                &chain,
+                routes
+                    .iter()
+                    .map(|(channel, _, _, output)| (channel, output)),
+            );
+            return match rollback {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(anyhow!(
+                    "{error}; bus processor rollback failed: {rollback_error}"
+                )),
             };
-            rewired.push((channel.clone(), output));
-        }
-        if !self.wait_for_graph().unwrap_or(false) {
-            for (channel, output) in rewired {
-                let _ = channel.input.connect_internal(&output);
-            }
-            let _ = self.session.remove_fx_chain(&chain);
-            self.wait();
-            self.staged_bus_fx.remove(&bus_id);
-            return Err(anyhow!("bus processor graph did not become active"));
         }
         self.staged_bus_fx.insert(
             bus_id,
@@ -815,29 +839,18 @@ impl NativeRuntime {
         Ok(())
     }
 
-    fn rewire_bus_channel_for_fx(
+    fn rollback_native_bus_fx<'a>(
         &self,
         chain: &FXChain,
-        channel: &NativeBusChannel,
-        index: usize,
+        routes: impl IntoIterator<Item = (&'a NativeBusChannel, &'a AudioPort)>,
     ) -> Result<()> {
-        let input = chain
-            .get_audio_input_port(index as u32)
-            .ok_or_else(|| anyhow!("bus processor is missing audio input {index}"))?;
-        let output = chain
-            .get_audio_output_port(index as u32)
-            .ok_or_else(|| anyhow!("bus processor is missing audio output {index}"))?;
-        let driver_output = self
-            .ports
-            .get(&channel.output_port_id)
-            .and_then(|port| match &port.handle {
-                NativePortHandle::Audio(output) => Some(output.clone()),
-                NativePortHandle::Midi(_) => None,
-            })
-            .ok_or_else(|| anyhow!("missing native bus output port"))?;
-        self.session.detach_audio_ports(&[channel.input.clone()])?;
-        channel.input.connect_internal(&input)?;
-        output.connect_internal(&driver_output)?;
+        self.session.remove_fx_chain(chain)?;
+        for (channel, output) in routes {
+            channel.input.connect_internal(output)?;
+        }
+        if !self.wait_for_graph()? {
+            return Err(anyhow!("restored bus graph did not become active"));
+        }
         Ok(())
     }
 
@@ -3238,7 +3251,9 @@ impl NativeRuntime {
             .ok_or_else(|| anyhow!("track has no processor"))?;
         match control {
             BackendTrackFxControl::SetActive(active) => {
-                fx.chain.set_active(active);
+                if !fx.chain.set_active(active) {
+                    return Err(anyhow!("track processor active state could not be queued"));
+                }
                 fx.active = active;
             }
             BackendTrackFxControl::SetVisible(visible) => fx.chain.set_visible(visible),
@@ -3410,7 +3425,9 @@ impl NativeRuntime {
                     .get_mut(&bus_id)
                     .and_then(|bus| bus.fx.as_mut())
                     .ok_or_else(|| anyhow!("bus has no processor"))?;
-                fx.chain.set_active(active);
+                if !fx.chain.set_active(active) {
+                    return Err(anyhow!("bus processor active state could not be queued"));
+                }
                 fx.active = active;
             }
             BackendBusFxControl::SetVisible(visible) => {
@@ -3583,7 +3600,9 @@ impl NativeRuntime {
         }
         if let Some(fx) = track.fx.as_mut() {
             if fx.active != processor_active {
-                fx.chain.set_active(processor_active);
+                if !fx.chain.set_active(processor_active) {
+                    return Err(anyhow!("track processor active state could not be queued"));
+                }
                 fx.active = processor_active;
             }
         }
@@ -5501,8 +5520,46 @@ mod tests {
         assert!(backend.bus_fx_state_string(created.bus_id).is_err());
     }
 
+    fn render_dummy_bus_audio(
+        backend: &mut NativeBackend,
+        source_track_id: BackendTrackId,
+        bus_id: BackendBusId,
+        input: &[f32],
+    ) -> Vec<f32> {
+        let frames = u32::try_from(input.len()).unwrap();
+        let runtime = backend.runtime_mut().unwrap();
+        runtime.driver.dummy_enter_controlled_mode();
+        let source = runtime.tracks[&source_track_id].audio_inputs[0].clone();
+        let output_port_id = runtime.buses[&bus_id].channels[0].output_port_id;
+        let NativePortHandle::Audio(output) = &runtime.ports[&output_port_id].handle else {
+            panic!("bus output is not audio");
+        };
+        let output = output.clone();
+        source.dummy_queue_data(input).unwrap();
+        output.dummy_request_data(frames).unwrap();
+        runtime.driver.dummy_request_controlled_frames(frames);
+        runtime.driver.dummy_run_requested_frames();
+        output.dummy_dequeue_data(frames)
+    }
+
+    fn assert_routed_bus_link(
+        backend: &mut NativeBackend,
+        source_port_id: BackendPortId,
+        destination_channel_id: BackendBusChannelId,
+    ) {
+        assert!(backend
+            .poll()
+            .unwrap()
+            .mixer
+            .confirmed_links
+            .contains(&BackendMixerLink {
+                source_port_id,
+                destination_channel_id,
+            }));
+    }
+
     #[shoop_wasm_test_support::shoop_test]
-    fn native_dummy_bus_fx_processor_switch_replaces_and_removes() {
+    fn native_dummy_bus_fx_new_processor_is_engine_active() {
         let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
             sample_rate: 48_000,
             buffer_size: 128,
@@ -5510,40 +5567,251 @@ mod tests {
         .unwrap();
         let created = backend
             .create_bus(BackendBusRequest {
-                name: "Switch".to_owned(),
-                channel_count: 2,
-                fx: Some(BackendBusFxRequest {
-                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
-                    audio_channels: 2,
-                }),
+                name: "Active".to_owned(),
+                channel_count: 1,
+                fx: None,
             })
             .unwrap();
-        backend
-            .set_bus_fx_control(created.bus_id, BackendBusFxControl::SetProcessor(None))
-            .unwrap();
-        let snapshot = backend.poll().unwrap();
-        assert!(snapshot.mixer.buses[&created.bus_id].fx.is_none());
         backend
             .set_bus_fx_control(
                 created.bus_id,
                 BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
                     processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
-                    audio_channels: 2,
+                    audio_channels: 1,
                 })),
             )
             .unwrap();
-        let snapshot = backend.poll().unwrap();
-        assert!(snapshot.mixer.buses[&created.bus_id].fx.is_some());
+        let runtime = backend.runtime().unwrap();
+        let fx = runtime.buses[&created.bus_id].fx.as_ref().unwrap();
+        assert!(fx.active);
+        assert_ne!(fx.chain.get_state().unwrap().active, 0);
+    }
+
+    #[shoop_wasm_test_support::shoop_test]
+    fn native_dummy_bus_fx_processor_switch_preserves_routed_audio() {
+        let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: 128,
+        }))
+        .unwrap();
+        let source = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "bus_source".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 0,
+            })
+            .unwrap();
+        backend
+            .set_track_control(source.track_id, BackendTrackControl::InputMonitoring(true))
+            .unwrap();
+        let created = backend
+            .create_bus(BackendBusRequest {
+                name: "Switch".to_owned(),
+                channel_count: 1,
+                fx: None,
+            })
+            .unwrap();
+        let source_port_id = source
+            .ports
+            .iter()
+            .find(|port| port.role == BackendPortRole::AudioOutput)
+            .unwrap()
+            .id;
+        let destination_channel_id = created.channels[0].id;
+        backend
+            .set_mixer_route(source_port_id, destination_channel_id, true)
+            .unwrap();
+        let input = vec![0.2; 128];
+        let dry = render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input);
+        assert!(dry.iter().any(|sample| sample.abs() > 0.1));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+
         assert!(backend
             .set_bus_fx_control(
                 created.bus_id,
                 BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
                     processor_type: TrackProcessorTypeId::OXISYNTH.to_owned(),
-                    audio_channels: 2,
+                    audio_channels: 1,
                 })),
             )
             .is_err());
+        assert!(backend.poll().unwrap().mixer.buses[&created.bus_id]
+            .fx
+            .is_none());
+        let after_rejected =
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input);
+        assert!(after_rejected.iter().any(|sample| sample.abs() > 0.1));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+
+        let builtin_request = BackendBusFxRequest {
+            processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+            audio_channels: 1,
+        };
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::SetProcessor(Some(builtin_request.clone())),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetParameter(
+                    BuiltInFxParameter::Drive,
+                    36.0,
+                )),
+            )
+            .unwrap();
+        let processed =
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input);
+        assert!(processed.iter().any(|sample| sample.abs() > 0.01));
+        assert!(processed
+            .iter()
+            .zip(&dry)
+            .any(|(processed, dry)| (processed - dry).abs() > 0.01));
+        assert!(backend.poll().unwrap().mixer.buses[&created.bus_id]
+            .fx
+            .as_ref()
+            .is_some_and(|fx| fx.active));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+
+        backend
+            .set_bus_fx_control(
+                created.bus_id,
+                BackendBusFxControl::SetProcessor(Some(builtin_request)),
+            )
+            .unwrap();
+        let replaced =
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input);
+        assert!(replaced.iter().any(|sample| sample.abs() > 0.1));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+
+        backend
+            .set_bus_fx_control(created.bus_id, BackendBusFxControl::SetProcessor(None))
+            .unwrap();
+        assert!(backend.poll().unwrap().mixer.buses[&created.bus_id]
+            .fx
+            .is_none());
+        let restored =
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input);
+        assert!(restored.iter().any(|sample| sample.abs() > 0.1));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
         backend.remove_bus(created.bus_id).unwrap();
+    }
+
+    #[cfg(feature = "native-fx")]
+    #[shoop_wasm_test_support::shoop_test]
+    fn native_dummy_bus_fx_carla_switch_preserves_routed_audio_when_available() {
+        let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
+            sample_rate: 48_000,
+            buffer_size: 128,
+        }))
+        .unwrap();
+        let available = backend
+            .bus_processor_catalog()
+            .unwrap()
+            .iter()
+            .any(|processor| {
+                processor.id.as_str() == TrackProcessorTypeId::CARLA_RACK && processor.available
+            });
+        if !available {
+            eprintln!("skipping native bus Carla routing test; Carla runtime is unavailable");
+            return;
+        }
+        let source = backend
+            .create_direct_track(DirectTrackRequest {
+                port_name_base: "carla_bus_source".to_owned(),
+                audio_channels: 1,
+                midi: false,
+                initial_loops: 0,
+            })
+            .unwrap();
+        backend
+            .set_track_control(source.track_id, BackendTrackControl::InputMonitoring(true))
+            .unwrap();
+        let created = backend
+            .create_bus(BackendBusRequest {
+                name: "CarlaSwitch".to_owned(),
+                channel_count: 2,
+                fx: None,
+            })
+            .unwrap();
+        let source_port_id = source
+            .ports
+            .iter()
+            .find(|port| port.role == BackendPortRole::AudioOutput)
+            .unwrap()
+            .id;
+        let destination_channel_id = created.channels[0].id;
+        backend
+            .set_mixer_route(source_port_id, destination_channel_id, true)
+            .unwrap();
+        let input = vec![0.2; 128];
+        assert!(
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+                .iter()
+                .any(|sample| sample.abs() > 0.1)
+        );
+
+        if let Err(error) = backend.set_bus_fx_control(
+            created.bus_id,
+            BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
+                processor_type: TrackProcessorTypeId::CARLA_RACK.to_owned(),
+                audio_channels: 2,
+            })),
+        ) {
+            assert!(error.to_string().contains("bus processor is unavailable"));
+            eprintln!(
+                "skipping native bus Carla audio assertion; Carla could not instantiate: {error:#}"
+            );
+            assert!(
+                render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+                    .iter()
+                    .any(|sample| sample.abs() > 0.1)
+            );
+            assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+            assert!(backend.poll().unwrap().mixer.buses[&created.bus_id]
+                .fx
+                .is_none());
+            return;
+        }
+        let mut peak = 0.0_f32;
+        for _ in 0..8 {
+            std::thread::sleep(Duration::from_millis(4));
+            peak = render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+                .into_iter()
+                .fold(peak, |peak, sample| peak.max(sample.abs()));
+        }
+        assert!(peak > 0.01, "Carla bus output peak was {peak}");
+        let snapshot = backend.poll().unwrap();
+        let fx = snapshot.mixer.buses[&created.bus_id].fx.as_ref().unwrap();
+        assert!(fx.active);
+        assert!(!matches!(
+            fx.lifecycle,
+            FxLifecycle::Crashed | FxLifecycle::Unavailable
+        ));
+        assert!(fx.crash_summary.is_none());
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+
+        backend
+            .set_bus_fx_control(created.bus_id, BackendBusFxControl::SetProcessor(None))
+            .unwrap();
+        assert!(
+            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+                .iter()
+                .any(|sample| sample.abs() > 0.1)
+        );
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_backend/src/native.rs
+++ b/src/rust/shoop_backend/src/native.rs
@@ -5711,26 +5711,17 @@ mod tests {
 
     #[cfg(feature = "native-fx")]
     #[shoop_wasm_test_support::shoop_test]
-    fn native_dummy_bus_fx_carla_switch_preserves_routed_audio_when_available() {
+    fn native_dummy_bus_fx_master_workflow_includes_carla_when_available() {
+        let (mut carla_ui_service, carla_ui_dispatcher) = CarlaMainThreadUiService::new();
+        configure_carla_ui_dispatcher(Some(carla_ui_dispatcher));
         let mut backend = NativeBackend::new(AudioDriverConfig::Dummy(DummyAudioDriverConfig {
             sample_rate: 48_000,
             buffer_size: 128,
         }))
         .unwrap();
-        let available = backend
-            .bus_processor_catalog()
-            .unwrap()
-            .iter()
-            .any(|processor| {
-                processor.id.as_str() == TrackProcessorTypeId::CARLA_RACK && processor.available
-            });
-        if !available {
-            eprintln!("skipping native bus Carla routing test; Carla runtime is unavailable");
-            return;
-        }
         let source = backend
             .create_direct_track(DirectTrackRequest {
-                port_name_base: "carla_bus_source".to_owned(),
+                port_name_base: "master_bus_source".to_owned(),
                 audio_channels: 1,
                 midi: false,
                 initial_loops: 0,
@@ -5739,32 +5730,71 @@ mod tests {
         backend
             .set_track_control(source.track_id, BackendTrackControl::InputMonitoring(true))
             .unwrap();
-        let created = backend
-            .create_bus(BackendBusRequest {
-                name: "CarlaSwitch".to_owned(),
-                channel_count: 2,
-                fx: None,
-            })
-            .unwrap();
         let source_port_id = source
             .ports
             .iter()
             .find(|port| port.role == BackendPortRole::AudioOutput)
             .unwrap()
             .id;
-        let destination_channel_id = created.channels[0].id;
+        let destination_channel_id =
+            backend.runtime().unwrap().buses[&MASTER_BUS_ID].channels[0].id;
         backend
             .set_mixer_route(source_port_id, destination_channel_id, true)
             .unwrap();
         let input = vec![0.2; 128];
+        let dry = render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input);
+        assert!(dry.iter().any(|sample| sample.abs() > 0.1));
+
+        backend
+            .set_bus_fx_control(
+                MASTER_BUS_ID,
+                BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
+                    processor_type: TrackProcessorTypeId::BUILTIN_FX.to_owned(),
+                    audio_channels: 2,
+                })),
+            )
+            .unwrap();
+        backend
+            .set_bus_fx_control(
+                MASTER_BUS_ID,
+                BackendBusFxControl::BuiltInFx(BuiltInFxControl::SetStageEnabled(
+                    BuiltInFxStage::Drive,
+                    true,
+                )),
+            )
+            .unwrap();
+        let processed =
+            render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input);
+        assert!(processed.iter().any(|sample| sample.abs() > 0.01));
+        assert!(processed
+            .iter()
+            .zip(&dry)
+            .any(|(processed, dry)| (processed - dry).abs() > 0.01));
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+        backend
+            .set_bus_fx_control(MASTER_BUS_ID, BackendBusFxControl::SetProcessor(None))
+            .unwrap();
         assert!(
-            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+            render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input)
                 .iter()
                 .any(|sample| sample.abs() > 0.1)
         );
+        assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
 
+        let carla_available = backend
+            .bus_processor_catalog()
+            .unwrap()
+            .iter()
+            .any(|processor| {
+                processor.id.as_str() == TrackProcessorTypeId::CARLA_RACK && processor.available
+            });
+        if !carla_available {
+            eprintln!("skipping native bus Carla routing test; Carla runtime is unavailable");
+            configure_carla_ui_dispatcher(None);
+            return;
+        }
         if let Err(error) = backend.set_bus_fx_control(
-            created.bus_id,
+            MASTER_BUS_ID,
             BackendBusFxControl::SetProcessor(Some(BackendBusFxRequest {
                 processor_type: TrackProcessorTypeId::CARLA_RACK.to_owned(),
                 audio_channels: 2,
@@ -5775,43 +5805,55 @@ mod tests {
                 "skipping native bus Carla audio assertion; Carla could not instantiate: {error:#}"
             );
             assert!(
-                render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+                render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input)
                     .iter()
                     .any(|sample| sample.abs() > 0.1)
             );
             assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
-            assert!(backend.poll().unwrap().mixer.buses[&created.bus_id]
+            assert!(backend.poll().unwrap().mixer.buses[&MASTER_BUS_ID]
                 .fx
                 .is_none());
+            configure_carla_ui_dispatcher(None);
             return;
         }
+        let initial_generation = backend.poll().unwrap().mixer.buses[&MASTER_BUS_ID]
+            .fx
+            .as_ref()
+            .unwrap()
+            .generation;
         let mut peak = 0.0_f32;
         for _ in 0..8 {
+            carla_ui_service.pump();
             std::thread::sleep(Duration::from_millis(4));
-            peak = render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+            peak = render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input)
                 .into_iter()
                 .fold(peak, |peak, sample| peak.max(sample.abs()));
         }
         assert!(peak > 0.01, "Carla bus output peak was {peak}");
         let snapshot = backend.poll().unwrap();
-        let fx = snapshot.mixer.buses[&created.bus_id].fx.as_ref().unwrap();
+        let fx = snapshot.mixer.buses[&MASTER_BUS_ID].fx.as_ref().unwrap();
         assert!(fx.active);
         assert!(!matches!(
             fx.lifecycle,
             FxLifecycle::Crashed | FxLifecycle::Unavailable
         ));
+        assert_eq!(fx.generation, initial_generation);
+        assert_eq!(fx.deadline_misses, 0);
+        assert_eq!(fx.stale_completions, 0);
         assert!(fx.crash_summary.is_none());
         assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
 
         backend
-            .set_bus_fx_control(created.bus_id, BackendBusFxControl::SetProcessor(None))
+            .set_bus_fx_control(MASTER_BUS_ID, BackendBusFxControl::SetProcessor(None))
             .unwrap();
         assert!(
-            render_dummy_bus_audio(&mut backend, source.track_id, created.bus_id, &input)
+            render_dummy_bus_audio(&mut backend, source.track_id, MASTER_BUS_ID, &input)
                 .iter()
                 .any(|sample| sample.abs() > 0.1)
         );
         assert_routed_bus_link(&mut backend, source_port_id, destination_channel_id);
+        carla_ui_service.pump();
+        configure_carla_ui_dispatcher(None);
     }
 
     #[shoop_wasm_test_support::shoop_test]

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -6691,39 +6691,42 @@ impl FXChain {
             self.state.lock().unwrap().visible = (visible && ok) as u32;
         }
     }
-    pub fn set_active(&self, active: bool) {
-        self.state.lock().unwrap().active = active as u32;
-        match &self.backend {
+    pub fn set_active(&self, active: bool) -> bool {
+        let accepted = match &self.backend {
             FXChainBackendKind::Test2x2x1 => {
                 let mut pending = Some(self.title.clone());
-                if let Err(error) = self.shared.send_control(move |s: &mut engine::Session| {
-                    if let Some(title) = pending.take() {
-                        s.set_test_fx_active(title, active);
-                    }
-                }) {
-                    log::error!("could not queue FX active state: {error}");
-                }
+                self.shared
+                    .send_control(move |s: &mut engine::Session| {
+                        if let Some(title) = pending.take() {
+                            s.set_test_fx_active(title, active);
+                        }
+                    })
+                    .is_ok()
             }
             FXChainBackendKind::BuiltInFx { .. } => {
                 let title = self.title.clone();
-                if let Err(error) = self.shared.send_control(move |session| {
-                    session.set_builtin_fx_active(&title, active);
-                }) {
-                    log::error!("could not queue Built-in FX active state: {error}");
-                }
+                self.shared
+                    .send_control(move |session| {
+                        session.set_builtin_fx_active(&title, active);
+                    })
+                    .is_ok()
             }
             FXChainBackendKind::OxiSynth(_) => {
                 let title = self.title.clone();
-                if let Err(error) = self.shared.send_control(move |session| {
-                    session.set_oxisynth_active(&title, active);
-                }) {
-                    log::error!("could not queue OxiSynth active state: {error}");
-                }
+                self.shared
+                    .send_control(move |session| {
+                        session.set_oxisynth_active(&title, active);
+                    })
+                    .is_ok()
             }
             #[cfg(feature = "carla")]
             FXChainBackendKind::Carla(host) => host.set_active(active),
-            FXChainBackendKind::Unavailable { .. } => {}
+            FXChainBackendKind::Unavailable { .. } => false,
+        };
+        if accepted {
+            self.state.lock().unwrap().active = active as u32;
         }
+        accepted
     }
     pub fn get_state(&self) -> Option<FXChainState> {
         let mut s = self.state.lock().unwrap().clone();

--- a/src/rust/shoop_engine/src/app_backend.rs
+++ b/src/rust/shoop_engine/src/app_backend.rs
@@ -9317,6 +9317,7 @@ mod tests {
             .create_fx_chain(FXChainType::CarlaRack, "carla", 0)
             .expect("chain handle");
         if !chain.available() {
+            assert!(!chain.set_active(true));
             eprintln!(
                 "skipping app-backend Carla availability assertion: {}",
                 chain.get_state_str().unwrap_or_default()

--- a/src/rust/shoop_engine/src/carla_processor.rs
+++ b/src/rust/shoop_engine/src/carla_processor.rs
@@ -443,14 +443,7 @@ mod bridge {
                 .map(|summary| (*summary).clone())
         }
 
-        pub fn set_active(&self, active: bool) {
-            // Publish desired activity immediately, then apply it in FIFO order on
-            // the bridge thread. This keeps application state deterministic without
-            // sharing the callback endpoint or making it consume control traffic.
-            self.control
-                .snapshot
-                .active
-                .store(active, Ordering::Release);
+        pub fn set_active(&self, active: bool) -> bool {
             if self
                 .control
                 .sender
@@ -458,8 +451,14 @@ mod bridge {
                 .is_err()
             {
                 self.control.snapshot.ready.store(false, Ordering::Release);
+                false
             } else {
+                self.control
+                    .snapshot
+                    .active
+                    .store(active, Ordering::Release);
                 self.control.wake.unpark();
+                true
             }
         }
 


### PR DESCRIPTION
## Summary

- preserve source-to-bus mixer edges by disconnecting only the direct bus-input-to-driver-output edge during native bus FX insertion
- activate every newly created FX chain before publishing `NativeFx.active = true`, and report rejected activation commands instead of publishing false state
- roll failed candidate insertion back to the direct route and reject unavailable processors without publishing an orphan chain
- add audio-level native dummy regressions for no FX → Built-in FX → replacement/removal, rejected insertion rollback, and the Carla-capable master-bus workflow

## Root causes

1. Bus FX insertion used `detach_audio_ports` on the live bus input. That removed the port and all incoming source-to-bus edges from the engine graph while `mixer_routes` still claimed those links existed.
2. The new FX chain was published as active without calling the shared activation API, leaving the processor inactive in the engine.

## Validation

- Regression proof before the production fix:
  - `native_dummy_bus_fx_new_processor_is_engine_active` failed with engine `active == 0`
  - `native_dummy_bus_fx_processor_switch_preserves_routed_audio` failed on silent processed output
- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command env RUSTFLAGS='-D warnings' cargo build --workspace --features shoop_engine/app_backend,shoop_backend/native-fx`
- `nix develop --command python3 scripts/check_shoop_test_usage.py`
- `nix develop --command python3 scripts/check_tracing_coverage.py --require-closed`
- repeated `nix develop --command cargo nextest run -p shoop_backend --features native-fx,shoop_engine/app_backend -E 'test(native_dummy_bus_fx)'`
- `nix develop --command cargo nextest run -p shoop_backend --features native-fx,shoop_engine/app_backend` (123 passed)
- `nix develop --command env SHOOP_ALLOW_MISSING_BACKENDS=1 cargo nextest run --workspace --features shoop_engine/app_backend,shoop_backend/native-fx --profile ci` (1,800 passed, 4 environment skips)

The Carla-capable master-bus regression produced non-silent audio through Carla Rack, retained the mixer route, kept graph generation stable, and observed zero deadline misses, stale completions, or crash summary.
