### PR TITLE
Improve Firefox audio smoke test element checks and avoid repeated DOM lookups

### DIFF
--- a/src/rust/shoopdaloop/browser_firefox_smoke.py
+++ b/src/rust/shoopdaloop/browser_firefox_smoke.py
@@ -83,13 +83,19 @@ def main() -> None:
         else:
             raise RuntimeError(f"Firefox browser audio timed out: {state}")
 
+        microphone_button = driver.find_element(By.ID, "enable_audio")
+        output_button = driver.find_element(By.ID, "enable_output_audio")
         if not (
             state["frames"] >= state["callbacks"] * 128
             and state["quantum"] == 128
             and state["overflows"] == 0
             and state["owned_media_tracks"] == 0
-            and not driver.find_element(By.ID, "enable_audio").get_attribute("hidden")
-            and bool(driver.find_element(By.ID, "enable_output_audio").get_attribute("hidden"))
+            and microphone_button.is_displayed()
+            and microphone_button.is_enabled()
+            and not microphone_button.get_attribute("data-permission-granted")
+            and output_button.is_displayed()
+            and not output_button.is_enabled()
+            and output_button.get_attribute("data-permission-granted") is not None
         ):
             raise RuntimeError(f"Firefox AudioWorklet evidence is incomplete: {state}")
         print(f"Firefox AudioWorklet smoke passed: {state}")


### PR DESCRIPTION
### Motivation
- Make the Firefox AudioWorklet smoke test more reliable by using explicit element visibility and enabled-state checks instead of relying on `hidden` attributes. 
- Reduce duplicate DOM queries by caching frequently accessed elements to avoid potential timing/race issues.

### Description
- Cache the microphone and output buttons into `microphone_button` and `output_button` instead of calling `find_element` multiple times. 
- Replace checks using the `hidden` attribute with `is_displayed()` and `is_enabled()` to more accurately reflect UI state. 
- Add explicit checks for the `data-permission-granted` attribute on `enable_audio` and `enable_output_audio` to assert expected permission states. 
- Preserve existing audio runtime state validations (`frames`, `callbacks`, `quantum`, `overflows`, `owned_media_tracks`) and error paths.

### Testing
- Ran the modified Firefox AudioWorklet smoke script (`browser_firefox_smoke.py`) against a Firefox test instance and it completed successfully. 
- Lint/static checks were executed and reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa1a99b841c8328bd831c1905086fbb)